### PR TITLE
Landing: self-correct a missing trailing slash so a bare /crossex mount works

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -80,6 +80,21 @@ function landingHtml(): PluginOption {
           .replace(
             '  </head>',
             [
+              // Trailing-slash guard, index ONLY. The landing is served behind
+              // reverse proxies at a sub-path (e.g. boros.pendle.finance/crossex
+              // -> Netlify 200-rewrite), and the bundle's relative './assets' +
+              // './api' URLs only resolve correctly when the document URL ends
+              // in '/': at a bare '/crossex' they resolve at the domain root
+              // and the page renders blank. The proxy layer cannot express the
+              // redirect (Netlify's _redirects matching is slash-agnostic and
+              // loops), so the page fixes its own URL before any module runs
+              // (inline head script beats the deferred module scripts; the
+              // preload scanner may fetch once in vain — harmless). At '/'
+              // (direct origin, dev preview) this is a no-op. position.html
+              // must NOT get this: '/crossex/position' already resolves
+              // './assets' to '/crossex/assets', and a forced slash would
+              // break exactly what this fixes here.
+              `    <script>if(!location.pathname.endsWith('/'))location.replace(location.pathname+'/'+location.search+location.hash);</script>`,
               `    <meta name="description" content="${LANDING_DESCRIPTION}" />`,
               `    <meta property="og:title" content="${LANDING_TITLE}" />`,
               `    <meta property="og:description" content="${LANDING_DESCRIPTION}" />`,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -80,20 +80,11 @@ function landingHtml(): PluginOption {
           .replace(
             '  </head>',
             [
-              // Trailing-slash guard, index ONLY. The landing is served behind
-              // reverse proxies at a sub-path (e.g. boros.pendle.finance/crossex
-              // -> Netlify 200-rewrite), and the bundle's relative './assets' +
-              // './api' URLs only resolve correctly when the document URL ends
-              // in '/': at a bare '/crossex' they resolve at the domain root
-              // and the page renders blank. The proxy layer cannot express the
-              // redirect (Netlify's _redirects matching is slash-agnostic and
-              // loops), so the page fixes its own URL before any module runs
-              // (inline head script beats the deferred module scripts; the
-              // preload scanner may fetch once in vain — harmless). At '/'
-              // (direct origin, dev preview) this is a no-op. position.html
-              // must NOT get this: '/crossex/position' already resolves
-              // './assets' to '/crossex/assets', and a forced slash would
-              // break exactly what this fixes here.
+              // Lets the landing be deployed under a sub-path (e.g. /crossex):
+              // the relative './assets' + './api' URLs need a trailing slash
+              // on the document URL, so the page appends one to its own URL
+              // before any module runs. Index only — position.html resolves
+              // correctly without it.
               `    <script>if(!location.pathname.endsWith('/'))location.replace(location.pathname+'/'+location.search+location.hash);</script>`,
               `    <meta name="description" content="${LANDING_DESCRIPTION}" />`,
               `    <meta property="og:title" content="${LANDING_TITLE}" />`,


### PR DESCRIPTION
The landing ships with a relative asset base (`./assets`) and a relative `./api` client so it can live behind any sub-path proxy — but that only resolves correctly when the document URL ends in `/`. At the bare `boros.pendle.finance/crossex` the assets resolve at the domain root, the host SPA answers them with HTML, and the page renders blank.

The proxy layer can't fix this: Netlify `_redirects` matching is trailing-slash-agnostic, so a `/crossex -> /crossex/ 301` rule matches its own target and loops (proved by dapp-nitro #1076's deploy preview).

So the page fixes its own URL: an inline head script in the **landing index.html only** does `location.replace(pathname + '/')` when the path lacks the trailing slash, before any module executes. No-op at `/` (direct origin, previews). `position.html` is deliberately excluded — `/crossex/position` already resolves `./assets` correctly and a forced slash would break it.

Landing-build only (the plugin doesn't run for the terminal build). Verified: `build:landing` puts the guard in `index.html` and not `position.html`; web tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)