### PR TITLE
Public landing: no-store HTML, immutable hashed assets

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -4,7 +4,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import fastifyStatic from '@fastify/static';
+import fastifyStatic, { type FastifyStaticOptions } from '@fastify/static';
 import { setClientTagContext } from '../core/boros/client';
 import { makeClientsIfConfigured, requireClients, type Clients } from '../core/clients';
 import { Store } from '../engine/db';
@@ -161,7 +161,18 @@ if (fs.existsSync(path.join(webDist, 'index.html'))) {
     app.get('/', serveIndex);
     app.get('/index.html', serveIndex);
   }
-  app.register(fastifyStatic, { root: webDist });
+  // Public landing sits behind CDNs: never cache HTML, hashed assets are immutable.
+  const staticOpts: FastifyStaticOptions = { root: webDist };
+  if (publicMode) {
+    staticOpts.cacheControl = false;
+    staticOpts.setHeaders = (res, filePath) => {
+      if (filePath.endsWith('.html')) res.setHeader('cache-control', 'no-store');
+      else if (filePath.includes(`${path.sep}assets${path.sep}`))
+        res.setHeader('cache-control', 'public, max-age=31536000, immutable');
+      else res.setHeader('cache-control', 'public, max-age=60, must-revalidate');
+    };
+  }
+  app.register(fastifyStatic, staticOpts);
 }
 
 app


### PR DESCRIPTION
## Problem
The public landing at `boros.pendle.finance/crossex` (Netlify proxy → Cloudflare → GKE origin) served stale deploys for hours: `Cf-Cache-Status: HIT` with `Age: 3279`. In `PUBLIC_MODE` HTML is served by `@fastify/static` with its defaults — `public, max-age=0` and Last-Modified-only validators — and the two-CDN chain's mtime-based 304 revalidation pinned old copies.

## Fix — PUBLIC_MODE only
The token-injection index routes for local installs are **untouched**. In public mode the static plugin (which already serves `index.html` at `/`) gets `cacheControl: false` + a `setHeaders` hook:
- any `.html` → `no-store`
- hashed `/assets/*` → `public, max-age=31536000, immutable` (content-addressed filenames)
- other files → `public, max-age=60, must-revalidate`

Local installs (`localhost:6688`) keep exactly the previous behavior in every route.

## Verified
- `tsc --noEmit` clean; all 148 server tests pass.
- Booted both modes locally: public → `/` and `/index.html` `no-store`, assets `immutable`; token mode → unchanged (`no-store` index with token meta, assets `public, max-age=0`).

After deploy, purge `boros.pendle.finance/crossex*` in Cloudflare once to evict the currently-pinned copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)