### PR TITLE
Tag Boros API requests with the app version and an _active marker

### DIFF
--- a/src/core/boros/client.ts
+++ b/src/core/boros/client.ts
@@ -152,12 +152,42 @@ export interface BorosTxn {
   postPositionS: string;
 }
 
-/** Client-identification tag the Boros backend expects on every request from
- * this tool. Appended centrally here so no fetcher can forget it. */
-const CLIENT_TAG = 'pendle_client=boroscrossex';
+/**
+ * Client-identification tag the Boros backend expects on every request from
+ * this tool. Appended centrally here so no fetcher can forget it. The tag is
+ * `pendle_client=boroscrossex<version><_active?>` — e.g. `boroscrossex1.3.0` or
+ * `boroscrossex1.3.0_active` for a credentialed ("active") user.
+ *
+ * WHY mutable module state instead of a const: the version comes from a server
+ * boot-time fs read of version.json, and `active` flips at runtime when a user
+ * hot-swaps in Gate credentials — neither is knowable at import. This core
+ * module stays free of any fs/env reads (that would couple it to the server
+ * layout); the server injects both via `setClientTagContext`. The defaults
+ * reproduce today's plain `boroscrossex` tag, so any caller that never sets the
+ * context (e.g. unit tests) is unaffected.
+ */
+const clientTagState = { version: '', active: false };
+
+/**
+ * Merge a partial update into the client-tag context. A null `version` clears
+ * it (falls back to the versionless tag). The version is sanitized defensively
+ * because it is concatenated into a URL unencoded: trimmed, and accepted only
+ * if it matches the safe set below — otherwise it is treated as absent.
+ */
+export function setClientTagContext(ctx: { version?: string | null; active?: boolean }): void {
+  if (ctx.version !== undefined) {
+    const trimmed = ctx.version === null ? '' : ctx.version.trim();
+    clientTagState.version = /^[0-9A-Za-z._-]+$/.test(trimmed) ? trimmed : '';
+  }
+  if (ctx.active !== undefined) {
+    clientTagState.active = ctx.active;
+  }
+}
 
 async function getJson(fetchImpl: FetchLike, path: string): Promise<unknown> {
-  const url = `${BOROS_BASE_URL}${path}${path.includes('?') ? '&' : '?'}${CLIENT_TAG}`;
+  const clientTag =
+    'pendle_client=boroscrossex' + clientTagState.version + (clientTagState.active ? '_active' : '');
+  const url = `${BOROS_BASE_URL}${path}${path.includes('?') ? '&' : '?'}${clientTag}`;
   let resp: Awaited<ReturnType<FetchLike>>;
   try {
     resp = await fetchImpl(url, { signal: AbortSignal.timeout(15_000) });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -5,6 +5,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import fastifyStatic from '@fastify/static';
+import { setClientTagContext } from '../core/boros/client';
 import { makeClientsIfConfigured, requireClients, type Clients } from '../core/clients';
 import { Store } from '../engine/db';
 import { startLoop, type LoopDeps } from '../engine/loop';
@@ -61,6 +62,12 @@ const clientsRef: { current: Clients | null } = {
   current: publicMode ? null : makeClientsIfConfigured(),
 };
 const getClients = () => requireClients(clientsRef.current);
+
+// Stamp the version onto every Boros API request (public mode too — it also
+// queries the public API), and mark this user "active" when credentials are
+// already configured. The credentials route flips active:true on a later
+// hot-swap. Core reads neither fs nor env, so the server injects both here.
+setClientTagContext({ version: readLocalVersion(repoRoot), active: Boolean(clientsRef.current) });
 
 // The engine (SQLite ledger + reconcile loop) exists only off public mode: the
 // public box is read-only, with no data dir, no ledger, and no venue mutations.

--- a/src/server/routes/credentials.ts
+++ b/src/server/routes/credentials.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { FastifyInstance } from 'fastify';
+import { setClientTagContext } from '../../core/boros/client';
 import { makeClients } from '../../core/clients';
 import { classifyGateError, CoreError } from '../../core/errors';
 import type { AppDeps } from '../app';
@@ -77,6 +78,10 @@ export function credentialsRoutes(deps: AppDeps) {
       process.env.GATE_API_KEY = key;
       process.env.GATE_API_SECRET = secret;
       svc.setClients(candidate);
+      // This user is now "active" — tag subsequent Boros API traffic accordingly.
+      // Credentials can only be added/replaced here, never removed, so there is
+      // no active:false path.
+      setClientTagContext({ active: true });
       deps.cache.bust(''); // every cached read may belong to the old account
 
       return reply.ok({ ok: true, accountMode });

--- a/tests/unit/boros-client.test.ts
+++ b/tests/unit/boros-client.test.ts
@@ -3,15 +3,21 @@
  * (18-dec settleFeeRate), the transactions pagination loop, response-shape
  * guards, and error categorization (429 → rate-limited so TtlCache cools down).
  */
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   fetchBorosCollaterals,
   fetchBorosMarkets,
   fetchBorosOrderBook,
   fetchBorosTransactions,
   resolveCollateralPricesUsd,
+  setClientTagContext,
   type FetchLike,
 } from '../../src/core/boros/client';
+
+// The client tag lives in module state; reset it around every test so a case
+// that sets a version/active flag can never leak into the plain-tag assertions.
+beforeEach(() => setClientTagContext({ version: null, active: false }));
+afterEach(() => setClientTagContext({ version: null, active: false }));
 
 const ADDR = '0x' + 'ab'.repeat(20);
 
@@ -318,5 +324,36 @@ describe('client identification tag', () => {
     for (const url of urls) {
       expect(url.searchParams.get('pendle_client'), url.pathname).toBe('boroscrossex');
     }
+  });
+
+  const tagOf = async (): Promise<string | null> => {
+    let seen: URL | undefined;
+    await fetchBorosMarkets(
+      stub((url) => {
+        seen = url;
+        return { body: { results: [] } };
+      }),
+    );
+    return seen!.searchParams.get('pendle_client');
+  };
+
+  it('appends the configured version', async () => {
+    setClientTagContext({ version: '1.3.0' });
+    expect(await tagOf()).toBe('boroscrossex1.3.0');
+  });
+
+  it('appends _active for a credentialed user, after the version', async () => {
+    setClientTagContext({ version: '1.3.0', active: true });
+    expect(await tagOf()).toBe('boroscrossex1.3.0_active');
+  });
+
+  it('appends _active with no version when the version is unknown', async () => {
+    setClientTagContext({ active: true });
+    expect(await tagOf()).toBe('boroscrossex_active');
+  });
+
+  it('drops a version that fails the safe-charset check', async () => {
+    setClientTagContext({ version: 'a b?' });
+    expect(await tagOf()).toBe('boroscrossex');
   });
 });


