### PR TITLE
added rates drilldown page

### DIFF
--- a/web/src/LandingApp.test.tsx
+++ b/web/src/LandingApp.test.tsx
@@ -1,9 +1,13 @@
 /** The public shell (Variant A — "the number leads"): a bare hero number, the
  * live 4-leg diagram that explains it, a shop-window spreads list, "three
- * things you need" as the page's only setup surface, and an FAQ holding the
- * caveats. The old step-by-step rail (LandingOnboardingGuide) was folded into
- * the three cards and deleted — the terminal's own OnboardingGuide is a
- * different component and is untouched. */
+ * things you need" as the OVERVIEW's only setup surface, and an FAQ holding the
+ * caveats.
+ *
+ * These cover the `overview` route. The page also has a `#/rates` route
+ * (RatesExplorer: the full opportunities panel plus the restored
+ * LandingOnboardingGuide rail) — see useHashRoute.test.tsx and
+ * RatesExplorer.test.tsx. The terminal's own OnboardingGuide is a different
+ * component and is untouched. */
 import { screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { LandingApp } from './LandingApp';

--- a/web/src/LandingApp.tsx
+++ b/web/src/LandingApp.tsx
@@ -2,7 +2,9 @@ import { BrandMark } from './components/BrandMark';
 import { Faq } from './landing/Faq';
 import { LandingHero } from './landing/LandingHero';
 import { MechanismDiagram } from './landing/MechanismDiagram';
+import { RatesExplorer } from './landing/RatesExplorer';
 import { ThreeThings } from './landing/ThreeThings';
+import { useHashRoute } from './landing/useHashRoute';
 import { REPO_URL } from './lib/landing';
 
 /**
@@ -19,6 +21,8 @@ import { REPO_URL } from './lib/landing';
  * exists on this page.
  */
 export function LandingApp() {
+  const [route, navigate] = useHashRoute();
+
   return (
     <div className="flex min-h-full flex-col">
       <header className="sticky top-0 z-40 border-b border-ink-800 bg-ink-950/80 backdrop-blur">
@@ -46,14 +50,30 @@ export function LandingApp() {
           lined up vertically. Setting it here means every block shares an edge
           and none of them can drift apart again. 1200 over Tailwind's 5xl
           (1024), which left the three setup cards visibly cramped. */}
-      <main className="mx-auto flex w-full max-w-[1200px] flex-1 flex-col gap-10 px-5 py-8 sm:gap-16 sm:py-10">
-        {/* Hero = pitch + the live number AND the spreads behind it, one card.
+      {/* The overview is one 1200px column (see above). The rates view carries
+          a 360px setup rail beside the panel, and at 1200 that left the cards
+          too narrow to read — so it gets the terminal's own 1500px. */}
+      <main
+        className={`mx-auto flex w-full flex-1 flex-col gap-10 px-5 py-8 sm:gap-16 sm:py-10 ${
+          route === 'rates' ? 'max-w-[1500px]' : 'max-w-[1200px]'
+        }`}
+      >
+        {route === 'rates' ? (
+          /* The deep view replaces the pitch rather than sitting under it: a
+             visitor who asked for every spread has already read the hero, and
+             leaving it above would push the list they asked for off-screen. */
+          <RatesExplorer onBack={() => navigate('overview')} />
+        ) : (
+          <>
+            {/* Hero = pitch + the live number AND the spreads behind it, one card.
               The mechanism diagram follows as the answer to "how", explaining
               the same pair the panel just headlined. */}
-        <LandingHero />
-        <MechanismDiagram />
-        <ThreeThings />
-        <Faq />
+            <LandingHero onExplore={() => navigate('rates')} />
+            <MechanismDiagram />
+            <ThreeThings />
+            <Faq />
+          </>
+        )}
       </main>
 
       <footer className="border-t border-ink-800 px-5 py-6 text-center text-[11px] text-ink-500">

--- a/web/src/landing/LandingHero.tsx
+++ b/web/src/landing/LandingHero.tsx
@@ -10,7 +10,7 @@ import { LiveRatesPanel } from './LiveRatesPanel';
  *
  * No data hook here at all: nothing on this side is live.
  */
-export function LandingHero() {
+export function LandingHero({ onExplore }: { onExplore: () => void }) {
   return (
     <section className="grid grid-cols-1 items-center gap-8 pt-2 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.92fr)] lg:gap-12">
       <div className="flex flex-col items-start gap-5">
@@ -32,7 +32,7 @@ export function LandingHero() {
         </a>
       </div>
 
-      <LiveRatesPanel />
+      <LiveRatesPanel onExplore={onExplore} />
     </section>
   );
 }

--- a/web/src/landing/LiveRatesPanel.tsx
+++ b/web/src/landing/LiveRatesPanel.tsx
@@ -21,7 +21,7 @@ import { positiveOnly, rankOpportunities, useLandingOpportunities } from './land
  * pair's costs beat its spread the headline goes red and says so — nothing is
  * hidden, it just isn't listed as an offer.
  */
-export function LiveRatesPanel() {
+export function LiveRatesPanel({ onExplore }: { onExplore: () => void }) {
   const query = useLandingOpportunities();
   // One ranking, reused. Calling rankOpportunities twice built two sets of
   // objects, so an identity filter against `best` silently matched nothing and
@@ -151,6 +151,20 @@ export function LiveRatesPanel() {
           </ol>
         )}
 
+        {/* A real button rather than a click handler on the whole card: the
+            rows above carry their own title tooltips, and a card-wide click
+            target would swallow them and leave the panel unreachable by
+            keyboard. Shown even when the list is empty or errored — the deep
+            view has the assumptions strip, which is exactly what a visitor
+            wants when nothing prices at this size. */}
+        <button
+          type="button"
+          onClick={onExplore}
+          className="mt-1 flex w-full items-center justify-center gap-1.5 rounded-lg border border-ink-700 bg-ink-900/60 px-3 py-2 text-xs font-semibold text-ink-200 transition-colors hover:border-cyan-500/50 hover:text-cyan-200"
+        >
+          Show me more
+          <span aria-hidden="true">→</span>
+        </button>
       </div>
     </div>
   );

--- a/web/src/landing/MechanismDiagram.tsx
+++ b/web/src/landing/MechanismDiagram.tsx
@@ -55,9 +55,21 @@ export function MechanismDiagram() {
     <section className="flex w-full flex-col gap-5 px-1">
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <h2 className="text-xl font-bold tracking-tight text-ink-100 sm:text-2xl">
+          {/* The RATE, not the asset: "How that ETH number is built" named the
+              wrong thing — the number a visitor is asking about is the headline
+              APR they just read, and printing it here ties this section to the
+              hero and to the result at the end of the math row below. Tone
+              follows the sign, same rule as that result. */}
           {live ? (
             <>
-              How that <span className="num text-emerald-400">{d.base}</span> number is built
+              How that{' '}
+              <span
+                className={`num ${d.onCapital < 0 ? 'text-rose-400' : 'text-emerald-400'}`}
+              >
+                {d.onCapital < 0 ? '' : '+'}
+                {pct(d.onCapital)}
+              </span>{' '}
+              number is built
             </>
           ) : (
             'How the spread is built'

--- a/web/src/landing/RatesExplorer.tsx
+++ b/web/src/landing/RatesExplorer.tsx
@@ -1,0 +1,58 @@
+import { LandingOnboardingGuide } from '../panels/LandingOnboardingGuide';
+import { OpportunitiesPanel } from '../panels/OpportunitiesPanel';
+
+/**
+ * The deep view behind the hero's "Show me more".
+ *
+ * Every live pair rather than the hero's top three, with the terminal's own
+ * "with these assumptions" strip on top so a visitor can re-price the whole
+ * list at their own size and fee tier. That strip is the reason this view
+ * exists: the hero's number is one fixed assumption set, and the honest answer
+ * to "is that real for me?" is to let them change it.
+ *
+ * `unconfigured` is the no-keys mode `App.tsx` already uses for a fresh
+ * install. On the landing build the panel also drops its Execute buttons
+ * entirely (see IS_LANDING in OpportunitiesPanel) — executing needs the
+ * terminal running locally, so the control could only ever be dead here. The
+ * setup rail on the right is the real next step. Nothing on this page can place
+ * an order, and no credential surface is reachable — the same guarantee the
+ * rest of the landing bundle makes.
+ */
+export function RatesExplorer({ onBack }: { onBack: () => void }) {
+  return (
+    <section className="flex w-full flex-col gap-5 px-1">
+      <div className="flex flex-col gap-3">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex w-fit items-center gap-1.5 rounded-lg border border-ink-700 bg-ink-900 px-3 py-1.5 text-xs text-ink-300 transition-colors hover:border-ink-500 hover:text-ink-100"
+        >
+          <span aria-hidden="true">←</span> Back
+        </button>
+
+        <div>
+          <h1 className="text-2xl font-extrabold tracking-tight text-ink-100 sm:text-3xl">
+            Every live spread
+          </h1>
+          <p className="mt-1.5 max-w-2xl text-sm text-ink-400">
+            Priced at your size and fee tier. Open{' '}
+            <span className="font-semibold text-ink-200">with these assumptions</span> to change
+            them — every card re-prices.
+          </p>
+        </div>
+      </div>
+
+      {/* Rates left, setup rail right — the original public-site layout.
+          Stacked below lg: the rail is a fixed 360px that cannot shrink, so in
+          a row it left the content column max(0, VW-420) — 0px on a phone, with
+          the sticky rail painting over the Execute buttons underneath. Rates
+          lead; guide follows. */}
+      <div className="flex w-full flex-col gap-5 lg:flex-row lg:items-start">
+        <div className="min-w-0 flex-1">
+          <OpportunitiesPanel unconfigured />
+        </div>
+        <LandingOnboardingGuide />
+      </div>
+    </section>
+  );
+}

--- a/web/src/landing/ThreeThings.tsx
+++ b/web/src/landing/ThreeThings.tsx
@@ -165,7 +165,7 @@ export function ThreeThings() {
         <ThingCard
           n={3}
           title="A funded CrossEx account"
-          what="Capital on Gate, moved into CrossEx. Plus a little on-chain gas."
+          what="Capital on Gate, moved into CrossEx."
         >
           <How>
             <ol className="flex list-decimal flex-col gap-0.5 pl-4 marker:text-ink-500">

--- a/web/src/landing/useHashRoute.test.tsx
+++ b/web/src/landing/useHashRoute.test.tsx
@@ -1,0 +1,93 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RATES_HASH, useHashRoute } from './useHashRoute';
+
+/**
+ * The landing's two views live in the URL hash, so the deep view is linkable
+ * and the browser's own Back button behaves.
+ *
+ * The case worth pinning down is the HISTORY one: the in-page Back button must
+ * POP the entry the hook pushed, not push a second. When it pushed, the
+ * browser's Back button sent a visitor forward into the very view they had just
+ * dismissed.
+ */
+async function settle() {
+  // history.back() is async — it fires hashchange on a later task.
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 20));
+  });
+}
+
+describe('useHashRoute', () => {
+  beforeEach(() => {
+    window.location.hash = '';
+  });
+
+  afterEach(() => {
+    window.location.hash = '';
+  });
+
+  it('starts on overview with no hash, and reads #/rates on first render', () => {
+    const a = renderHook(() => useHashRoute());
+    expect(a.result.current[0]).toBe('overview');
+
+    window.location.hash = RATES_HASH;
+    const b = renderHook(() => useHashRoute());
+    expect(b.result.current[0]).toBe('rates');
+  });
+
+  it('navigating to rates puts it in the URL', async () => {
+    const { result } = renderHook(() => useHashRoute());
+    act(() => result.current[1]('rates'));
+    await settle();
+
+    expect(window.location.hash).toBe(RATES_HASH);
+    expect(result.current[0]).toBe('rates');
+  });
+
+  it('leaving rates POPS our own entry, so browser Back does not return to it', async () => {
+    const { result } = renderHook(() => useHashRoute());
+    const before = window.history.length;
+
+    act(() => result.current[1]('rates'));
+    await settle();
+    act(() => result.current[1]('overview'));
+    await settle();
+
+    expect(result.current[0]).toBe('overview');
+    expect(window.location.hash).toBe('');
+    // The push was unwound rather than stacked on: one more entry would mean
+    // the browser's Back button lands on #/rates again.
+    expect(window.history.length).toBeLessThanOrEqual(before + 1);
+  });
+
+  it('responds to browser Back/Forward (a raw hashchange)', async () => {
+    const { result } = renderHook(() => useHashRoute());
+
+    act(() => {
+      window.location.hash = RATES_HASH;
+    });
+    await settle();
+    expect(result.current[0]).toBe('rates');
+
+    act(() => {
+      window.location.hash = '';
+    });
+    await settle();
+    expect(result.current[0]).toBe('overview');
+  });
+
+  it('leaving rates on a DEEP LINK replaces the hash instead of pushing', async () => {
+    // No entry of ours to pop: pushing '' here would make the browser's Back
+    // button walk back into #/rates.
+    window.location.hash = RATES_HASH;
+    const { result } = renderHook(() => useHashRoute());
+    expect(result.current[0]).toBe('rates');
+
+    act(() => result.current[1]('overview'));
+    await settle();
+
+    expect(result.current[0]).toBe('overview');
+    expect(window.location.hash).toBe('');
+  });
+});

--- a/web/src/landing/useHashRoute.ts
+++ b/web/src/landing/useHashRoute.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from 'react';
+
+/** The landing page's two views. `overview` is the pitch; `rates` is the
+ * full opportunity list with the assumptions strip. */
+export type LandingRoute = 'overview' | 'rates';
+
+export const RATES_HASH = '#/rates';
+
+function readHash(): LandingRoute {
+  if (typeof window === 'undefined') return 'overview';
+  return window.location.hash === RATES_HASH ? 'rates' : 'overview';
+}
+
+/**
+ * A two-state route in the URL hash, so the deep view is linkable and the
+ * browser's Back button returns to the pitch.
+ *
+ * A hash rather than a path: the landing is served as static files, so a real
+ * path would 404 on a hard refresh unless the host rewrites it. A hash needs no
+ * server cooperation and no router dependency.
+ *
+ * `hashchange` covers Back/Forward and any other in-page link; navigate() is
+ * what the buttons call. Assigning `location.hash` pushes a history entry,
+ * which is what makes Back work — never use `replace` here.
+ */
+export function useHashRoute(): [LandingRoute, (next: LandingRoute) => void] {
+  const [route, setRoute] = useState<LandingRoute>(readHash);
+
+  useEffect(() => {
+    const onChange = () => setRoute(readHash());
+    window.addEventListener('hashchange', onChange);
+    // Resync once: useState's lazy initializer already read the hash, but a
+    // redirect or an anchor click landing between that render and this effect
+    // would otherwise leave `route` stale. Cheap, and a no-op when they agree.
+    onChange();
+    return () => window.removeEventListener('hashchange', onChange);
+  }, []);
+
+  /** Entries this hook itself pushed, so leaving `rates` can POP the one it
+   * pushed rather than stacking a third. Without this the in-page Back button
+   * pushed a second entry, and the browser's own Back then returned the visitor
+   * to `#/rates` — the very view they had just dismissed. */
+  const pushed = useRef(0);
+
+  const navigate = (next: LandingRoute) => {
+    if (next === 'rates') {
+      window.location.hash = RATES_HASH;
+      pushed.current += 1;
+      return; // hashchange sets the route
+    }
+
+    if (pushed.current > 0) {
+      // We put the #/rates entry there, so unwind it. `history.back()` is
+      // async and fires hashchange, which is what updates `route`.
+      pushed.current -= 1;
+      window.history.back();
+      return;
+    }
+
+    // Arrived directly on #/rates (a shared link): there is no entry of ours to
+    // pop, so replace it — pushing '' here would make the browser's Back button
+    // return to #/rates instead of leaving the site.
+    if (window.location.hash) {
+      window.history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
+    setRoute('overview');
+    window.scrollTo({ top: 0 });
+  };
+
+  return [route, navigate];
+}

--- a/web/src/panels/LandingOnboardingGuide.test.tsx
+++ b/web/src/panels/LandingOnboardingGuide.test.tsx
@@ -1,0 +1,125 @@
+/** The public rail: four steps collapsed to their titles, with step 1 open and
+ * carrying the paste-into-your-own-LLM audit prompt above an OS-aware install
+ * command. No key surface may ever appear here. */
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { renderWithClient } from '../test/utils';
+import { LandingOnboardingGuide } from './LandingOnboardingGuide';
+
+/** Step titles are disclosure buttons; open the one we want to inspect. */
+async function openStep(name: RegExp) {
+  await userEvent.click(screen.getByRole('button', { name }));
+}
+
+describe('LandingOnboardingGuide', () => {
+  it('is four steps, install first, before anything touching Gate', () => {
+    renderWithClient(<LandingOnboardingGuide />);
+
+    // Only the four step headings are top-level; the Gate step's own ordered
+    // list nests inside step 2, so scope to the outer <ol>.
+    const steps = screen.getAllByRole('listitem').filter((li) => li.querySelector('h3'));
+    expect(steps).toHaveLength(4);
+    expect(within(steps[0]).getByRole('heading')).toHaveTextContent('Install the terminal');
+    expect(within(steps[1]).getByRole('heading')).toHaveTextContent(
+      'Fund Gate and enable CrossEx',
+    );
+    expect(within(steps[2]).getByRole('heading')).toHaveTextContent('Create your API key');
+    expect(within(steps[3]).getByRole('heading')).toHaveTextContent('Execute');
+  });
+
+  it('keeps the three Gate errands, in order, inside the one step', async () => {
+    renderWithClient(<LandingOnboardingGuide />);
+    await openStep(/^Fund Gate and enable CrossEx/);
+
+    // The nested <li>s are the errands — the step <li>s carry an <h3>.
+    const errands = screen
+      .getAllByRole('listitem')
+      .filter((li) => !li.querySelector('h3'))
+      .map((li) => li.textContent ?? '');
+    expect(errands).toHaveLength(3);
+    // Enabling CrossEx must precede moving funds into it, and both precede the
+    // API key — that ordering is the reason this is a list and not a sentence.
+    expect(errands[0]).toMatch(/gate\.com\/signup/);
+    expect(errands[1]).toMatch(/Switch on CrossEx/);
+    expect(errands[2]).toMatch(/Move your funds into CrossEx/);
+  });
+
+  it('offers the audit inside step 1, above the install command', () => {
+    renderWithClient(<LandingOnboardingGuide />);
+
+    const install = within(screen.getAllByRole('listitem')[0]);
+    const audit = install.getByRole('button', { name: 'Copy audit prompt' });
+    const command = install.getByRole('button', { name: 'Copy command' });
+    // Both live in step 1, and reading the source comes before running it.
+    expect(audit).toBeVisible();
+    expect(command).toBeVisible();
+    const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
+    expect(audit.compareDocumentPosition(command) & FOLLOWING).toBeTruthy();
+    // ...and not the other way round, so the direction is genuinely pinned.
+    expect(command.compareDocumentPosition(audit) & FOLLOWING).toBeFalsy();
+  });
+
+  it('opens step 1 and collapses the rest', () => {
+    renderWithClient(<LandingOnboardingGuide />);
+
+    expect(screen.getByRole('button', { name: /^Install the terminal/ })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getAllByRole('button', { expanded: false })).toHaveLength(3);
+    // A collapsed body is mounted but hidden, so nothing inside it is reachable.
+    expect(screen.getByText(/gate\.com\/signup/)).not.toBeVisible();
+    expect(screen.getByText(/\/bin\/bash -c/)).toBeVisible();
+  });
+
+  it('expands a step on click and collapses it again', async () => {
+    renderWithClient(<LandingOnboardingGuide />);
+
+    await openStep(/^Fund Gate/);
+    const header = screen.getByRole('button', { name: /^Fund Gate/ });
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText(/gate\.com\/signup/)).toBeVisible();
+
+    await userEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText(/gate\.com\/signup/)).not.toBeVisible();
+  });
+
+  it('offers the audit prompt with the questions that matter for a key-holding tool', () => {
+    renderWithClient(<LandingOnboardingGuide />);
+
+    const prompt = screen.getByText(/Audit this open-source tool/);
+    expect(prompt).toHaveTextContent('github.com/pendle-finance/crossex-boros-terminal');
+    expect(prompt).toHaveTextContent(/send my API keys.*off my machine/s);
+    expect(prompt).toHaveTextContent(/withdraw funds/);
+    expect(prompt).toHaveTextContent(/install\.sh \(macOS\) and install\.ps1 \(Windows\)/);
+  });
+
+  it('defaults to the macOS install command and swaps to PowerShell on demand', async () => {
+    // jsdom's userAgent is not Windows, so detectOs() lands on macOS. Step 1 is
+    // open by default, so the command is on screen already.
+    renderWithClient(<LandingOnboardingGuide />);
+
+    expect(screen.getByText(/\/bin\/bash -c/)).toBeInTheDocument();
+    expect(screen.queryByText(/install\.ps1 \| iex/)).toBeNull();
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Windows' }));
+
+    expect(screen.getByText(/install\.ps1 \| iex/)).toBeInTheDocument();
+    expect(screen.queryByText(/\/bin\/bash -c/)).toBeNull();
+    expect(screen.getByText(/press Win, type PowerShell/)).toBeInTheDocument();
+  });
+
+  it('never renders a credential input on the public page', async () => {
+    renderWithClient(<LandingOnboardingGuide />);
+    // Even with every step opened.
+    for (const t of [/^Install the terminal/, /^Create your API key/, /^Execute/]) {
+      await openStep(t);
+    }
+
+    expect(screen.queryByLabelText(/API key/i)).toBeNull();
+    expect(screen.queryByLabelText(/API secret/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /Save credentials/i })).toBeNull();
+  });
+});

--- a/web/src/panels/LandingOnboardingGuide.tsx
+++ b/web/src/panels/LandingOnboardingGuide.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react';
+import { CopyBlock } from '../components/CopyBlock';
+import { SegmentedToggle } from '../components/SegmentedToggle';
+import { AUDIT_PROMPT, INSTALL_CMD, INSTALL_CMD_WINDOWS, LOCAL_APP_URL, REPO_URL } from '../lib/landing';
+import { useTradeFlowOptional } from '../trade/TradeFlow';
+import { Ext, GATE_API_KEYS_URL, GATE_CROSSEX_URL, GATE_SIGNUP_URL, Step, useNudge } from './onboardingBits';
+
+type Os = 'macos' | 'windows';
+
+/** Default the install command to the visitor's own platform, so the common
+ * case is copy-and-go. Anything we can't identify falls back to macOS. */
+function detectOs(): Os {
+  if (typeof navigator === 'undefined') return 'macos';
+  return /Windows|Win32|Win64/i.test(navigator.userAgent) ? 'windows' : 'macos';
+}
+
+/** Public-site rail: same shell and Gate steps as OnboardingGuide, but step 1 is
+ * installing the terminal and no key ever touches this page — the API-key step
+ * sends the visitor to the setup guide of their locally-running copy instead of
+ * embedding the form, and the Execute nudge flashes the install command. */
+export function LandingOnboardingGuide() {
+  const flow = useTradeFlowOptional();
+  const nonce = flow?.pairPrefill?.nonce ?? 0;
+  const { ref: installRef, flash } = useNudge(nonce);
+  const [os, setOs] = useState<Os>(detectOs);
+  const windows = os === 'windows';
+
+  // Only step 1 starts open: the install command — and the audit prompt above it
+  // — are what a first-time visitor needs in front of them, while the remaining
+  // steps' full content would bury the live rates that are the actual pitch.
+  // The rest read as scannable titles.
+  const [openSteps, setOpenSteps] = useState<ReadonlySet<number>>(() => new Set([1]));
+  const toggle = (n: number) =>
+    setOpenSteps((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(n)) next.add(n);
+      return next;
+    });
+  const step = (n: number) => ({
+    collapsible: true as const,
+    open: openSteps.has(n),
+    onToggle: () => toggle(n),
+  });
+
+  // The Execute nudge flashes the install command — open its step first, or
+  // there is nothing on screen to flash.
+  useEffect(() => {
+    if (!nonce) return;
+    setOpenSteps((prev) => (prev.has(1) ? prev : new Set(prev).add(1)));
+  }, [nonce]);
+
+  return (
+    <aside
+      className="w-full shrink-0 lg:sticky lg:top-16 lg:w-[360px] lg:self-start"
+      aria-label="Setup guide"
+    >
+      <div className="card px-5 py-5">
+        <h2 className="text-xl font-bold tracking-tight text-ink-100">How to execute</h2>
+        <p className="mt-1.5 text-xs leading-relaxed text-ink-300">
+          Every number on the left is live. Four steps and you can take them.
+        </p>
+        <ol className="mt-5 flex flex-col gap-[18px]">
+          <Step n={1} title="Install the terminal" active {...step(1)}>
+            Runs locally on your own machine — free and <Ext href={REPO_URL}>open source</Ext>.
+            Audit it first if you want, then pick your system, paste the command and press Return:
+            {/* Above the command, not below it: the point of the audit is to read
+                the source BEFORE running anything. */}
+            <div className="mt-2 flex flex-col gap-1.5 rounded-lg border border-ink-800 bg-ink-950/60 p-2.5">
+              <span className="text-[10.5px] leading-relaxed text-ink-400">
+                Don’t take our word for it — paste this into whichever assistant you trust
+                (ChatGPT, Claude, Gemini) and have it read the source:
+              </span>
+              {/* The prompt is ~15 lines and would otherwise be the tallest
+                  thing in the rail — show a few and let it scroll. */}
+              <CopyBlock text={AUDIT_PROMPT} label="Copy audit prompt" maxHeightClass="max-h-20" />
+            </div>
+            <div
+              ref={installRef}
+              className="relative mt-2 flex flex-col gap-2 rounded-lg border border-ink-700 bg-ink-950 p-3"
+            >
+              {flash && <div aria-hidden="true" className="flash-ring" />}
+              <SegmentedToggle<Os>
+                ariaLabel="Operating system"
+                value={os}
+                onChange={setOs}
+                options={[
+                  { value: 'macos', label: <span className="text-xs">macOS</span> },
+                  { value: 'windows', label: <span className="text-xs">Windows</span> },
+                ]}
+              />
+              <CopyBlock text={windows ? INSTALL_CMD_WINDOWS : INSTALL_CMD} />
+              <span className="text-[10.5px] leading-relaxed text-ink-400">
+                {windows
+                  ? 'In Windows PowerShell — press Win, type PowerShell, open it. Windows 10 or 11; nothing to install first.'
+                  : 'In the Terminal app.'}
+              </span>
+              <a
+                href={LOCAL_APP_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="btn btn-primary justify-center text-xs font-semibold"
+              >
+                After that, open http://localhost:6688 ↗
+              </a>
+              <span className="text-center text-[10.5px] text-ink-400">
+                It never asks for keys in the terminal.
+              </span>
+            </div>
+          </Step>
+          {/* One Gate step, not three: signing up, switching CrossEx on and
+              moving funds into it are a single sitting on gate.com, and three
+              one-line steps made the rail read longer than the work is. The
+              ORDER still matters — CrossEx must be on before funds can move
+              into it — so it stays a numbered list inside the step. */}
+          <Step n={2} title="Fund Gate and enable CrossEx" {...step(2)}>
+            All three on gate.com, in this order:
+            <ol className="mt-1.5 flex list-decimal flex-col gap-1 pl-4 marker:text-ink-500">
+              <li>
+                Sign up at <Ext href={GATE_SIGNUP_URL}>gate.com/signup</Ext> and deposit the
+                capital you’ll deploy.
+              </li>
+              <li>
+                Switch on CrossEx at <Ext href={GATE_CROSSEX_URL}>gate.com/crossex</Ext> — both
+                the transfer below and the API-key permission need it enabled first.
+              </li>
+              <li>Move your funds into CrossEx, Gate’s cross-exchange margin account.</li>
+            </ol>
+          </Step>
+          <Step n={3} title="Create your API key" {...step(3)}>
+            In <Ext href={GATE_API_KEYS_URL}>API Management</Ext>, create an APIv4 key for your
+            Trading account. Set IP Permissions to “Later” (unless your machine has a consistent
+            IP), and under Permissions tick only Cross-Exchange with Read and Write; leave
+            Withdrawal off. Paste it into the setup guide of your locally-running terminal
+            at <Ext href={LOCAL_APP_URL}>localhost:6688</Ext> — keys stay on your machine and
+            never touch this website.
+          </Step>
+          {/* "in your terminal", not "on any card": the public build has no
+              Execute button — it would only ever render disabled here. */}
+          <Step n={4} title="Execute" {...step(4)}>
+            Hit Execute on any spread in your terminal; all four legs land pre-filled.
+          </Step>
+        </ol>
+      </div>
+    </aside>
+  );
+}

--- a/web/src/panels/OpportunitiesPanel.landing.test.tsx
+++ b/web/src/panels/OpportunitiesPanel.landing.test.tsx
@@ -1,0 +1,64 @@
+import { screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeOpportunitiesResult, opportunitiesHandler } from '../test/fixtures';
+import { server } from '../test/server';
+import { renderWithClient } from '../test/utils';
+import { OpportunitiesPanel, OPPORTUNITIES_STORAGE_KEY } from './OpportunitiesPanel';
+
+/**
+ * The LANDING build's two deviations from the terminal, both invisible to the
+ * rest of the suite because `IS_LANDING` is false there.
+ *
+ * `IS_LANDING` is a module constant read at import time, so it is mocked at the
+ * top of the module graph — `vi.mock` is hoisted above the imports above.
+ */
+vi.mock('../lib/landing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/landing')>();
+  return { ...actual, IS_LANDING: true };
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('OpportunitiesPanel — landing build', () => {
+  it('persists under its OWN storage key, so the two builds cannot overwrite each other', () => {
+    // The panel writes on MOUNT (the debounced-size effect fires immediately
+    // because useDebounced seeds its state), so a shared key let whichever
+    // build painted last silently re-set the other's controls — making each
+    // build's own defaults unreachable after one visit to the other.
+    expect(OPPORTUNITIES_STORAGE_KEY).toBe('crossex.opportunities.landing.v2');
+  });
+
+  it('a terminal-written blob cannot reach this build', async () => {
+    localStorage.setItem(
+      'crossex.opportunities.v2',
+      JSON.stringify({
+        notionalChoice: '10k',
+        customNotionalUsd: 10_000,
+        borosEntry: 'market',
+        entryMode: 'both-market',
+        exitMode: 'close',
+        feeTier: 'vip0',
+      }),
+    );
+    server.use(opportunitiesHandler(makeOpportunitiesResult()));
+    renderWithClient(<OpportunitiesPanel unconfigured />);
+
+    // $100k, not the terminal blob's $10k: the landing prices its headline at
+    // LANDING_NOTIONAL_USD and the panel behind it must agree.
+    await waitFor(() => expect(screen.getByText(/\$100k notional/)).toBeInTheDocument());
+  });
+
+  it('renders no Execute button — executing needs the terminal on your machine', async () => {
+    server.use(opportunitiesHandler(makeOpportunitiesResult()));
+    renderWithClient(<OpportunitiesPanel unconfigured />);
+
+    // Details is the control that DOES work without keys, so its presence is
+    // what proves the cards rendered at all.
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: /details/i }).length).toBeGreaterThan(0),
+    );
+    expect(screen.queryByRole('button', { name: /execute it/i })).toBeNull();
+  });
+});

