### PR TITLE
Windows: start the background service through conhost --headless so it has no window

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Everything lands in one folder: `%LOCALAPPDATA%\CrossEx-Boros`.
   and reboots: a standard **LaunchAgent** on macOS, a per-user **Scheduled Task** on
   Windows. It is not hidden — on Windows you can see it in **Task Scheduler** under the
   name **"CrossEx-Boros Terminal"** (note that Scheduled Tasks never appear in Task
-  Manager's *Startup apps* tab, so that is not where to look for it). It runs windowless
-  and stops when you sign out, starting again next time you sign in.
+  Manager's *Startup apps* tab, so that is not where to look for it). It normally runs
+  windowless, and stops when you sign out, starting again next time you sign in.
 - Opens the app in your browser and creates the launcher (an app in `~/Applications`, or a
   Start Menu shortcut).
 - **It never asks for your exchange keys in the terminal** — those are entered later, in

--- a/README.md
+++ b/README.md
@@ -317,8 +317,9 @@ notionals and check your positions on the exchange directly.
   ([microsoft/terminal#12464](https://github.com/microsoft/terminal/issues/12464)).
   Re-run the install command to pick up the fix. If it persists, the installer will have
   said so during the install — set **Settings → System → For developers → Terminal** to
-  **Windows Console Host**. If the window reappears every few seconds the server itself is
-  also crash-looping, so check `server.err.log` above.
+  **Windows Console Host**. Closing the window is not a fix and does not mean anything is
+  broken: it hosts the server, so closing it stops the app and the service restarts it a
+  few seconds later. Nothing about it affects your keys, your positions, or your data.
 - **"Port 6688 is already in use" during install** — find the owner with
   `Get-NetTCPConnection -LocalPort 6688 -State Listen | Select-Object OwningProcess`, quit
   it, and re-run the installer (or `$env:BOROS_PORT=7788` before re-running).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,10 @@ Everything lands in one folder: `%LOCALAPPDATA%\CrossEx-Boros`.
   admin password, no changes to your system setup or PATH.
 - Registers a background service that keeps the app running and restarts it after crashes
   and reboots: a standard **LaunchAgent** on macOS, a per-user **Scheduled Task** on
-  Windows.
+  Windows. It is not hidden — on Windows you can see it in **Task Scheduler** under the
+  name **"CrossEx-Boros Terminal"** (note that Scheduled Tasks never appear in Task
+  Manager's *Startup apps* tab, so that is not where to look for it). It runs windowless
+  and stops when you sign out, starting again next time you sign in.
 - Opens the app in your browser and creates the launcher (an app in `~/Applications`, or a
   Start Menu shortcut).
 - **It never asks for your exchange keys in the terminal** — those are entered later, in
@@ -289,6 +292,8 @@ notionals and check your positions on the exchange directly.
 
 ## Troubleshooting
 
+**macOS**
+
 - **The page won't load** — the service may still be starting; wait a few seconds and
   reload. Check its status with
   `launchctl print gui/$(id -u)/com.boros.crossex-terminal | grep -E "state|pid"`
@@ -300,6 +305,26 @@ notionals and check your positions on the exchange directly.
   command to re-enable it.
 - **Restart the service manually** —
   `launchctl kickstart -k gui/$(id -u)/com.boros.crossex-terminal`.
+
+**Windows**
+
+- **The page won't load** — check the service and its logs with
+  `Get-ScheduledTaskInfo -TaskName 'CrossEx-Boros Terminal'` and
+  `Get-Content "$env:LOCALAPPDATA\CrossEx-Boros\logs\server.err.log" -Tail 40`.
+- **A blank PowerShell window keeps opening** — that is our background service, and it is
+  supposed to be invisible. Older versions became visible when the default terminal was
+  Windows Terminal, which drops the hide-the-window state
+  ([microsoft/terminal#12464](https://github.com/microsoft/terminal/issues/12464)).
+  Re-run the install command to pick up the fix. If it persists, the installer will have
+  said so during the install — set **Settings → System → For developers → Terminal** to
+  **Windows Console Host**. If the window reappears every few seconds the server itself is
+  also crash-looping, so check `server.err.log` above.
+- **"Port 6688 is already in use" during install** — find the owner with
+  `Get-NetTCPConnection -LocalPort 6688 -State Listen | Select-Object OwningProcess`, quit
+  it, and re-run the installer (or `$env:BOROS_PORT=7788` before re-running).
+- **Restart the service manually** —
+  `Stop-ScheduledTask -TaskName 'CrossEx-Boros Terminal'; Start-ScheduledTask -TaskName 'CrossEx-Boros Terminal'`,
+  or stop it for good by running the [uninstaller](#uninstall).
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -571,9 +571,22 @@ function Register-Service {
 # the failure surfaces only in the task's LastTaskResult, after both calls are
 # long done. So a clean registration is not evidence; a running supervisor is.
 # This is what makes the fallback in Install-Service safe to rely on.
+#
+# Matched on the RUNNER's own command line, NOT on any Get-ServerProcess hit.
+# That function deliberately also matches anything running out of $Root\node,
+# so a stray runtime node.exe - one Stop-StaleServer force-killed but did not
+# outlive, since it stops re-checking after that kill - would answer "the
+# supervisor is up" when nothing had started at all. The fallback would never
+# fire and the failed registration would surface much later, as Wait-ForServer's
+# "never started listening on port", which reads like a completely different
+# fault. Only powershell/conhost carrying the runner path IS the supervisor.
 function Wait-ForSupervisor {
   foreach ($i in 1..20) {
-    if (@(Get-ServerProcess).Count -gt 0) { return $true }
+    $supervisor = @(Get-ServerProcess | Where-Object {
+      $_.CommandLine -and
+      $_.CommandLine.IndexOf($RunnerPath, [StringComparison]::OrdinalIgnoreCase) -ge 0
+    })
+    if ($supervisor.Count -gt 0) { return $true }
     Start-Sleep -Milliseconds 500
   }
   return $false
@@ -623,6 +636,10 @@ function Install-Service {
   Write-Host '      Settings > System > For developers > Terminal to "Windows Console Host".' -ForegroundColor Yellow
   Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
   Stop-StaleServer   # reap anything the headless attempt did manage to start
+  # Not verified with Wait-ForSupervisor, deliberately: this is the action that
+  # shipped before this fallback existed, there is nothing further to fall back
+  # TO, and Wait-ForServer is about to report a dead service anyway - with the
+  # log path, which is more use here than another ten seconds of waiting.
   Register-Service -Mode 'Plain' -Runner $runner
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -371,7 +371,11 @@ function Swap-App {
 # non-elevated WMI query and still slips through; the port checks that follow in
 # each script exist to catch exactly that case.
 function Get-ServerProcess {
-  $exes = @('node.exe', 'powershell.exe', 'pwsh.exe')
+  # conhost.exe belongs here because the task action wraps the supervisor in
+  # `conhost.exe --headless powershell.exe ... -File <runner>`: the runner path
+  # is in ITS command line too, so it matches on exactly the same evidence as
+  # the shell it hosts, and no unrelated conhost can ever be caught.
+  $exes = @('node.exe', 'powershell.exe', 'pwsh.exe', 'conhost.exe')
   # Trailing backslash on purpose: a bare "$Root\node" prefix would also match a
   # sibling like "$Root\node-v22\node.exe"; the separator pins it to the folder.
   $nodeDir = (Join-Path $Root 'node') + '\'
@@ -515,15 +519,22 @@ port $Port is already in use by another program.
   }
 }
 
-function Install-Service {
-  Say 'Registering the background service...'
-  # Keep the always-on logs from growing without bound: reset on each (re)install.
-  Set-Content -Path (Join-Path $LogDir 'server.out.log') -Value '' -Encoding UTF8
-  Set-Content -Path (Join-Path $LogDir 'server.err.log') -Value '' -Encoding UTF8
-
-  $runner = Write-RunnerScript
-  $action = New-ScheduledTaskAction -Execute 'powershell.exe' `
-    -Argument "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$runner`""
+function Register-Service {
+  param(
+    [Parameter(Mandatory)][ValidateSet('Headless', 'Plain')][string]$Mode,
+    [Parameter(Mandatory)][string]$Runner
+  )
+  # 'Headless' wraps the runner in conhost.exe --headless; 'Plain' is the bare
+  # powershell.exe action, kept as the fallback. See Install-Service for why.
+  $psArgs = "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$Runner`""
+  if ($Mode -eq 'Headless') {
+    $exe = Join-Path $env:SystemRoot 'System32\conhost.exe'
+    $arg = "--headless powershell.exe $psArgs"
+  } else {
+    $exe = 'powershell.exe'
+    $arg = $psArgs
+  }
+  $action = New-ScheduledTaskAction -Execute $exe -Argument $arg
   # Keepalive by REPETITION, not by restart-on-failure. Task Scheduler's "if the
   # task fails, restart every N" keys off the action's exit code and quietly does
   # not fire in a number of ordinary cases - it did not bring the server back
@@ -538,15 +549,81 @@ function Install-Service {
   $trigger.Repetition = (New-ScheduledTaskTrigger -Once -At (Get-Date) `
     -RepetitionInterval (New-TimeSpan -Minutes 1)).Repetition
 
+  # Deliberately NO -Hidden. It does not hide the window - it hides the TASK from
+  # Task Scheduler's library view, so a user hunting for whatever keeps starting
+  # at sign-in cannot find it there either (and Task Manager's Startup tab never
+  # lists Scheduled Tasks at all). Suppressing the window is the ACTION's job,
+  # above. A background service that trades real money should stay findable.
   $settings = New-ScheduledTaskSettingsSet `
     -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -DontStopOnIdleEnd `
     -StartWhenAvailable -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) `
-    -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances IgnoreNew -Hidden
-  $principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" -LogonType Interactive -RunLevel Limited
+    -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances IgnoreNew
+  $principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" `
+    -LogonType Interactive -RunLevel Limited
 
   Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger `
     -Settings $settings -Principal $principal -Force | Out-Null
   Start-ScheduledTask -TaskName $TaskName
+}
+
+# Did the task actually put a supervisor on the CPU? Register-ScheduledTask and
+# Start-ScheduledTask both return happily for an action Windows will not run -
+# the failure surfaces only in the task's LastTaskResult, after both calls are
+# long done. So a clean registration is not evidence; a running supervisor is.
+# This is what makes the fallback in Install-Service safe to rely on.
+function Wait-ForSupervisor {
+  foreach ($i in 1..20) {
+    if (@(Get-ServerProcess).Count -gt 0) { return $true }
+    Start-Sleep -Milliseconds 500
+  }
+  return $false
+}
+
+function Install-Service {
+  Say 'Registering the background service...'
+  # Keep the always-on logs from growing without bound: reset on each (re)install.
+  Set-Content -Path (Join-Path $LogDir 'server.out.log') -Value '' -Encoding UTF8
+  Set-Content -Path (Join-Path $LogDir 'server.err.log') -Value '' -Encoding UTF8
+
+  $runner = Write-RunnerScript
+
+  # -WindowStyle Hidden is NOT enough to keep this service silent, and the
+  # window it fails to hide is the single worst thing a user can see from us.
+  #
+  # powershell.exe is a console-subsystem binary: Windows creates the console
+  # BEFORE the process runs, and PowerShell can only hide it afterwards. When
+  # the default terminal application is Windows Terminal - the Windows 11 22H2+
+  # default - that console is handed off to WindowsTerminal.exe and the hidden
+  # state is dropped on the way (microsoft/terminal#12464). What the user gets,
+  # as reported in the wild: a blank "Windows PowerShell" window at sign-in
+  # showing nothing (the runner sends both streams to log files), belonging to a
+  # task Task Manager's Startup tab does not list because it never lists
+  # Scheduled Tasks - and Windows Terminal's termination behaviour can keep that
+  # window on screen even after the process behind it is gone. It looks exactly
+  # like malware, and the user cannot find anything to disable.
+  #
+  # Moving the task out of the desktop session (LogonType S4U) would settle it,
+  # but registering an S4U task needs privileges a standard user does not have -
+  # verified: "Access is denied" from a normal account - and this installer
+  # promises no Administrator password. So the console must not be created at
+  # all: conhost.exe --headless starts the console host with no window and
+  # without the default-terminal handoff. conhost.exe has shipped with Windows
+  # since 7 and needs no elevation, no extra file and no VBScript shim.
+  #
+  # --headless is undocumented, so treat it as best-effort: register with it,
+  # PROVE a supervisor actually came up, and fall back to the plain
+  # powershell.exe action (previous behaviour) if it did not. A visible window
+  # is bad; a service that does not run is worse.
+  $registered = $true
+  try { Register-Service -Mode 'Headless' -Runner $runner } catch { $registered = $false }
+  if ($registered -and (Wait-ForSupervisor)) { return }
+
+  Write-Host 'Note: could not start the service windowless on this PC, so it is registered' -ForegroundColor Yellow
+  Write-Host '      the ordinary way. If a blank PowerShell window appears and stays, set' -ForegroundColor Yellow
+  Write-Host '      Settings > System > For developers > Terminal to "Windows Console Host".' -ForegroundColor Yellow
+  Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+  Stop-StaleServer   # reap anything the headless attempt did manage to start
+  Register-Service -Mode 'Plain' -Runner $runner
 }
 
 # ---------------------------------------------------------------------------

--- a/install.ps1
+++ b/install.ps1
@@ -605,9 +605,17 @@ function Install-Service {
   #
   # powershell.exe is a console-subsystem binary: Windows creates the console
   # BEFORE the process runs, and PowerShell can only hide it afterwards. When
-  # the default terminal application is Windows Terminal - the Windows 11 22H2+
-  # default - that console is handed off to WindowsTerminal.exe and the hidden
-  # state is dropped on the way (microsoft/terminal#12464). What the user gets,
+  # the default terminal application resolves to Windows Terminal, that console
+  # is handed off to WindowsTerminal.exe and the hidden state is dropped on the
+  # way (microsoft/terminal#12464).
+  #
+  # WHICH machines those are is not tidy, and it is why this reproduces for some
+  # users and not others on what looks like the same OS. Windows 11 only, and
+  # the shipping "Let Windows decide" does not resolve the same way everywhere -
+  # observed landing on Console Host (no fault) on one Windows 11 PC during this
+  # investigation, while the reporter's clearly landed on Windows Terminal. Do
+  # not assume a machine is unaffected because a colleague's is. What the user
+  # on the wrong side of that coin flip gets,
   # as reported in the wild: a blank "Windows PowerShell" window at sign-in
   # showing nothing (the runner sends both streams to log files), belonging to a
   # task Task Manager's Startup tab does not list because it never lists

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -57,7 +57,11 @@ function Say { param([string]$m) Write-Host '==> ' -ForegroundColor Cyan -NoNewl
 # non-elevated WMI query and still slips through; the port checks that follow in
 # each script exist to catch exactly that case.
 function Get-ServerProcess {
-  $exes = @('node.exe', 'powershell.exe', 'pwsh.exe')
+  # conhost.exe belongs here because the task action wraps the supervisor in
+  # `conhost.exe --headless powershell.exe ... -File <runner>`: the runner path
+  # is in ITS command line too, so it matches on exactly the same evidence as
+  # the shell it hosts, and no unrelated conhost can ever be caught.
+  $exes = @('node.exe', 'powershell.exe', 'pwsh.exe', 'conhost.exe')
   # Trailing backslash on purpose: a bare "$Root\node" prefix would also match a
   # sibling like "$Root\node-v22\node.exe"; the separator pins it to the folder.
   $nodeDir = (Join-Path $Root 'node') + '\'
@@ -118,7 +122,7 @@ if (@(Get-ServerProcess).Count -gt 0) {
   # kills only node.exe cannot work - the supervisor loop respawns node within
   # seconds and the re-run uninstaller finds it running all over again.
   Write-Host "    Get-CimInstance Win32_Process |" -ForegroundColor Red
-  Write-Host "      Where-Object { ('node.exe','powershell.exe','pwsh.exe') -contains `$_.Name -and `$_.CommandLine -and" -ForegroundColor Red
+  Write-Host "      Where-Object { ('node.exe','powershell.exe','pwsh.exe','conhost.exe') -contains `$_.Name -and `$_.CommandLine -and" -ForegroundColor Red
   Write-Host "        (`$_.CommandLine -like '*$qRunner*' -or `$_.CommandLine -like '*$qEntry*') } |" -ForegroundColor Red
   Write-Host "      Sort-Object { `$_.CommandLine -like '*$qRunner*' } -Descending |" -ForegroundColor Red
   Write-Host "      ForEach-Object { Stop-Process -Id `$_.ProcessId -Force }" -ForegroundColor Red


### PR DESCRIPTION
## The report

A user on Windows: *"since I installed yesterday, Windows Powershell will open by itself randomly, every 10 seconds or so"* … *"Nothing. It opens on start up despite being disabled on Start Up apps, then if I close it it just reopens after 5 - 10 seconds"*.

That is our Scheduled Task. Every clause maps to something in `install.ps1`:

| Reported | Cause |
|---|---|
| "Windows PowerShell" | The task action **is** `powershell.exe` — and that is exactly how such a window is titled. |
| "**Nothing**" happens after it opens | `run-server.ps1` sends node's stdout *and* stderr to log files, so the console genuinely prints nothing. A blank window that just sits there. |
| "despite being disabled on Start Up apps" | Task Manager's Startup tab lists Run-key and Startup-folder entries only. It has never listed Scheduled Tasks, so our `-AtLogOn` trigger is invisible there. |
| "if I close it it just reopens after 5 - 10 seconds" | Closing the window kills the server it hosts. The supervisor then relaunches it after `Min(60, 5 * Max(1, $fails))` — whose floor is 5s even after a completely healthy run, since `Max(1, 0)` is 1. Task Scheduler's repetition and restart-on-failure are both 1 minute, so nothing else in the system produces that cadence. |

## Why it happens

`powershell.exe` is a console-subsystem binary: Windows creates the console **before** the process runs, and PowerShell can only hide it afterwards. When the default terminal application resolves to Windows Terminal, that console is handed to `WindowsTerminal.exe` and the hidden state is dropped on the way (microsoft/terminal#12464). `-WindowStyle Hidden` does nothing.

**Which machines are affected is not tidy**, and that is worth knowing before anyone tries to reproduce it. Windows 11 only — but the shipping "Let Windows decide" setting does not resolve the same way everywhere. During this investigation one Windows 11 PC on "Let Windows decide" landed on Console Host and showed no fault at all; setting it explicitly to Windows Terminal on the same machine reproduced it immediately. The reporter's evidently resolves to Windows Terminal.

So a maintainer on Windows 11 may well be unable to reproduce this, and that is not evidence against the report. It also explains why a bug this visible has produced so few of them.

Windows Terminal's termination behaviour can also keep the window on screen *after* the process behind it exits — so the window can outlive what opened it.

## The fix

**Wrap the task action in `conhost.exe --headless`**, which starts the console host with no window and without the default-terminal handoff. `conhost.exe` has shipped since Windows 7 and needs no elevation, no extra file, and no VBScript shim.

**Why not move the task out of the desktop session?** `-LogonType S4U` would settle it properly, but registering an S4U task needs privileges a standard user does not have — verified as a flat `Access is denied` from a normal account — and this installer's stated promise is that no Administrator password is required. That route is closed.

**`--headless` is undocumented**, so it is treated as best-effort: register with it, *prove* a supervisor actually came up, and fall back to the previous plain `powershell.exe` action if not. That proof matters — neither `Register-ScheduledTask` nor `Start-ScheduledTask` reports an action Windows will not run; the failure surfaces only in `LastTaskResult`, long after both calls return. A visible window is bad; a service that does not run is worse.

One caveat for the maintainer to weigh: AV engines sometimes flag `conhost --headless` because malware uses it to hide. Uncomfortable for an app that just had a user think it *was* malware — though a flagged installer fails loudly, which beats a silent scary window.

`conhost.exe` joins the process match in both scripts. The action puts the runner path in *its* command line too, so it matches on exactly the same evidence as the shell it hosts and no unrelated `conhost` can be caught.

**Dropped `-Hidden`.** It never hid the *window* — it hides the *task* from Task Scheduler's library view, which is precisely why the reporter couldn't find what kept starting at sign-in. A service that trades real money should stay findable.

## Verification

All on **Windows 11 with Windows Terminal as the default terminal application** — the configuration that reproduces the bug.

**Mechanism**, as an A/B of two otherwise identical Scheduled Tasks differing only in the action:

| action | window on screen | `LastTaskResult` | shell running |
|---|---|---|---|
| `powershell.exe -WindowStyle Hidden` (current) | **yes** | `0x00041301` | 1 |
| `conhost.exe --headless powershell.exe …` (this PR) | **no** | `0x00041301` | 1 |

The "shell running" column is the control: the fix hides the window without preventing PowerShell from launching.

**End to end, through the installer:**

- Install completes with no fallback note, so the headless registration took.
- Signed out and back in — **no window**, and http://localhost:6688 loads. This is the `-AtLogOn` path the report was actually about, and the one every hand-started test misses.
- Both halves present in the ordinary interactive session, non-elevated:

  ```
  Name             ProcessId SessionId
  ----             --------- ---------
  conhost.exe           5096         1
  powershell.exe        8660         1
  ```

- Uninstaller removes everything cleanly — no false "still running" from a lingering `conhost`.

**Rejected empirically rather than assumed:** `-LogonType S4U` returns a flat `Access is denied` from a standard account.

**Not exercised:** re-running the installer over a live instance (the update path), and the fallback branch. The fallback lands on the exact action this PR replaces, so its worst case is current behaviour.

## Docs

- The install bullet names the task (**"CrossEx-Boros Terminal"**), says where to find it, and says outright that Scheduled Tasks never appear in Startup apps.
- Troubleshooting was macOS-only. Added a Windows half, including this window specifically, with the Console Host workaround for the fallback case.

## Scope

Purely cosmetic, and confirmed as such: the reporter says the app itself works normally. Nothing here changes the server, the engine, or any trading path — only how the Scheduled Task launches its supervisor.

That is worth stating because the window is alarming out of proportion to the fault. A blank, unkillable console that reappears at every sign-in, attached to nothing the user can find in Startup apps, reads as a compromise — on an app holding exchange API keys.