### PR DESCRIPTION
## What

The `pendle_client` tag on every Boros API request now carries the running version and whether the user has Gate credentials configured:

- No Gate key: `pendle_client=boroscrossex1.3.0`
- Gate key configured (incl. added later via the setup UI): `pendle_client=boroscrossex1.3.0_active`
- `version.json` missing/unreadable → falls back to plain `boroscrossex` / `boroscrossex_active`

## How

- `src/core/boros/client.ts` — the `CLIENT_TAG` const becomes tiny module state (`version`, `active`) with an exported `setClientTagContext()` partial setter; `getJson` builds the tag per request. The version is sanitized to `[0-9A-Za-z._-]` (it is concatenated into a URL unencoded). Core stays free of fs/env reads.
- `src/server/index.ts` — boot stamps `version` from `readLocalVersion(repoRoot)` (the same `version.json` the update check uses — no new versioning mechanism) and `active` from whether credentials are already configured. Runs in public mode too, where `active` is always false.
- `src/server/routes/credentials.ts` — the PUT flips `active: true` right after a successful key commit, so the tag updates on hot-swap without a restart. Failed validations never flip it.
- `tests/unit/boros-client.test.ts` — existing plain-tag assertions still pass (defaults reproduce today's tag); 4 new cases: version-only, version+active, active-only, garbage version dropped; context reset around every test.

## Verify

`yarn typecheck` and full `yarn test` green: 46 files, 556 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)