### PR TITLE
Windows: run the background service with no console window

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ for a Gate.io API key:
   platform. It stops the previous version first, so an old copy never lingers. Your keys
   and trade history are never touched by updates. When a new version is published, the
   terminal shows an amber **Update** pill in the header with these exact instructions.
+- ⚠️ **Leave the machine on while a deal is open.** A trade here is a *deal* — a maker leg
+  plus the hedge that neutralises it — and it is the server's reconcile loop that places
+  that hedge once the maker leg fills, that requotes, retries, and closes. Gate's CrossEx
+  has no dead-man's switch, so **nothing sits on the exchange as a backstop**: no resting
+  stop, no server-side unwind. If the machine sleeps or shuts down mid-deal, a half-filled
+  deal stays half-filled — one leg live, unhedged, moving with the market — for as long as
+  it takes you to bring the server back. Nothing is lost or corrupted: the first tick after
+  a restart reads venue truth and picks the deal up exactly where it left off (recovery *is*
+  the loop — see [docs/MAKER-HEDGE.md](docs/MAKER-HEDGE.md)). Your exposure in the meantime
+  is simply however long the server was down, so close out before a shutdown, or don't start
+  a deal you can't leave the machine running for.
 
 ### Uninstall
 

--- a/install.ps1
+++ b/install.ps1
@@ -522,8 +522,24 @@ function Install-Service {
   Set-Content -Path (Join-Path $LogDir 'server.err.log') -Value '' -Encoding UTF8
 
   $runner = Write-RunnerScript
-  $action = New-ScheduledTaskAction -Execute 'powershell.exe' `
-    -Argument "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$runner`""
+  # conhost.exe, NOT powershell.exe with -WindowStyle Hidden. That flag cannot do
+  # the job: Windows allocates the console at CreateProcess, before PowerShell has
+  # parsed a single argument of its own, and the console is then handed to whatever
+  # the user's default terminal is. Where that is Windows Terminal - the default on
+  # a clean Windows 11 install - WT launches itself and shows a window, ignoring the
+  # SW_HIDE that PowerShell applies a moment later. The "background service" came up
+  # as a terminal window on the desktop, and closing that window killed the
+  # supervisor and left node.exe orphaned on the port with nothing watching it.
+  # Machines that still delegate to classic conhost honour the late hide and were
+  # never affected - which is why this reproduces on some boxes and not others.
+  #
+  # --headless creates no window at all, so the handoff never happens. It is how
+  # CreatePseudoConsole spawns conhost internally and has shipped since Windows 10
+  # 1809. conhost stays alive as the child's console host for as long as the
+  # supervisor runs, so the task instance stays Running and the one-minute
+  # repetition trigger below keeps behaving as a no-op under IgnoreNew.
+  $action = New-ScheduledTaskAction -Execute 'conhost.exe' `
+    -Argument "--headless powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File `"$runner`""
   # Keepalive by REPETITION, not by restart-on-failure. Task Scheduler's "if the
   # task fails, restart every N" keys off the action's exit code and quietly does
   # not fire in a number of ordinary cases - it did not bring the server back


### PR DESCRIPTION
On Windows 11 the "background service" can come up as a **visible terminal window** from logon
onwards. Closing it kills the supervisor and leaves `node.exe` orphaned, still LISTENING on
127.0.0.1:6688 with nothing watching it.

### Why `-WindowStyle Hidden` can't work

`powershell.exe` is console-subsystem, so Windows allocates the console at `CreateProcess` —
*before* PowerShell parses any of its own arguments. `-WindowStyle Hidden` then calls `ShowWindow`
on a console that already exists. Same in 5.1 and 7; no argument value avoids it.

Whether you *see* it depends on who draws that console. Classic conhost honours the late hide.
**Windows Terminal — the Windows 11 default — launches itself and shows a window**, out of reach
of `ShowWindow(GetConsoleWindow(), …)` because WT is a separate process. Hence: reproduces for
some users, not others. Seen on two 25H2 machines, not on a 23H2 one.

(The `DelegationConsole`/`DelegationTerminal` registry values are *not* a reliable predictor — one
affected machine reads all-zeros, "Let Windows decide", and still shows the window every time.)

### The fix

    conhost.exe --headless powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File <runner>

`conhost.exe` is GUI-subsystem, so it gets no console, and `--headless` builds a windowless one the
child inherits — Windows never creates a console, so delegation never runs. `--headless` is how
`CreatePseudoConsole` spawns conhost internally; shipped since Windows 10 1809.

Measured from a clean baseline (no `WindowsTerminal.exe` running):

| Task action | WindowsTerminal procs | New visible windows |
|---|---|---|
| current, `-WindowStyle Hidden` | 0 → 2 | **1** |
| `conhost.exe --headless …` | 0 → 0 | **0** |

**One line changes** — what the task action executes. Trigger, repetition keepalive, `IgnoreNew`,
`RestartCount`, principal, `uninstall.ps1` and the generated `run-server.ps1` are byte-identical.
`Get-ServerProcess` needs no change: the supervisor is still a `powershell.exe` carrying the runner
path, only its parent differs. conhost needs no entry either — it exits once its child is gone.

I also tried `-LogonType S4U` (fails "Access is denied" unelevated — needs the batch-logon right,
which would force the installer to require admin) and a `wscript.exe`/`.vbs` shim (works, but adds
a generated file and an unsigned `.vbs` in `%LOCALAPPDATA%` is a heuristic magnet).

### Testing

Two Windows 11 25H2 machines, both of which reproduce on `main`. Each tested as a controlled pair:
install `main`, confirm the window at logon; install this branch, repeat on the same machine.

- Fresh install, and **real sign-out/sign-in** — no window on either machine. Repetition then
  ticked ~9× with `IgnoreNew` refusing each duplicate, counts pinned at 1 conhost / 1 supervisor.
- Killed the listening node → both nodes respawned, port re-bound in ~10s, supervisor pid unchanged.
- Re-installed over the live service → all-new pids, no port/handle errors, no `app.old` leftovers.
- Uninstall → task unregistered, no processes, port free, `config\`/`data\` retained.

### Three things worth knowing

1. **This command line matches a published detection signature** — SigmaHQ's
   `proc_creation_win_conhost_headless_powershell` (Splunk has an equivalent), on every install at
   every logon. Not a blocker, but for a tool holding exchange API keys you should weigh it rather
   than hear it from a user's EDR. Every "launch hidden" alternative carries similar exposure.
2. **Stopping the task doesn't stop the service — and doesn't on `main` either.** Task Scheduler
   kills only the direct action process: today the supervisor (orphaning a live `node.exe`), with
   this change the conhost. Pre-existing; installer and uninstaller are unaffected as both also
   call `Stop-StaleServer`. Noting it because there's currently no documented way to halt the
   engine short of uninstalling.
3. **The repetition keepalive is dormant right after an install/update** until the next sign-in — a
   task registered post-logon has no `StartBoundary`. The supervisor loop still covers crashes.