### PR TITLE
Drop 'not a Pendle product' from the landing footer

### DIFF
--- a/web/src/LandingApp.tsx
+++ b/web/src/LandingApp.tsx
@@ -57,7 +57,7 @@ export function LandingApp() {
       </main>
 
       <footer className="border-t border-ink-800 px-5 py-6 text-center text-[11px] text-ink-500">
-        Free, open source, experimental software — not a Pendle product. It places real orders with
+        Free, open source, experimental software. It places real orders with
         real funds and can lose money. Nothing here is financial, investment, legal or tax advice.
       </footer>
     </div>


### PR DESCRIPTION
One-line follow-up: the footer copy edit (`87b7fa2` on `feat/landing-revamp`) landed after the #6 squash merge, so main still carries the old disclaimer. With the landing shipping under boros.pendle.finance, the removal is the intended copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)