### PR TITLE
Follow the repo rename to pendle-finance/arbitrage-with-crossex

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Paste this into the **Terminal** app (Finder → Applications → Utilities → 
 press Return:
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/install.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/install.sh)"
 ```
 
 When it finishes (a few minutes the first time), the terminal opens in your browser at
@@ -53,7 +53,7 @@ PowerShell** is fine — no need to install anything first). Press `Win`, type
 `PowerShell`, open it, then paste:
 
 ```powershell
-irm https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/install.ps1 | iex
 ```
 
 When it finishes, the terminal opens in your browser at **http://localhost:6688** —
@@ -136,7 +136,7 @@ for a Gate.io API key:
 **macOS**
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/uninstall.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/uninstall.sh)"
 ```
 
 Keys and trade history in `~/.boros-crossex` are kept; append ` -- --purge` to remove
@@ -145,13 +145,13 @@ those too (or `rm -rf ~/.boros-crossex`).
 **Windows**
 
 ```powershell
-irm https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/uninstall.ps1 | iex
+irm https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/uninstall.ps1 | iex
 ```
 
 Keys and trade history in `%LOCALAPPDATA%\CrossEx-Boros` are kept. To remove those too:
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/uninstall.ps1))) -Purge
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/uninstall.ps1))) -Purge
 ```
 
 Either way this stops and removes the background service, the app, its private Node.js
@@ -200,8 +200,8 @@ read it and the moment you run it — and again on every update. To close that g
 **1. Pin a commit.** Clone the repo and note the exact tree you are about to audit:
 
 ```bash
-git clone https://github.com/pendle-finance/crossex-boros-terminal
-cd crossex-boros-terminal
+git clone https://github.com/pendle-finance/arbitrage-with-crossex
+cd arbitrage-with-crossex
 git log -1 --format=%H     # ← this commit is what you are auditing
 ```
 
@@ -213,12 +213,12 @@ same commit, so the script you run is the one you read):
 
 ```bash
 REF=<commit-sha>
-BOROS_REF=$REF /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/$REF/install.sh)"
+BOROS_REF=$REF /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/$REF/install.sh)"
 ```
 
 ```powershell
 $env:BOROS_REF = '<commit-sha>'
