### PR TITLE
Public mode: default no-store on responses without an explicit Cache-Control

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -145,6 +145,13 @@ export function buildApp(deps: AppDeps): FastifyInstance {
       reply.header('X-Content-Type-Options', 'nosniff');
       reply.header('Referrer-Policy', 'strict-origin-when-cross-origin');
     });
+    // CDNs in front cache header-less responses; default everything to no-store.
+    app.addHook('onSend', async (_req, reply, payload) => {
+      if (!reply.getHeader('cache-control') && !reply.raw.getHeader('cache-control')) {
+        reply.header('cache-control', 'no-store');
+      }
+      return payload;
+    });
   } else {
     app.addHook('onRequest', async (req, reply) => {
       // The Host/Origin guard cannot stop framing: a page that iframes


### PR DESCRIPTION
Follow-up to #11. The HTML is fixed, but the landing's `/api` JSON (the hero fixed-APR number, rates data) went out with **no** `Cache-Control`, so Cloudflare's cache-everything rule held it for the 2h default TTL (`Cf-Cache-Status: HIT`, `Age: 675`) — the hero showed hours-old rates.

## Fix
`PUBLIC_MODE`-only `onSend` hook in `buildApp`: any response that didn't set its own `Cache-Control` gets `no-store`. Routes/static files that do set one (immutable hashed assets, 60s misc files) are untouched — the hook checks both Fastify and raw headers. Local installs unaffected.

## Verified
- `tsc` clean, 148 server tests pass.
- `PUBLIC_MODE` boot: `/api/opportunities` → `no-store` (404s too), `/` → `no-store`, `/assets/*` → `immutable`.

After deploy: one Cloudflare purge of `boros.pendle.finance/crossex*` to evict the currently-cached JSON, then the hero number stays live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)