### PR TITLE
Rename/pr1 display and domain

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -42,7 +42,7 @@ jobs:
       # deploy so the og:image/canonical injection path is the one that ships.
       - run: yarn --cwd web build:landing
         env:
-          LANDING_URL: https://crossexboros.com
+          LANDING_URL: https://boros.pendle.finance/crossex
       - run: |
           shopt -s nullglob
           pos=(web/dist/assets/position-*.js)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Share a position, explain a stopped deal, and a Windows service that stays hidde
 - **A fully hedged 4-leg position box grows a "Share ↗" button.** It renders a PNG card — "I'm
   getting X% fixed APR on $Y capital" plus the four legs — and offers the link, the PNG, and an X
   post pre-filled with the link. The numbers are frozen as you saw them, cost toggles included.
-- **The link is a page that explains the trade.** `crossexboros.com/position` draws how the four
+- **The link is a page that explains the trade.** `boros.pendle.finance/crossex/position` draws how the four
   legs hedge, the PnL waterfall and the capital split, with collapsible explainers, a roll-over /
   close-perps toggle that re-derives every number, and a "self-reported, not verified" disclaimer.
 - **The whole snapshot travels in the URL.** The public page stores nothing — no database, no new

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Public landing deployment (crossexboros.com): the Fastify server in PUBLIC_MODE
+# Public landing deployment (boros.pendle.finance/crossex): the Fastify server in PUBLIC_MODE
 # serving the prebuilt landing SPA. The frontend is built by deploy/deploy.sh
 # before the image — this image never runs tsc/vite (the VM is small on purpose).
 # The container holds ZERO secrets: no .env, no keys, and PUBLIC_MODE registers

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Not available to, or intended for, any person where such use is unlawful (includ
 
 ---
 
-# CrossEx-Boros Terminal
+# Arbitrage with CrossEx
 
 **Open source tool** · **Experimental, use at your own risks**
 
@@ -38,8 +38,8 @@ press Return:
 
 When it finishes (a few minutes the first time), the terminal opens in your browser at
 **http://localhost:6688** — bookmark it. From then on the app is always running in the
-background, even after you restart your Mac. You'll also find a **"CrossEx-Boros
-Terminal"** launcher in your `~/Applications` folder.
+background, even after you restart your Mac. You'll also find a **"Arbitrage with
+CrossEx"** launcher in your `~/Applications` folder.
 
 Everything lands in one folder: `~/.boros-crossex`.
 
@@ -58,7 +58,7 @@ irm https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main
 
 When it finishes, the terminal opens in your browser at **http://localhost:6688** —
 bookmark it. The app then starts on its own every time you sign in, and you'll find a
-**"CrossEx-Boros Terminal"** shortcut in your Start Menu.
+**"Arbitrage with CrossEx"** shortcut in your Start Menu.
 
 Everything lands in one folder: `%LOCALAPPDATA%\CrossEx-Boros`.
 
@@ -352,7 +352,7 @@ user data lives outside the auto-updated app directory.
 
 ## Web terminal — `yarn dev` / `yarn start`
 
-A local web app ("CrossEx-Boros Terminal") wraps the same core with a monitoring dashboard and a
+A local web app ("Arbitrage with CrossEx") wraps the same core with a monitoring dashboard and a
 safety-gated trading UI:
 
 ```bash

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -2,7 +2,7 @@
 
 In this guide, we will cover:
 1. How the strategy works
-2. The recommended flow for using CrossEx Boros Terminal
+2. The recommended flow for using Arbitrage with CrossEx
 3. How to maximise return
 4. What could go wrong
 
@@ -21,7 +21,7 @@ Boros Academy walks through this strategy in more depth: [Fixed-Return Funding A
 
 **Fixed does not mean risk-free** - see section 4.
 
-## 2. The recommended flow for using CrossEx Boros Terminal
+## 2. The recommended flow for using Arbitrage with CrossEx
 You will use the tool for 3 things, in order:
 
 ### A. Discover and understand opportunities
@@ -113,7 +113,7 @@ Last, let's see the different ways things could go wrong:
 4. Liquidation of Boros positions:
    - If the Boros market prices move too much away from the spread you locked in, your Boros position could be **liquidated**, and the 4-legged position's fixed return is compromised.
    - To avoid this, its advisable to **maintain a buffer** on the Boros margin (especially when Boros margin is relatively non-capital-intensive)
-5. Issues with CrossEx Boros Terminal:
+5. Issues with Arbitrage with CrossEx:
    - Any issues that result in opening a **non-hedged pair** of perp positions will expose you to losses due to price fluctuation.
    - Its advisable to **double check that your perp positions are hedged** after execution.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -87,7 +87,7 @@ Under **Include**, the **▾** button next to it itemises that cost so you can c
 ## 3. How to maximise return
 These few factors move the needle the most in maximising your return on the 4-legged Funding Rate Arbitrage
 1. Reduce perp fees with a **higher VIP tier** in Gate.
-   * Play around with the VIP tier assumption in https://crossexboros.com, and you will see the immediate impact of your VIP tier on the potential returns.
+   * Play around with the VIP tier assumption in https://boros.pendle.finance/crossex, and you will see the immediate impact of your VIP tier on the potential returns.
    * As an example, my current VIP8 tier boosts a particular opportunity from **11.3% APR** to **16.2% APR**. For reference, I need a 400k capital in Gate to get VIP8 tier.
 2. **Rolling over**
    * Being able to roll over an existing 4-legged position into the next maturity is a powerful boost to your return

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,5 @@
 <#
-  CrossEx-Boros Terminal - Windows installer.
+  Arbitrage with CrossEx - Windows installer.
 
   Usage (paste into PowerShell):
     irm https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/install.ps1 | iex
@@ -42,8 +42,15 @@ $Ref      = $env:BOROS_REF
 $Port     = if ($env:BOROS_PORT)   { [int]$env:BOROS_PORT } else { 6688 }
 $Root     = if ($env:BOROS_ROOT)   { $env:BOROS_ROOT }   else { Join-Path $env:LOCALAPPDATA 'CrossEx-Boros' }
 $NodeLine = 'v24'
-$TaskName = 'CrossEx-Boros Terminal'
-$AppTitle = 'CrossEx-Boros Terminal'
+$TaskName = 'Arbitrage with CrossEx'
+$AppTitle = 'Arbitrage with CrossEx'
+# Display names this app shipped under before. The scheduled task and the Start
+# Menu shortcut are keyed BY NAME, so a rename orphans the old ones: the old task
+# keeps launching the old install and the two servers fight over the port.
+# APPEND the outgoing name on every rename - never replace the list.
+# ($Root is deliberately NOT renamed alongside these: it holds the API keys and
+# the trade ledger, and moving it would risk orphaning both.)
+$LegacyTitles = @('CrossEx-Boros Terminal', 'Boros CrossEx Terminal')
 $LogDir   = Join-Path $Root 'logs'
 
 $ServerEntry = Join-Path $Root 'app\src\server\index.ts'
@@ -55,7 +62,7 @@ function Fail {
   # throw, not exit: this script is normally run as `irm ... | iex`, where `exit`
   # would terminate the user's entire PowerShell session rather than the install.
   param([string]$m)
-  throw "CrossEx-Boros install failed: $m"
+  throw "Arbitrage with CrossEx install failed: $m"
 }
 
 # `$IsWindows` exists only in PowerShell 6+; on Windows PowerShell 5.1 it is undefined.
@@ -504,6 +511,13 @@ while (`$true) {
 function Stop-RunningService {
   Say 'Stopping any running instance...'
   Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+  # Tasks registered under a previous product name. Without this, an upgrade
+  # across a rename leaves the old task registered and starting the old app -
+  # two servers, one port. This is what makes the rename a safe UPDATE.
+  foreach ($legacy in $LegacyTitles) {
+    Stop-ScheduledTask -TaskName $legacy -ErrorAction SilentlyContinue
+    Unregister-ScheduledTask -TaskName $legacy -Confirm:$false -ErrorAction SilentlyContinue
+  }
   Stop-StaleServer   # reap any old/orphaned server so re-running always updates
 
   if (Test-PortInUseByOther) {
@@ -627,6 +641,11 @@ function New-Launcher {
   # SmartScreen to object to.
   $programs = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
   New-Item -ItemType Directory -Force -Path $programs | Out-Null
+  # Shortcuts left by a previous product name - otherwise the Start Menu keeps
+  # one entry per name this app has ever had, all pointing at the same port.
+  foreach ($legacy in $LegacyTitles) {
+    Remove-Item -Path (Join-Path $programs "$legacy.url") -Force -ErrorAction SilentlyContinue
+  }
   $lnk = Join-Path $programs "$AppTitle.url"
   "[InternetShortcut]`r`nURL=http://localhost:$Port`r`n" | Set-Content -Path $lnk -Encoding ASCII
 }

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# CrossEx-Boros Terminal — macOS installer.
+# Arbitrage with CrossEx — macOS installer.
 #
 # Usage (paste into Terminal):
 #   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/install.sh)"
@@ -40,7 +40,7 @@ PORT="${BOROS_PORT:-6688}"
 ROOT="${BOROS_ROOT:-$HOME/.boros-crossex}"
 NODE_LINE="v24"
 LABEL="com.boros.crossex-terminal"
-APP_TITLE="CrossEx-Boros Terminal"
+APP_TITLE="Arbitrage with CrossEx"
 LOG_DIR="$HOME/Library/Logs/boros-crossex"
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 
@@ -346,8 +346,12 @@ wait_for_server() {
 make_launcher() {
   # A tiny local .app that opens the terminal in your browser. Created locally,
   # so macOS Gatekeeper has no reason to block it.
-  # Second path is the launcher name from before the CrossEx-Boros rename.
-  rm -rf "$HOME/Applications/$APP_TITLE.app" "$HOME/Applications/Boros CrossEx Terminal.app"
+  # The extra paths are the launcher names this app shipped under before. The
+  # .app is keyed by name, so each rename would otherwise leave a stale launcher
+  # in ~/Applications. APPEND the outgoing name on every rename; never replace.
+  rm -rf "$HOME/Applications/$APP_TITLE.app" \
+    "$HOME/Applications/CrossEx-Boros Terminal.app" \
+    "$HOME/Applications/Boros CrossEx Terminal.app"
   osacompile -e "do shell script \"open http://localhost:$PORT\"" \
     -o "$HOME/Applications/$APP_TITLE.app" >/dev/null 2>&1 || true
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "arb-tools",
   "version": "0.1.0",
   "private": true,
-  "description": "CrossEx-Boros Terminal \u2014 delta-neutral funding-rate arbitrage on Gate CrossEx (web terminal + Fastify server)",
+  "description": "Arbitrage with CrossEx \u2014 delta-neutral funding-rate arbitrage on Gate CrossEx (web terminal + Fastify server)",
   "license": "MIT",
   "repository": "github:pendle-finance/crossex-boros-terminal",
   "packageManager": "yarn@1.22.22",

--- a/src/core/share/codec.ts
+++ b/src/core/share/codec.ts
@@ -1,5 +1,5 @@
 /** Share-position payload codec — the wire format behind
- * `crossexboros.com/position?d=<encoded>`.
+ * `boros.pendle.finance/crossex/position?d=<encoded>`.
  *
  * The payload is a compact short-key JSON snapshot of one 4-leg position,
  * base64url-encoded into the URL itself: the public box stores nothing, so the

--- a/src/server/position.ts
+++ b/src/server/position.ts
@@ -71,7 +71,7 @@ function metaBlock(p: SharePayloadV1): string {
   const desc = clamp(
     `${pct(p.sp)} spread locked until ${dateUtc(p.m)} (${daysText}). ` +
       `Expected PnL by maturity ${signedUsd(p.p)}. Boros rate legs + hedged perps on ${venues}, ` +
-      `delta-neutral via Gate CrossEx. Self-reported — shared from the open-source CrossEx-Boros terminal.`,
+      `delta-neutral via Gate CrossEx. Self-reported — shared from the open-source Arbitrage with CrossEx terminal.`,
     DESC_MAX,
   );
   const t = escapeHtml(title);

--- a/tests/server/position-page.test.ts
+++ b/tests/server/position-page.test.ts
@@ -19,9 +19,9 @@ const TEMPLATE = `<!doctype html>
 <html lang="en" class="dark">
   <head>
     <!-- position-meta -->
-    <title>Shared 4-leg hedged position — CrossEx-Boros</title>
+    <title>Shared 4-leg hedged position — Arbitrage with CrossEx</title>
     <meta name="description" content="A delta-neutral, fixed-rate 4-leg funding arbitrage position." />
-    <meta property="og:title" content="Shared 4-leg hedged position — CrossEx-Boros" />
+    <meta property="og:title" content="Shared 4-leg hedged position — Arbitrage with CrossEx" />
     <meta property="og:description" content="A delta-neutral, fixed-rate 4-leg funding arbitrage position." />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />

--- a/tests/server/position-page.test.ts
+++ b/tests/server/position-page.test.ts
@@ -26,9 +26,9 @@ const TEMPLATE = `<!doctype html>
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
     <!-- /position-meta -->
-    <link rel="canonical" href="https://crossexboros.com/position" />
-    <meta property="og:url" content="https://crossexboros.com/position" />
-    <meta property="og:image" content="https://crossexboros.com/position-og.png" />
+    <link rel="canonical" href="https://boros.pendle.finance/crossex/position" />
+    <meta property="og:url" content="https://boros.pendle.finance/crossex/position" />
+    <meta property="og:image" content="https://boros.pendle.finance/crossex/position-og.png" />
   </head>
   <body><div id="root"></div></body>
 </html>
@@ -112,9 +112,9 @@ describe('renderPositionHtml (pure)', () => {
 
   it('rewrites canonical/og:url to this exact share, og:image untouched', () => {
     const html = renderPositionHtml(TEMPLATE, validD);
-    expect(html).toContain(`<link rel="canonical" href="https://crossexboros.com/position?d=${validD}" />`);
-    expect(html).toContain(`<meta property="og:url" content="https://crossexboros.com/position?d=${validD}" />`);
-    expect(html).toContain('<meta property="og:image" content="https://crossexboros.com/position-og.png" />');
+    expect(html).toContain(`<link rel="canonical" href="https://boros.pendle.finance/crossex/position?d=${validD}" />`);
+    expect(html).toContain(`<meta property="og:url" content="https://boros.pendle.finance/crossex/position?d=${validD}" />`);
+    expect(html).toContain('<meta property="og:image" content="https://boros.pendle.finance/crossex/position-og.png" />');
   });
 
   it('returns the template byte-identical for every malformed shape', () => {
@@ -162,7 +162,7 @@ describe('GET /position', () => {
     const res = await app.inject({
       method: 'GET',
       url: `/position?d=${validD}`,
-      headers: { host: 'crossexboros.com' },
+      headers: { host: 'boros.pendle.finance/crossex' },
     });
     expect(res.statusCode).toBe(200);
     expect(res.headers['content-type']).toContain('text/html');

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,5 +1,5 @@
 <#
-  CrossEx-Boros Terminal - Windows uninstaller.
+  Arbitrage with CrossEx - Windows uninstaller.
 
     irm https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/uninstall.ps1 | iex
 
@@ -23,8 +23,11 @@ $Root     = if ($env:BOROS_ROOT) { $env:BOROS_ROOT } else { Join-Path $env:LOCAL
 # Resolved exactly as install.ps1 resolves it: the last-resort port guard below
 # must check the port the server was actually installed on.
 $Port     = if ($env:BOROS_PORT) { [int]$env:BOROS_PORT } else { 6688 }
-$TaskName = 'CrossEx-Boros Terminal'
-$AppTitle = 'CrossEx-Boros Terminal'
+$TaskName = 'Arbitrage with CrossEx'
+$AppTitle = 'Arbitrage with CrossEx'
+# Kept in step with install.ps1: an uninstall must also clear the task and the
+# shortcut left by any previous product name, or they outlive the app.
+$LegacyTitles = @('CrossEx-Boros Terminal', 'Boros CrossEx Terminal')
 $ServerEntry = Join-Path $Root 'app\src\server\index.ts'
 $RunnerPath  = Join-Path $Root 'run-server.ps1'
 
@@ -103,6 +106,10 @@ function Stop-StaleServer {
 Say 'Stopping the background service...'
 try { Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue } catch { }
 try { Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue } catch { }
+foreach ($legacy in $LegacyTitles) {
+  try { Stop-ScheduledTask -TaskName $legacy -ErrorAction SilentlyContinue } catch { }
+  try { Unregister-ScheduledTask -TaskName $legacy -Confirm:$false -ErrorAction SilentlyContinue } catch { }
+}
 Stop-StaleServer
 
 if (@(Get-ServerProcess).Count -gt 0) {
@@ -161,8 +168,11 @@ foreach ($d in @('app', 'app.new', 'app.old', 'node', 'logs')) {
 $runner = Join-Path $Root 'run-server.ps1'
 if (Test-Path $runner) { Remove-Item -Force $runner -ErrorAction SilentlyContinue }
 
-$lnk = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\$AppTitle.url"
-if (Test-Path $lnk) { Remove-Item -Force $lnk -ErrorAction SilentlyContinue }
+$programs = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
+foreach ($title in @($AppTitle) + $LegacyTitles) {
+  $lnk = Join-Path $programs "$title.url"
+  if (Test-Path $lnk) { Remove-Item -Force $lnk -ErrorAction SilentlyContinue }
+}
 
 if ($Purge) {
   Say 'Removing API keys and trade history (-Purge)...'

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# CrossEx-Boros Terminal — macOS uninstaller.
+# Arbitrage with CrossEx — macOS uninstaller.
 #
 #   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/uninstall.sh)"
 #
@@ -14,7 +14,7 @@ set -euo pipefail
 
 ROOT="${BOROS_ROOT:-$HOME/.boros-crossex}"
 LABEL="com.boros.crossex-terminal"
-APP_TITLE="CrossEx-Boros Terminal"
+APP_TITLE="Arbitrage with CrossEx"
 LOG_DIR="$HOME/Library/Logs/boros-crossex"
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 
@@ -97,8 +97,11 @@ main() {
 
   say "Removing the app and its private Node.js runtime…"
   rm -rf "$ROOT/app" "$ROOT/app.new" "$ROOT/app.old" "$ROOT/node" "$ROOT"/node-v*-darwin-*
-  # Second path is the launcher name from before the CrossEx-Boros rename.
-  rm -rf "$HOME/Applications/$APP_TITLE.app" "$HOME/Applications/Boros CrossEx Terminal.app"
+  # The extra paths are the launcher names this app shipped under before; kept in
+  # step with install.sh so an uninstall leaves no launcher from any past name.
+  rm -rf "$HOME/Applications/$APP_TITLE.app" \
+    "$HOME/Applications/CrossEx-Boros Terminal.app" \
+    "$HOME/Applications/Boros CrossEx Terminal.app"
   rm -rf "$LOG_DIR"
 
   if [ "${1:-}" = "--purge" ]; then

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "version": "1.3.0",
   "highlights": [
-    "Share a position: a PNG card, a public crossexboros.com link, and a pre-filled X post, straight from a hedged 4-leg box",
+    "Share a position: a PNG card, a public boros.pendle.finance/crossex link, and a pre-filled X post, straight from a hedged 4-leg box",
     "The link opens a page that explains the trade — the four legs as a hedging diagram, the PnL waterfall, the capital split",
     "The whole snapshot rides in the URL: the public page stores nothing, and your wallet address never travels with a link",
     "A deal that stops because your limit price kept crossing the market now says so, and points you back to the order form",

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CrossEx-Boros Terminal</title>
+    <title>Arbitrage with CrossEx</title>
     <!-- Replaced by the server with this install's API token; the client sends
          it back on every /api call. Left as-is by the landing build. -->
     <meta name="arb-token" content="__ARB_TOKEN__" />

--- a/web/package.json
+++ b/web/package.json
@@ -2,7 +2,7 @@
   "name": "crossex-terminal-web",
   "private": true,
   "version": "0.1.0",
-  "description": "CrossEx-Boros Terminal — monitoring + trading UI for Gate.io CrossEx",
+  "description": "Arbitrage with CrossEx — monitoring + trading UI for Gate.io CrossEx",
   "license": "MIT",
   "repository": "github:pendle-finance/crossex-boros-terminal",
   "scripts": {

--- a/web/position.html
+++ b/web/position.html
@@ -8,15 +8,15 @@
          payload; these are the generic fallbacks served when ?d= is missing or
          invalid — and by the Vite dev server, which does no injection. -->
     <!-- position-meta -->
-    <title>Shared 4-leg hedged position — CrossEx-Boros</title>
+    <title>Shared 4-leg hedged position — Arbitrage with CrossEx</title>
     <meta
       name="description"
-      content="A delta-neutral, fixed-rate 4-leg funding arbitrage position, shared from the open-source CrossEx-Boros terminal."
+      content="A delta-neutral, fixed-rate 4-leg funding arbitrage position, shared from the open-source Arbitrage with CrossEx terminal."
     />
-    <meta property="og:title" content="Shared 4-leg hedged position — CrossEx-Boros" />
+    <meta property="og:title" content="Shared 4-leg hedged position — Arbitrage with CrossEx" />
     <meta
       property="og:description"
-      content="A delta-neutral, fixed-rate 4-leg funding arbitrage position, shared from the open-source CrossEx-Boros terminal."
+      content="A delta-neutral, fixed-rate 4-leg funding arbitrage position, shared from the open-source Arbitrage with CrossEx terminal."
     />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />

--- a/web/src/PositionApp.tsx
+++ b/web/src/PositionApp.tsx
@@ -49,7 +49,7 @@ function CtaFooter() {
     <section className="card p-3 text-center sm:p-5">
       <p className="text-sm leading-relaxed text-ink-300">
         This position was executed with Pendle&apos;s free, open-source{' '}
-        <span className="font-semibold text-ink-100">CrossEx-Boros Terminal</span> — it runs on
+        <span className="font-semibold text-ink-100">Arbitrage with CrossEx</span> — it runs on
         your own machine, and your keys never leave it.
       </p>
       <div className="mt-3 flex flex-wrap items-center justify-center gap-2">

--- a/web/src/PositionApp.tsx
+++ b/web/src/PositionApp.tsx
@@ -1,4 +1,4 @@
-/** The public shared-position page (`crossexboros.com/position?d=…`).
+/** The public shared-position page (`boros.pendle.finance/crossex/position?d=…`).
  *
  * Fully static from the URL payload: the codec's strict schema is the only
  * input validation needed, decoded strings render exclusively as React text

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1,5 +1,5 @@
 /**
- * Hand-mirrored API contract for the CrossEx-Boros Terminal backend
+ * Hand-mirrored API contract for the Arbitrage with CrossEx backend
  * (Fastify on http://localhost:6688, proxied at /api).
  *
  * Monitoring route shapes mirror what the backend serializes from gate-api +

--- a/web/src/components/BrandMark.tsx
+++ b/web/src/components/BrandMark.tsx
@@ -5,11 +5,12 @@ import { Chip } from './Chip';
 export function BrandMark() {
   return (
     <>
-      <h1 className="flex items-baseline gap-2 text-base font-semibold tracking-tight text-ink-100">
-        CrossEx-Boros
-        <span className="font-mono text-xs font-medium uppercase tracking-widest text-cyan-400">
-          Terminal
-        </span>
+      {/* Two-tone wordmark: the leading "Arbitrage" carries the cyan accent, the
+       * rest stays neutral. Mirrored on the canvas share card (lib/shareCard.ts)
+       * — keep the two in step. */}
+      <h1 className="flex items-baseline gap-1.5 text-base font-semibold tracking-tight text-ink-100">
+        <span className="text-cyan-400">Arbitrage</span>
+        with CrossEx
       </h1>
       <div className="flex items-center gap-2">
         <Chip sm tone="blue" title="Free and open source — audit or contribute on GitHub">

--- a/web/src/lib/share.ts
+++ b/web/src/lib/share.ts
@@ -56,5 +56,5 @@ export function buildXIntentUrl(p: SharePayloadV1): string {
 }
 
 export function shareFileName(p: SharePayloadV1): string {
-  return `crossex-boros-${p.b.toLowerCase()}-${fmtDateUtc(p.m)}.png`;
+  return `arbitrage-with-crossex-${p.b.toLowerCase()}-${fmtDateUtc(p.m)}.png`;
 }

--- a/web/src/lib/share.ts
+++ b/web/src/lib/share.ts
@@ -6,7 +6,7 @@
 import { encodeSharePayload, type SharePayloadV1 } from './shareCodec';
 import { fmtDateUtc, fmtPct, fmtUsd } from './fmt';
 
-export const SHARE_BASE_URL = 'https://crossexboros.com';
+export const SHARE_BASE_URL = 'https://boros.pendle.finance/crossex';
 export const SHARE_PATH = '/position';
 
 /** Whole days of the strategy's term — clock start to maturity — the

--- a/web/src/lib/shareCard.ts
+++ b/web/src/lib/shareCard.ts
@@ -168,13 +168,15 @@ export async function renderShareCard(p: SharePayloadV1, scale = 2): Promise<HTM
   const right = SHARE_CARD_W - 64;
 
   // --- header: wordmark left, base + hedge pills right.
-  ctx.fillStyle = TEXT_HI;
+  // Two-tone, mirroring the DOM header in components/BrandMark.tsx: cyan
+  // "Arbitrage", neutral " with CrossEx". One font for both halves, so the
+  // second is placed by measuring the first.
   ctx.font = `600 26px ${SANS}`;
-  ctx.fillText('CrossEx-Boros', left, 76);
-  const wordmarkW = ctx.measureText('CrossEx-Boros').width;
   ctx.fillStyle = CYAN;
-  ctx.font = `500 13px ${MONO}`;
-  ctx.fillText('T E R M I N A L', left + wordmarkW + 14, 76);
+  ctx.fillText('Arbitrage', left, 76);
+  const accentW = ctx.measureText('Arbitrage').width;
+  ctx.fillStyle = TEXT_HI;
+  ctx.fillText(' with CrossEx', left + accentW, 76);
   const hedgeTone =
     p.h === 'h'
       ? { color: EMERALD, bg: 'rgba(52,211,153,0.12)', border: 'rgba(52,211,153,0.35)' }

--- a/web/src/lib/shareCodec.ts
+++ b/web/src/lib/shareCodec.ts
@@ -1,5 +1,5 @@
 /** Share-position payload codec — the wire format behind
- * `crossexboros.com/position?d=<encoded>`.
+ * `boros.pendle.finance/crossex/position?d=<encoded>`.
  *
  * The payload is a compact short-key JSON snapshot of one 4-leg position,
  * base64url-encoded into the URL itself: the public box stores nothing, so the

--- a/web/src/panels/SharePositionModal.test.tsx
+++ b/web/src/panels/SharePositionModal.test.tsx
@@ -45,7 +45,7 @@ describe('SharePositionModal', () => {
     mount();
     const input = screen.getByLabelText('Position share link') as HTMLInputElement;
     expect(input.value).toBe(buildShareUrl(payload));
-    expect(input.value.startsWith('https://crossexboros.com/position?d=')).toBe(true);
+    expect(input.value.startsWith('https://boros.pendle.finance/crossex/position?d=')).toBe(true);
     const d = new URL(input.value).searchParams.get('d') ?? '';
     expect(decodeSharePayload(d)).toEqual({ ok: true, payload });
   });

--- a/web/src/panels/SharePositionModal.test.tsx
+++ b/web/src/panels/SharePositionModal.test.tsx
@@ -36,7 +36,7 @@ describe('SharePositionModal', () => {
       'data:image/png;base64,stub',
     );
     const download = screen.getByRole('link', { name: 'Download PNG' });
-    expect(download).toHaveAttribute('download', `crossex-boros-hype-${fmtDateUtc(payload.m)}.png`);
+    expect(download).toHaveAttribute('download', `arbitrage-with-crossex-hype-${fmtDateUtc(payload.m)}.png`);
     // jsdom defines neither ClipboardItem nor clipboard.write → no Copy image.
     expect(screen.queryByRole('button', { name: 'Copy image' })).not.toBeInTheDocument();
   });

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -14,7 +14,7 @@ import { defineConfig } from 'vitest/config';
 // the public page metadata. Vitest runs in mode `test`, so tests always see the
 // terminal app.
 
-const LANDING_TITLE = 'CrossEx-Boros Terminal — live fixed-rate arbitrage on Boros × Gate CrossEx';
+const LANDING_TITLE = 'Arbitrage with CrossEx — live fixed-rate arbitrage on Boros × Gate CrossEx';
 const LANDING_DESCRIPTION =
   'Live delta-neutral funding-rate opportunities between Boros fixed rates and Gate CrossEx perps. ' +
   'A free, open-source terminal by Pendle that runs on your own machine — your keys never leave it.';


### PR DESCRIPTION
PR 1 — rename/pr1-display-and-domain → main
Title: Rename the product to Arbitrage with CrossEx, and move the public URLs to boros.pendle.finance/crossex

Merge: now — no external dependency.

What
Renames the product everywhere user-visible, and points canonical/share URLs at the new home. 25 files, +106/−67, in two commits you can review separately:

d6cc993 — display name, logo, installer titles, + the legacy-name cleanup
79ccab5 — canonical, og:url, og:image, share-link base
Logo is now two-tone: cyan Arbitrage + neutral with CrossEx, in both the DOM header (BrandMark.tsx) and the canvas share card (shareCard.ts). The old cyan TERMINAL suffix is dropped.

The part that isn't cosmetic
The Windows scheduled task and Start Menu shortcut are keyed by name. Renaming them without unregistering the old ones leaves the previous task running the old install — two servers on port 6688, two engines reconciling against the same ledger. install.ps1/uninstall.ps1 now carry a $LegacyTitles list that every future rename appends to; install.sh already did this for the macOS .app.

Verified on a real Windows host, upgrading over a live Running service: exactly one scheduled task, one Start Menu entry, one listener on 6688, and both the config and data markers intact.

Explicitly not changed
~/.boros-crossex, %LOCALAPPDATA%\CrossEx-Boros, BOROS_*, the LaunchAgent label, port 6688, and the crossex.opportunities.v2 localStorage keys. All invisible to users, and moving them is the only way this rename could lose someone's API keys or trade history. Nothing moves, so there's nothing to lose.

Known external dependency (not owned by this repo)
Installed apps have the old share base compiled in, so they keep minting crossexboros.com links until their owners update, and every link already shared points there. That domain needs a permanent 301 preserving path and query (return 301 https://boros.pendle.finance/crossex$request_uri;) — a bare-domain redirect returns 200 and silently serves a generic page, because the ?d= payload is the position. The domain is not controlled by this repo's owners. This PR is what stops the set of such links growing.

Checks
typecheck ✓ · 556/556 backend ✓ · 401/401 web ✓ · both builds ✓ · both landing leak guards ✓