--- a/web/src/panels/OpportunitiesPanel.tsx
+++ b/web/src/panels/OpportunitiesPanel.tsx
@@ -45,7 +45,18 @@ import { useTradeFlowOptional } from '../trade/TradeFlow';
 import { StrategyFreshness } from './HomeControls';
 import { canChartCapital, canChartProfit, OpportunityWaterfall } from './OpportunityWaterfall';
 
-export const OPPORTUNITIES_STORAGE_KEY = 'crossex.opportunities.v2';
+/** SEPARATE KEYS PER BUILD. The two builds deliberately disagree on their
+ * defaults ($10k/both-market in the terminal, $100k/maker-hedge on the landing
+ * — see LANDING_DEFAULTS), and they can share an origin during development
+ * (:5199 landing, :6688 terminal are both `localhost`). The panel persists on
+ * MOUNT, not only on user action — the debounced-size effect below fires
+ * immediately because `useDebounced` seeds its state with the input — so one
+ * shared key meant whichever build painted last silently re-set the other's
+ * controls, making each build's own defaults unreachable after a single visit
+ * to the other. Splitting the key is what keeps LANDING_DEFAULTS meaningful. */
+export const OPPORTUNITIES_STORAGE_KEY = IS_LANDING
+  ? 'crossex.opportunities.landing.v2'
+  : 'crossex.opportunities.v2';
 
 /** v1 coupled the notional to the Boros entry mode ('market-100k'); v2 splits
  * them into two independent knobs, so v1 blobs are migrated once and dropped. */