-irm "https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/$($env:BOROS_REF)/install.ps1" | iex
+irm "https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/$($env:BOROS_REF)/install.ps1" | iex
 ```
 
 …or straight from the clone you just audited, with no second download at all:
@@ -254,11 +254,11 @@ of this repo for an even deeper read.
 I'm considering installing an open-source crypto trading tool on my Mac, and I want you
 to audit it before I run anything.
 
-Repository:  https://github.com/pendle-finance/crossex-boros-terminal
+Repository:  https://github.com/pendle-finance/arbitrage-with-crossex
 Commit to audit:  <paste the commit SHA you pinned — or "main" for the current tip>
-Source tree at that commit:  https://github.com/pendle-finance/crossex-boros-terminal/tree/<commit>
-Installer I would run:  https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/<commit>/install.sh
-Uninstaller:  https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/<commit>/uninstall.sh
+Source tree at that commit:  https://github.com/pendle-finance/arbitrage-with-crossex/tree/<commit>
+Installer I would run:  https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/<commit>/install.sh
+Uninstaller:  https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/<commit>/uninstall.sh
 
 Please read the installer, the uninstaller, and the application source code, then answer:
 

--- a/install.ps1
+++ b/install.ps1
@@ -2,7 +2,7 @@
   CrossEx-Boros Terminal - Windows installer.
 
   Usage (paste into PowerShell):
-    irm https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/install.ps1 | iex
+    irm https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/install.ps1 | iex
 
   What this script does - and everything it does:
     1. Downloads a private copy of Node.js (official nodejs.org build, checksum
@@ -33,7 +33,7 @@ $ProgressPreference = 'SilentlyContinue'  # Invoke-WebRequest is far faster with
 # ---------------------------------------------------------------------------
 # Configuration (BOROS_* env vars exist for development/testing overrides)
 # ---------------------------------------------------------------------------
-$RepoSlug = if ($env:BOROS_REPO)   { $env:BOROS_REPO }   else { 'pendle-finance/crossex-boros-terminal' }
+$RepoSlug = if ($env:BOROS_REPO)   { $env:BOROS_REPO }   else { 'pendle-finance/arbitrage-with-crossex' }
 $Branch   = if ($env:BOROS_BRANCH) { $env:BOROS_BRANCH } else { 'main' }
 # Pin an exact commit, tag or branch: BOROS_REF wins over BOROS_BRANCH. This is
 # how you install the very tree you audited - see "Install exactly what you

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # CrossEx-Boros Terminal — macOS installer.
 #
 # Usage (paste into Terminal):
-#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/install.sh)"
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/install.sh)"
 #
 # What this script does — and everything it does:
 #   1. Downloads a private copy of Node.js (official nodejs.org build, checksum
@@ -21,7 +21,7 @@
 # running version first (including any orphaned/wedged copy), so an old version
 # never lingers. Your keys and trade history (kept in ~/.boros-crossex/config and
 # ~/.boros-crossex/data) are never touched.
-# Uninstall: https://github.com/pendle-finance/crossex-boros-terminal#uninstall
+# Uninstall: https://github.com/pendle-finance/arbitrage-with-crossex#uninstall
 #
 # This script is bash-3.2 compatible (macOS system bash).
 
@@ -30,7 +30,7 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Configuration (BOROS_* env vars exist for development/testing overrides)
 # ---------------------------------------------------------------------------
-REPO_SLUG="${BOROS_REPO:-pendle-finance/crossex-boros-terminal}"
+REPO_SLUG="${BOROS_REPO:-pendle-finance/arbitrage-with-crossex}"
 BRANCH="${BOROS_BRANCH:-main}"
 # Pin an exact commit, tag or branch: BOROS_REF wins over BOROS_BRANCH. This is
 # how you install the very tree you audited — see "Install exactly what you

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "CrossEx-Boros Terminal \u2014 delta-neutral funding-rate arbitrage on Gate CrossEx (web terminal + Fastify server)",
   "license": "MIT",
-  "repository": "github:pendle-finance/crossex-boros-terminal",
+  "repository": "github:pendle-finance/arbitrage-with-crossex",
   "packageManager": "yarn@1.22.22",
   "engines": {
     "node": ">=20"

--- a/src/server/version.ts
+++ b/src/server/version.ts
@@ -13,7 +13,7 @@ import * as path from 'node:path';
 import type { FetchLike } from '../core/boros/client';
 
 export const VERSION_URL =
-  'https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/version.json';
+  'https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/version.json';
 const FETCH_TIMEOUT_MS = 5_000;
 /** Cap on remote highlights — the modal is a nudge, not a changelog. */
 const MAX_HIGHLIGHTS = 10;

--- a/tests/server/version.test.ts
+++ b/tests/server/version.test.ts
@@ -147,7 +147,7 @@ describe('GET /api/version', () => {
 
   it('echoes the installer provenance so the UI can show which commit runs', async () => {
     const install = {
-      repo: 'pendle-finance/crossex-boros-terminal',
+      repo: 'pendle-finance/arbitrage-with-crossex',
       requestedRef: 'refs/heads/main',
       commit: 'f4f681af8b36c1bddc98048f214ff1405d56ca73',
       source: 'github-archive',

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,13 +1,13 @@
 <#
   CrossEx-Boros Terminal - Windows uninstaller.
 
-    irm https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/uninstall.ps1 | iex
+    irm https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/uninstall.ps1 | iex
 
   Removes the background task, the app, and its private Node.js runtime.
   Your API keys (config\) and trade history (data\) are KEPT unless you pass
   -Purge:
 
-    & ([scriptblock]::Create((irm https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/uninstall.ps1))) -Purge
+    & ([scriptblock]::Create((irm https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/uninstall.ps1))) -Purge
 
   This is the Windows counterpart of uninstall.sh; the two are kept in step.
 #>

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,7 +2,7 @@
 #
 # CrossEx-Boros Terminal — macOS uninstaller.
 #
-#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/uninstall.sh)"
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/uninstall.sh)"
 #
 # Removes the background service, the app, and its private Node.js runtime.
 # Your API keys (~/.boros-crossex/config) and trade history (~/.boros-crossex/data)

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "description": "CrossEx-Boros Terminal — monitoring + trading UI for Gate.io CrossEx",
   "license": "MIT",
-  "repository": "github:pendle-finance/crossex-boros-terminal",
+  "repository": "github:pendle-finance/arbitrage-with-crossex",
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -342,7 +342,7 @@ describe('user guide', () => {
     expect(alert).toHaveTextContent(/Couldn’t load the guide/);
     expect(within(alert).getByRole('link', { name: 'docs/USER_GUIDE.md' })).toHaveAttribute(
       'href',
-      'https://github.com/pendle-finance/crossex-boros-terminal/blob/main/docs/USER_GUIDE.md',
+      'https://github.com/pendle-finance/arbitrage-with-crossex/blob/main/docs/USER_GUIDE.md',
     );
   });
 });

--- a/web/src/components/DisclaimerGate.tsx
+++ b/web/src/components/DisclaimerGate.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useAcceptDisclaimer, useDisclaimer } from '../api/queries';
 import { Modal } from './Modal';
 
-const DISCLAIMER_URL = 'https://github.com/pendle-finance/crossex-boros-terminal/blob/main/docs/DISCLAIMER.md';
+const DISCLAIMER_URL = 'https://github.com/pendle-finance/arbitrage-with-crossex/blob/main/docs/DISCLAIMER.md';
 
 /** First-run gate: blocks the terminal until the disclaimer is accepted. The
  * server ALSO refuses trading routes until acceptance is recorded — this modal

--- a/web/src/components/UpdateIndicator.test.tsx
+++ b/web/src/components/UpdateIndicator.test.tsx
@@ -44,7 +44,7 @@ describe('UpdateIndicator', () => {
     expect(screen.getAllByText('(this machine)')).toHaveLength(1);
     expect(screen.getByRole('link', { name: /Full changelog/ })).toHaveAttribute(
       'href',
-      'https://github.com/pendle-finance/crossex-boros-terminal/blob/main/CHANGELOG.md',
+      'https://github.com/pendle-finance/arbitrage-with-crossex/blob/main/CHANGELOG.md',
     );
   });
 

--- a/web/src/components/UserGuideModal.tsx
+++ b/web/src/components/UserGuideModal.tsx
@@ -15,7 +15,7 @@ import remarkGfm from 'remark-gfm';
 import { Modal } from './Modal';
 import { Skeleton } from './Skeleton';
 
-const REPO = 'pendle-finance/crossex-boros-terminal';
+const REPO = 'pendle-finance/arbitrage-with-crossex';
 const BRANCH = 'main';
 const DOC = 'docs/USER_GUIDE.md';
 

--- a/web/src/landing/Faq.tsx
+++ b/web/src/landing/Faq.tsx
@@ -24,7 +24,7 @@ const FAQS: { q: string; a: ReactNode }[] = [
     a: (
       <>
         The Pendle team. It's an open-source project, published at{' '}
-        <Ext href={REPO_URL}>github.com/pendle-finance/crossex-boros-terminal</Ext>. It is
+        <Ext href={REPO_URL}>github.com/pendle-finance/arbitrage-with-crossex</Ext>. It is
         still experimental software, provided "as is" — use it at your own risk.
       </>
     ),
@@ -63,7 +63,7 @@ const FAQS: { q: string; a: ReactNode }[] = [
     a: (
       <>
         It's open source and experimental. Read it yourself:{' '}
-        <Ext href={REPO_URL}>github.com/pendle-finance/crossex-boros-terminal</Ext>, or hand
+        <Ext href={REPO_URL}>github.com/pendle-finance/arbitrage-with-crossex</Ext>, or hand
         the prompt below to an assistant you trust before you paste in a key.
       </>
     ),

--- a/web/src/lib/landing.ts
+++ b/web/src/lib/landing.ts
@@ -3,16 +3,16 @@
  * leaves VITE_LANDING unset so every landing branch is inert. */
 export const IS_LANDING = import.meta.env.VITE_LANDING === '1';
 
-export const REPO_URL = 'https://github.com/pendle-finance/crossex-boros-terminal';
+export const REPO_URL = 'https://github.com/pendle-finance/arbitrage-with-crossex';
 
 /** Verbatim from README "Install (macOS)" — the one command a visitor runs. */
 export const INSTALL_CMD =
-  '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/install.sh)"';
+  '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/install.sh)"';
 
 /** Verbatim from README "Install (Windows)". Windows 10/11 with the built-in
  * Windows PowerShell 5 — the visitor installs nothing first. */
 export const INSTALL_CMD_WINDOWS =
-  'irm https://raw.githubusercontent.com/pendle-finance/crossex-boros-terminal/main/install.ps1 | iex';
+  'irm https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/install.ps1 | iex';
 
 /** Paste-into-your-own-LLM audit prompt. The whole pitch is "don't trust us,
  * the source is right there" — this hands the visitor a concrete way to act on
@@ -24,7 +24,7 @@ export const INSTALL_CMD_WINDOWS =
  * a link built from it, and two different repo URLs for the same project is
  * exactly the doubt the prompt exists to remove. */
 export const AUDIT_PROMPT = `Audit this open-source tool for me before I run it:
-https://github.com/pendle-finance/crossex-boros-terminal
+https://github.com/pendle-finance/arbitrage-with-crossex
 
 It runs on my own machine and will hold my Gate exchange API keys. Read the real
 source, then answer:

--- a/web/src/panels/LandingOnboardingGuide.test.tsx
+++ b/web/src/panels/LandingOnboardingGuide.test.tsx
@@ -90,7 +90,7 @@ describe('LandingOnboardingGuide', () => {
     renderWithClient(<LandingOnboardingGuide />);
 
     const prompt = screen.getByText(/Audit this open-source tool/);
-    expect(prompt).toHaveTextContent('github.com/pendle-finance/crossex-boros-terminal');
+    expect(prompt).toHaveTextContent('github.com/pendle-finance/arbitrage-with-crossex');
     expect(prompt).toHaveTextContent(/send my API keys.*off my machine/s);
     expect(prompt).toHaveTextContent(/withdraw funds/);
     expect(prompt).toHaveTextContent(/install\.sh \(macOS\) and install\.ps1 \(Windows\)/);


### PR DESCRIPTION
PR 2 — rename/pr3-repo-slug → main
Title: Follow the repo rename to pendle-finance/arbitrage-with-crossex

⛔ Merge only after the GitHub repo has actually been renamed.

What
Updates the repo slug in install one-liners, the update check, the user-guide fetch, the disclaimer link and the FAQ. 16 files, +36/−36, pure string change.

Why the ordering is strict
Three of these are fetched at runtime: the update check (src/server/version.ts), the user guide (UserGuideModal.tsx), and the install commands shown to users. Merging before the rename points all three at a 404 — confirmed by hitting the new raw URL, which currently 404s.

Renaming the repo first is safe: GitHub redirects the old paths including raw.githubusercontent, verified against this repo's own earlier transfer, so already-installed apps keep resolving throughout.

Permanent constraint this creates
Installed apps reference the old slug forever, so pendle-finance/crossex-boros-terminal must keep redirecting indefinitely — the old name must never be reused for another repo, or every un-updated install loses its update check and user guide.

Checks
typecheck ✓ · 556/556 backend ✓ · 401/401 web ✓ (verified independently off main)