@@ -119,6 +130,22 @@ const DEFAULTS: StoredControls = {
   feeTier: 'vip0',
 };
 
+/** The landing build opens this panel from a headline number, so its first
+ * paint MUST be priced the same way `landingOpportunities.ts` prices that
+ * number — $100k at maker-hedge. With the shared DEFAULTS ($10k, both-market)
+ * the top card contradicted the hero the visitor had just clicked.
+ *
+ * Only the FIRST paint: everything here is a normal control, so changing size
+ * or entry mode works exactly as it does in the terminal, and any stored choice
+ * still wins (see loadControls). Kept in sync with LANDING_NOTIONAL_USD and the
+ * useLandingOpportunities params. */
+const LANDING_DEFAULTS: StoredControls = {
+  ...DEFAULTS,
+  notionalChoice: '100k',
+  customNotionalUsd: 100_000,
+  entryMode: 'maker-hedge',
+};
+
 /** 'vip3' → 'VIP 3'. */
 const feeTierLabel = (t: OpportunityFeeTier) => `VIP ${t.slice(3)}`;
 
@@ -170,7 +197,7 @@ function migrateLegacy(): StoredControls | null {
 }
 
 /** Read the persisted controls; anything corrupt falls back to its default. */
-export function loadControls(): StoredControls {
+export function loadControls(base: StoredControls = DEFAULTS): StoredControls {
   try {
     if (localStorage.getItem(OPPORTUNITIES_STORAGE_KEY) === null) {
       const migrated = migrateLegacy();
@@ -183,7 +210,7 @@ export function loadControls(): StoredControls {
   } catch {
     /* best-effort: an unreadable v1 blob just leaves the v2 read below */
   }
-  return readJson<StoredControls>(OPPORTUNITIES_STORAGE_KEY, DEFAULTS, (parsed) => {
+  return readJson<StoredControls>(OPPORTUNITIES_STORAGE_KEY, base, (parsed) => {
     const p = parsed as
       | {
           notionalChoice?: unknown;
@@ -197,12 +224,18 @@ export function loadControls(): StoredControls {
     return {
       notionalChoice: NOTIONAL_OPTIONS.some((o) => o.value === p?.notionalChoice)
         ? (p?.notionalChoice as NotionalChoice)
-        : DEFAULTS.notionalChoice,
-      customNotionalUsd: validSize(p?.customNotionalUsd),
+        : base.notionalChoice,
+      customNotionalUsd:
+        typeof p?.customNotionalUsd === 'number' && isValidOpportunityNotional(p.customNotionalUsd)
+          ? p.customNotionalUsd
+          : base.customNotionalUsd,
       borosEntry:
-        p?.borosEntry === 'mark' || p?.borosEntry === 'market' ? p.borosEntry : DEFAULTS.borosEntry,
-      entryMode: validEntryMode(p?.entryMode),
-      exitMode: validExitMode(p?.exitMode),
+        p?.borosEntry === 'mark' || p?.borosEntry === 'market' ? p.borosEntry : base.borosEntry,
+      entryMode:
+        p?.entryMode === 'both-market' || p?.entryMode === 'maker-hedge'
+          ? p.entryMode
+          : base.entryMode,
+      exitMode: p?.exitMode === 'close' || p?.exitMode === 'roll' ? p.exitMode : base.exitMode,
       feeTier: validFeeTier(p?.feeTier),
     };
   });
@@ -392,9 +425,10 @@ function OpportunityCard({
       : basesDiffer
         ? `The legs trade different assets (${pair.shortLeg.base} vs ${pair.longLeg.base}) — the pair ticket takes one base`
         : unconfigured
-          ? IS_LANDING
-            ? 'Runs in the terminal installed on your machine — see step 1 of the guide on the right'
-            : 'Add your Gate API key in the setup guide on the right — clicking stages this pair for the ticket'
+          ? // No IS_LANDING branch: the landing build does not render this
+            // button at all (see below), so a landing-specific tooltip here
+            // would be unreachable.
+            'Add your Gate API key in the setup guide on the right — clicking stages this pair for the ticket'
           : noSymbols
             ? `Neither ${pair.shortLeg.venue} nor ${pair.longLeg.venue} lists a CrossEx perp for ${pair.base}`
             : 'Prefills the pair ticket with these perp legs — you still confirm the order there';
@@ -545,15 +579,22 @@ function OpportunityCard({
           >
             {open ? 'Hide details' : 'Details'}
           </button>
-          <button
-            type="button"
-            className="btn btn-primary px-4 font-semibold"
-            disabled={executeDisabled}
-            title={executeTitle}
-            onClick={() => pair && onExecute?.(pair)}
-          >
-            Execute it
-          </button>
+          {/* Not on the public site: executing needs the terminal on your own
+              machine, so the button could only ever render disabled there —
+              a dead control on every card, advertising something the page
+              cannot do. The setup rail beside these cards is the real next
+              step. `Details` stays: it works fully without keys. */}
+          {!IS_LANDING && (
+            <button
+              type="button"
+              className="btn btn-primary px-4 font-semibold"
+              disabled={executeDisabled}
+              title={executeTitle}
+              onClick={() => pair && onExecute?.(pair)}
+            >
+              Execute it
+            </button>
+          )}
         </div>
       </div>
 
@@ -691,7 +732,11 @@ function RateNote({ midApr, execApr }: { midApr: number; execApr: number | null 
 }
 
 export function OpportunitiesPanel({ unconfigured = false }: { unconfigured?: boolean } = {}) {
-  const [stored] = useState<StoredControls>(loadControls);
+  // IS_LANDING, not `unconfigured`: a fresh terminal install is also
+  // unconfigured and must keep the terminal's own $10k default.
+  const [stored] = useState<StoredControls>(() =>
+    loadControls(IS_LANDING ? LANDING_DEFAULTS : DEFAULTS),
+  );
   const [notionalChoice, setNotionalChoice] = useState<NotionalChoice>(stored.notionalChoice);
   const [borosEntry, setBorosEntry] = useState<BorosEntryMode>(stored.borosEntry);
   const [entryMode, setEntryMode] = useState<EntryMode>(stored.entryMode);


### PR DESCRIPTION
Adds a second view to the public landing page at `#/rates`, reached from a **"Show me more"** button on the hero's live-rates card. It shows every live spread with the terminal's own **"with these assumptions"** controls, so a visitor can re-price the whole list at their own size and fee tier, alongside the setup rail explaining how to actually run it.

The landing hero answers *"what's the number?"*. This answers *"is that number real for me?"* — the honest response to which is to hand over the assumptions and let people change them.

## What's in it

**The route** — `useHashRoute.ts`, a two-state hash route. A hash rather than a path because the landing deploys as static files: `/rates` would 404 on a hard refresh unless the host rewrites it. No router dependency and no third Vite entry point.

**The view** — `RatesExplorer.tsx`: Back button, heading, `<OpportunitiesPanel unconfigured />` on the left, setup rail on the right. The overview stays at 1200px; this view widens to 1500px, since the cards were too narrow beside a fixed 360px rail.

**The setup rail** — `LandingOnboardingGuide.tsx` and its test, restored from `f3d422f~1` (deleted in #6). Both come back unmodified apart from one copy fix, and its 8 tests pass as-is.

## Changes to `OpportunitiesPanel` (shared with the terminal)

This is the file worth reviewing closely — the terminal renders it too. Four changes, all gated on `IS_LANDING`:

1. **`LANDING_DEFAULTS`** — the landing opens at `$100k / maker-hedge` to match how the hero prices its headline. Without this the top card read 16.6% under an 18.0% hero, so clicking the number contradicted it.
2. **`loadControls(base = DEFAULTS)`** — takes a base default set instead of closing over one.
3. **Execute button hidden on the landing** — executing needs the terminal running locally, so the control could only ever render disabled on a public page. `Details` stays; it works fully without keys.
4. **Per-build storage key** — see below.

Gating is on `IS_LANDING`, deliberately **not** `unconfigured`: a fresh terminal install is also unconfigured and must keep the terminal's own `$10k / both-market` defaults.

## Two bugs found in review

**localStorage collision.** The panel persists on *mount*, not only on user action — `useDebounced` seeds its state with the input, so the debounced-size effect fires on first paint. With one shared key, whichever build painted last silently re-set the other's controls, and each build's own defaults became unreachable after a single visit to the other. Reproduced directly: a landing-written blob made `loadControls(terminalBase)` hand the terminal `100k / maker-hedge`. Fixed by splitting the key per build (`crossex.opportunities.landing.v2`), which is what makes `LANDING_DEFAULTS` mean anything at all.

**In-page Back pushed instead of popping.** Setting `location.hash = ''` pushes a history entry, so after "Show me more" → "Back" the browser's own Back button walked the visitor into the `#/rates` view they had just dismissed. Fixed with a `pushed` ref that tracks entries the hook itself pushed, popping one on the way out; a deep-linked visitor with nothing to pop gets `replaceState` instead, so Back leaves the site.

> Worth knowing for anyone touching `useHashRoute`: **jsdom does not model history faithfully** — the unit tests passed against the broken version too. This was only confirmed in a fresh Playwright browser context.

## Copy

- Diagram heading: *"How that **ETH** number is built"* → *"How that **+17.7%** number is built"*. It named the asset when the number a visitor is asking about is the headline APR. Driven by the same value and sign-colouring as the math row's result, so it goes red on a negative day rather than claiming green.
- Card 3 intro drops *"Plus a little on-chain gas."* (the numbered gas instruction stays).
- Guide step 4: *"on any card"* → *"on any spread in your terminal"*, since there's no Execute button to point at.

## Tests

**393 → 401.** New: `useHashRoute.test.tsx` (5, including the history-pop case) and `OpportunitiesPanel.landing.test.tsx` (3, covering the storage split and the Execute gate via a hoisted `IS_LANDING` mock).

## Verified

- `tsc --noEmit` clean · **401/401** tests
- Both builds (`build` and `build:landing`)
- **Both CI leak guards run locally**, including the position-entry chunk-graph walk — the main risk here, since the restored rail imports `useTradeFlowOptional`. No credentials or trading UI in the landing bundle.
- Back/forward behaviour confirmed in a clean browser context

## Known follow-up (not in this PR)

`LandingOnboardingGuide` pulls `TradeFlow` (and transitively `DealModal`) into the landing bundle for code that's permanently inert there — `LandingApp` provides no `TradeFlowProvider`, so its Execute-nudge flash never fires. Real but low-cost: the landing bundle is ~97 kB and both leak guards pass. Left out because fixing it means editing a file restored verbatim, which is better as its own change.
