### PR TITLE
Opportunities: list every viable pair, behind a compact facet bar

### DIFF
--- a/src/server/routes/opportunities.ts
+++ b/src/server/routes/opportunities.ts
@@ -132,14 +132,22 @@ function ruleClient(deps: AppDeps): CrossExApi {
  *
  * A failed read or a symbol with no row leaves that symbol absent, which nulls
  * only that pair's capital — the notional-basis numbers still price.
+ *
+ * Returns a warning when the read failed for EVERY symbol. One shared
+ * `getLeverageMax` call backs them all, so a single outage empties the whole
+ * map — and with no leverage cap anywhere, no pair can model its capital, no
+ * pair prices an APR on capital, and the terminal shows an empty list. Silence
+ * there reads as "no opportunities at this notional", sending the reader to
+ * re-tune a size that was never the problem.
  */
 async function loadLeverageMax(
   deps: AppDeps,
   symbols: string[],
   fresh: boolean,
   out: Map<string, number>,
-): Promise<void> {
+): Promise<string | null> {
   let batch: Promise<Map<string, number>> | undefined;
+  let failure: unknown;
   await Promise.all(
     symbols.map(async (symbol) => {
       try {
@@ -153,11 +161,15 @@ async function loadLeverageMax(
           { fresh },
         );
         if (value > 0) out.set(symbol, value);
-      } catch {
+      } catch (err) {
         // Omit the symbol; the math turns that into a reason naming the venue.
+        failure ??= err;
       }
     }),
   );
+  if (symbols.length === 0 || out.size > 0 || failure === undefined) return null;
+  const { category } = classifyGateError(failure);
+  return `Couldn't load the CrossEx risk limits right now (${category}) — without a max leverage per venue no opportunity can model the capital it consumes, so none can be ranked. This isn't about your notional; the caps return on the next refresh.`;
 }
 
 export function opportunitiesRoutes(deps: AppDeps) {
@@ -317,7 +329,9 @@ export function opportunitiesRoutes(deps: AppDeps) {
           );
           venueBooks.set(key, value);
         }),
-        loadLeverageMax(deps, [...perpSymbols], fresh, leverageMaxBySymbol),
+        loadLeverageMax(deps, [...perpSymbols], fresh, leverageMaxBySymbol).then((warning) => {
+          if (warning !== null) warnings.push(warning);
+        }),
       ]);
 
       const result = buildOpportunities(

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -133,7 +133,7 @@ describe('App tab shell', () => {
     // The panel itself renders inside the tab panel (its cards land once the
     // /api/opportunities fixture resolves).
     expect(
-      await within(panel('opportunities')).findByRole('button', { name: 'Execute it' }),
+      await within(panel('opportunities')).findByRole('button', { name: /^Execute ETH short/ }),
     ).toBeInTheDocument();
     expect(panel('opportunities')).toBeVisible();
   });
@@ -267,7 +267,7 @@ describe('App tab shell', () => {
     expect(screen.getByLabelText('Gate VIP tier')).toBeInTheDocument();
 
     // Symbols are expectedly absent — the button stays enabled as the guide's nudge.
-    const execute = screen.getByRole('button', { name: 'Execute it' });
+    const execute = screen.getByRole('button', { name: /^Execute ETH short/ });
     expect(execute).toBeEnabled();
     await userEvent.click(execute);
     await waitFor(() => expect(screen.getByLabelText('API key')).toHaveFocus());

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -506,8 +506,12 @@ export interface OpportunityGroup {
   warnings: string[];
 }
 
-/** Groups arrive pre-ranked (net fixed APR on capital desc) — never re-sort
- * client-side. */
+/** Groups arrive pre-ranked, and so do the `pairs` within each — on net fixed
+ * APR on capital, then netFixedApr, execSpreadApr, grossSpreadApr. A view that
+ * flattens the groups has to REPRODUCE that comparator (see
+ * `panels/opportunityFilters.ts`), not just its first key: the flat array is
+ * group-major, so sort stability alone would break a cross-group tie by group
+ * rank and float a strictly worse pair to the top. */
 export interface OpportunitiesResult {
   groups: OpportunityGroup[];
   meta: {

--- a/web/src/panels/OpportunitiesPanel.test.tsx
+++ b/web/src/panels/OpportunitiesPanel.test.tsx
@@ -7,6 +7,7 @@ import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
 import type {
   ActionInput,
+  OpportunityLeg,
   OpportunityPair,
   PreviewResponse,
   PreviewResult,
@@ -21,6 +22,7 @@ import {
   makeOpportunityMarketRow,
   makeOpportunityPair,
   opportunitiesHandler,
+  OPP_MATURITY,
   OPP_NT,
   previewFor,
   symbolHandlers,
@@ -38,7 +40,7 @@ const paramsOf = (url: string) => Object.fromEntries(new URL(url).searchParams);
 /** The card's collapse toggle, one per group. */
 const toggles = () => screen.getAllByRole('button', { name: /^(Show|Hide) details for/ });
 
-const executeButtons = () => screen.getAllByRole('button', { name: 'Execute it' });
+const executeButtons = () => screen.getAllByRole('button', { name: /^Execute / });
 
 /** Every knob lives inside the collapsed assumptions strip — open it first. */
 const openAssumptions = () =>
@@ -455,7 +457,7 @@ describe('OpportunitiesPanel — collapse', () => {
 
     await waitFor(() => expect(toggles()).toHaveLength(1));
     expect(screen.getByText('7.0% APR')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Execute it' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Execute ETH short Hyperliquid/ })).toBeInTheDocument();
     expect(toggles()[0]).toHaveTextContent('Details');
     expect(toggles()[0]).toHaveAttribute('aria-expanded', 'false');
     expect(container.querySelector('[data-waterfall]')).toBeNull();
@@ -1001,7 +1003,7 @@ describe('OpportunitiesPanel → PairTicket prefill', () => {
     await openAssumptions();
     const panelModes = screen.getByRole('radiogroup', { name: 'Perp entry mode' });
     await userEvent.click(within(panelModes).getByRole('radio', { name: /Limit \+ hedge/ }));
-    await userEvent.click(screen.getByRole('button', { name: 'Execute it' }));
+    await userEvent.click(screen.getByRole('button', { name: /^Execute ETH short Hyperliquid/ }));
 
     await waitFor(() =>
       expect(screen.getByLabelText('Notional per leg (USDT)')).toHaveValue('10000'),
@@ -1018,5 +1020,313 @@ describe('OpportunitiesPanel → PairTicket prefill', () => {
     expect(legs[0]).toMatchObject({ symbol: 'BINANCE_FUTURE_ETH_USDT', side: 'BUY' });
     expect(legs[1]).toMatchObject({ symbol: 'HYPERLIQUID_FUTURE_ETH_USDC', side: 'SELL' });
     expect(legs.some((a) => a.kind === 'open-limit' && a.pairRole === 'maker')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Every viable pair, and the facet bar that narrows them
+// ---------------------------------------------------------------------------
+
+/** Distinct id per (side, venue, base). Deriving ids from the venue NAME's
+ * length silently collapsed two venues of equal length onto one id — and the
+ * two market ids are the whole discriminator in a row's React key. */
+const marketIds = new Map<string, number>();
+const marketIdFor = (side: 'short' | 'long', venue: string, base: string): number => {
+  const k = `${side}:${venue}:${base}`;
+  if (!marketIds.has(k)) marketIds.set(k, 900 + marketIds.size);
+  return marketIds.get(k) as number;
+};
+
+/** Hyperliquid quotes USDC on CrossEx; the USDT venues quote USDT. */
+const quoteOf = (venue: string) => (venue === 'HYPERLIQUID' ? 'USDC' : 'USDT');
+
+/** A leg the server could actually emit: the Boros venue, its CrossEx mapping
+ * and the symbol all name the same exchange and the same coin. Renaming only
+ * `venue` decouples the field the venue facet keys on from the one Execute
+ * keys on, which hides exactly the regressions these fixtures exist to catch. */
+function venueLeg(side: 'short' | 'long', venue: string, base: string): OpportunityLeg {
+  return {
+    ...makeOpportunityLeg(),
+    marketId: marketIdFor(side, venue, base),
+    venue,
+    crossexVenue: venue,
+    crossexSymbol: `${venue}_FUTURE_${base}_${quoteOf(venue)}`,
+    base,
+  };
+}
+
+/** One pair pinned to an APR and a pair of Boros venues. */
+function venuePair(
+  apr: number | null,
+  shortVenue: string,
+  longVenue: string,
+  base = 'ETH',
+  over: Partial<OpportunityPair> = {},
+): OpportunityPair {
+  return {
+    ...makeOpportunityPair(),
+    base,
+    shortLeg: venueLeg('short', shortVenue, base),
+    longLeg: venueLeg('long', longVenue, base),
+    netFixedAprOnCapital: apr,
+    ...over,
+  };
+}
+
+/** ETH offers two venue combinations; BTC, in a later cohort, offers one. */
+const multiPairResult = () =>
+  makeOpportunitiesResult({
+    groups: [
+      makeOpportunityGroup({
+        tokenId: 3,
+        underlying: 'ETH',
+        pairs: [
+          venuePair(0.12, 'HYPERLIQUID', 'BINANCE'),
+          venuePair(0.04, 'HYPERLIQUID', 'GATE'),
+        ],
+      }),
+      makeOpportunityGroup({
+        tokenId: 4,
+        underlying: 'BTC',
+        maturity: OPP_MATURITY + 60 * 86_400,
+        secondsToMaturity: 90 * 86_400,
+        pairs: [
+          venuePair(0.08, 'BYBIT', 'GATE', 'BTC', { secondsToMaturity: 90 * 86_400 }),
+        ],
+      }),
+    ],
+  });
+
+const chip = (name: RegExp) => screen.getByRole('button', { name });
+
+/** The Execute control of one card, named by its legs (every card's used to be
+ * the bare "Execute it", which named none of them). */
+const executeFor = (name: RegExp) => screen.getByRole('button', { name });
+
+describe('OpportunitiesPanel — every viable pair', () => {
+  it('shows every pair in a group, not only its best, ranked across groups', async () => {
+    server.use(opportunitiesHandler(multiPairResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    // Best APR first, regardless of which cohort it came from.
+    expect(screen.getAllByText(/^\d+\.\d% APR$/).map((el) => el.textContent)).toEqual([
+      '12.0% APR',
+      '8.0% APR',
+      '4.0% APR',
+    ]);
+    // The two ETH cards are told apart by their legs, in the toggle's name too.
+    expect(toggles()[0]).toHaveAccessibleName(/ETH short Hyperliquid \/ long Binance/);
+    expect(toggles()[2]).toHaveAccessibleName(/ETH short Hyperliquid \/ long Gate/);
+  });
+
+  it('still drops the pairs that price no APR or a loss', async () => {
+    server.use(
+      opportunitiesHandler(
+        makeOpportunitiesResult({
+          groups: [
+            makeOpportunityGroup({
+              pairs: [
+                venuePair(0.12, 'HYPERLIQUID', 'BINANCE'),
+                venuePair(null, 'HYPERLIQUID', 'GATE'),
+                venuePair(-0.03, 'BYBIT', 'GATE'),
+              ],
+            }),
+          ],
+        }),
+      ),
+    );
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(1));
+    expect(screen.getByText('12.0% APR')).toBeInTheDocument();
+  });
+});
+
+describe('OpportunitiesPanel → PairTicket prefill, runner-up pairs', () => {
+  it('arms the ticket with the legs of the card that was CLICKED, not the group best', async () => {
+    const calls: ActionInput[][] = [];
+    server.use(
+      ...baseHandlers(),
+      ...symbolHandlers([ETH_HYPERLIQUID, ETH_BINANCE, ETH_GATE]),
+      previewHandler(calls),
+      // One ETH cohort, two venue combinations: Binance at 12%, Gate at 4%.
+      opportunitiesHandler(
+        makeOpportunitiesResult({
+          groups: [
+            makeOpportunityGroup({
+              pairs: [
+                venuePair(0.12, 'HYPERLIQUID', 'BINANCE'),
+                venuePair(0.04, 'HYPERLIQUID', 'GATE'),
+              ],
+            }),
+          ],
+        }),
+      ),
+    );
+    renderWithClient(
+      <>
+        <OpportunitiesPanel />
+        <PairTicket />
+      </>,
+    );
+
+    await waitFor(() => expect(toggles()).toHaveLength(2));
+    // The RUNNER-UP — the card the old one-per-group list could not even show.
+    await userEvent.click(executeFor(/^Execute ETH short Hyperliquid \/ long Gate/));
+
+    await waitFor(() => expect(calls.at(-1)).toHaveLength(2), { timeout: 4000 });
+    const legs = calls.at(-1) as ActionInput[];
+    // Gate's legs, not the 12% Binance pair's.
+    expect(legs.map((a) => a.symbol).sort()).toEqual([
+      'GATE_FUTURE_ETH_USDT',
+      'HYPERLIQUID_FUTURE_ETH_USDC',
+    ]);
+    expect(legs.find((a) => a.symbol === 'GATE_FUTURE_ETH_USDT')).toMatchObject({ side: 'BUY' });
+    expect(legs.find((a) => a.symbol === 'HYPERLIQUID_FUTURE_ETH_USDC')).toMatchObject({
+      side: 'SELL',
+    });
+    expect(legs.some((a) => a.symbol === 'BINANCE_FUTURE_ETH_USDT')).toBe(false);
+  });
+});
+
+describe('OpportunitiesPanel — filters', () => {
+  it('narrows on an asset chip and restores on Clear filters', async () => {
+    server.use(opportunitiesHandler(multiPairResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    expect(screen.getByText('showing 3 of 3')).toBeInTheDocument();
+
+    await userEvent.click(chip(/^BTC 1$/));
+    await waitFor(() => expect(toggles()).toHaveLength(1));
+    expect(screen.getByText('8.0% APR')).toBeInTheDocument();
+    expect(screen.getByText('showing 1 of 3')).toBeInTheDocument();
+    expect(chip(/^BTC 1$/)).toHaveAttribute('aria-pressed', 'true');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+  });
+
+  it('matches a venue on either leg, and ORs two chips in one dimension', async () => {
+    server.use(opportunitiesHandler(multiPairResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    // Gate is the LONG leg of one ETH pair and of the BTC pair.
+    await userEvent.click(chip(/^Gate 2$/));
+    await waitFor(() => expect(toggles()).toHaveLength(2));
+
+    await userEvent.click(chip(/^Binance 1$/));
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+  });
+
+  it('counts each chip against the other filters, and deadens one that adds nothing', async () => {
+    server.use(opportunitiesHandler(multiPairResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    await userEvent.click(chip(/^ETH 2$/));
+
+    // Venue counts fall to what ETH leaves; Bybit trades no ETH, so its chip
+    // would add nothing and reads as a dead end. It stays in the tab order and
+    // keeps its tooltip — `aria-disabled`, not the native `disabled` that would
+    // hide the explanation from the people who need it.
+    await waitFor(() => expect(chip(/^Bybit 0$/)).toHaveAttribute('aria-disabled', 'true'));
+    expect(chip(/^Bybit 0$/)).toBeEnabled();
+    expect(chip(/^Bybit 0$/)).toHaveAttribute('title');
+    // Clicking it is inert rather than blocked by the browser.
+    await userEvent.click(chip(/^Bybit 0$/));
+    expect(toggles()).toHaveLength(2);
+    expect(chip(/^Hyperliquid 2$/)).toHaveAttribute('aria-disabled', 'false');
+    // The asset chips keep counting over every row — BTC still offers its 1.
+    expect(chip(/^BTC 1$/)).toHaveAttribute('aria-disabled', 'false');
+  });
+
+  it('applies the APR floor as a percent', async () => {
+    server.use(opportunitiesHandler(multiPairResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    await userEvent.type(screen.getByLabelText('Min APR'), '5');
+
+    await waitFor(() => expect(toggles()).toHaveLength(2));
+    expect(screen.queryByText('4.0% APR')).not.toBeInTheDocument();
+  });
+
+  it('offers no filter row for a dimension that cannot exclude anything', async () => {
+    server.use(opportunitiesHandler(makeOpportunitiesResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(1));
+    // A single card: its one asset and one maturity are obviously no choice —
+    // and neither are its TWO venue chips, since the card carries both legs, so
+    // picking either leaves exactly the card already on screen.
+    expect(screen.queryByText('Asset')).not.toBeInTheDocument();
+    expect(screen.queryByText('Matures')).not.toBeInTheDocument();
+    expect(screen.queryByText('Venue')).not.toBeInTheDocument();
+  });
+
+  it('keeps a selected chip listed and releasable after its rows leave the data', async () => {
+    server.use(opportunitiesHandler(multiPairResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    await userEvent.click(chip(/^BTC 1$/));
+    await waitFor(() => expect(toggles()).toHaveLength(1));
+
+    // The next response prices no BTC at all. The filter is still armed, so its
+    // chip has to survive at count 0 — otherwise the list stays narrowed with
+    // nothing on screen to explain it, and nothing to click to undo it.
+    server.use(
+      opportunitiesHandler(
+        makeOpportunitiesResult({
+          groups: [
+            makeOpportunityGroup({ pairs: [venuePair(0.12, 'HYPERLIQUID', 'BINANCE')] }),
+          ],
+        }),
+      ),
+    );
+    await userEvent.click(screen.getByTitle('Refetch strategy data'));
+
+    await waitFor(() => expect(chip(/^BTC 0$/)).toBeInTheDocument());
+    expect(chip(/^BTC 0$/)).toHaveAttribute('aria-pressed', 'true');
+    // Still releasable at count 0 — never deadened while selected.
+    expect(chip(/^BTC 0$/)).toHaveAttribute('aria-disabled', 'false');
+    await userEvent.click(chip(/^BTC 0$/));
+    await waitFor(() => expect(toggles()).toHaveLength(1));
+  });
+
+  it('filtered down to nothing blames the filters, not the assumptions', async () => {
+    server.use(opportunitiesHandler(multiPairResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    await userEvent.type(screen.getByLabelText('Min APR'), '99');
+
+    await waitFor(() =>
+      expect(screen.getByText('No opportunity matches these filters')).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('No fixed-return opportunities')).not.toBeInTheDocument();
+    // The bar survives, so the way out is still in reach.
+    expect(screen.getByText('showing 0 of 3')).toBeInTheDocument();
+
+    await userEvent.click(
+      within(screen.getByText('No opportunity matches these filters').parentElement!).getByRole(
+        'button',
+        { name: 'Clear filters' },
+      ),
+    );
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+  });
+
+  it('hides the bar entirely when the assumptions price nothing', async () => {
+    server.use(opportunitiesHandler(makeOpportunitiesResult({ groups: [] })));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() =>
+      expect(screen.getByText('No fixed-return opportunities')).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole('group', { name: 'Filter opportunities' })).not.toBeInTheDocument();
   });
 });

--- a/web/src/panels/OpportunitiesPanel.test.tsx
+++ b/web/src/panels/OpportunitiesPanel.test.tsx
@@ -31,6 +31,7 @@ import { env, server } from '../test/server';
 import { renderWithClient } from '../test/utils';
 import { PairTicket } from '../trade/PairTicket';
 import { OPPORTUNITIES_STORAGE_KEY, OpportunitiesPanel } from './OpportunitiesPanel';
+import { OPPORTUNITY_FILTERS_STORAGE_KEY } from './opportunityFilters';
 
 /** The blob v2 supersedes — seeded by hand in the migration tests. */
 const LEGACY_KEY = 'crossex.opportunities.v1';
@@ -1099,6 +1100,10 @@ const multiPairResult = () =>
 
 const chip = (name: RegExp) => screen.getByRole('button', { name });
 
+/** Venue, Matures and Min APR fold behind the filter icon — only Asset rides
+ * the bar's own line. */
+const openMoreFilters = () => userEvent.click(screen.getByRole('button', { name: /^Filters/ }));
+
 /** The Execute control of one card, named by its legs (every card's used to be
  * the bare "Execute it", which named none of them). */
 const executeFor = (name: RegExp) => screen.getByRole('button', { name });
@@ -1191,7 +1196,7 @@ describe('OpportunitiesPanel → PairTicket prefill, runner-up pairs', () => {
 });
 
 describe('OpportunitiesPanel — filters', () => {
-  it('narrows on an asset chip and restores on Clear filters', async () => {
+  it('releases an asset chip by clicking it again — no Clear needed on the bar', async () => {
     server.use(opportunitiesHandler(multiPairResult()));
     renderWithClient(<OpportunitiesPanel />);
 
@@ -1203,9 +1208,30 @@ describe('OpportunitiesPanel — filters', () => {
     expect(screen.getByText('8.0% APR')).toBeInTheDocument();
     expect(screen.getByText('showing 1 of 3')).toBeInTheDocument();
     expect(chip(/^BTC 1$/)).toHaveAttribute('aria-pressed', 'true');
+    // The bar's own line carries no Clear: every chip on it is its own undo.
+    expect(screen.queryByRole('button', { name: 'Clear filters' })).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    await userEvent.click(chip(/^BTC 1$/));
     await waitFor(() => expect(toggles()).toHaveLength(3));
+  });
+
+  it('offers the blanket Clear inside the popover, where the folded filters are', async () => {
+    server.use(opportunitiesHandler(multiPairResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    // Nothing armed: no Clear to offer, inside or out.
+    await openMoreFilters();
+    expect(screen.queryByRole('button', { name: 'Clear filters' })).not.toBeInTheDocument();
+
+    await userEvent.click(chip(/^Gate 2$/));
+    await waitFor(() => expect(toggles()).toHaveLength(2));
+
+    const popover = screen.getByRole('dialog');
+    await userEvent.click(within(popover).getByRole('button', { name: 'Clear filters' }));
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    // Clearing does not close the popover the reader is still working in.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
   it('matches a venue on either leg, and ORs two chips in one dimension', async () => {
@@ -1213,6 +1239,7 @@ describe('OpportunitiesPanel — filters', () => {
     renderWithClient(<OpportunitiesPanel />);
 
     await waitFor(() => expect(toggles()).toHaveLength(3));
+    await openMoreFilters();
     // Gate is the LONG leg of one ETH pair and of the BTC pair.
     await userEvent.click(chip(/^Gate 2$/));
     await waitFor(() => expect(toggles()).toHaveLength(2));
@@ -1226,7 +1253,9 @@ describe('OpportunitiesPanel — filters', () => {
     renderWithClient(<OpportunitiesPanel />);
 
     await waitFor(() => expect(toggles()).toHaveLength(3));
+    // Asset stays on the bar's line; the venue chips it re-counts do not.
     await userEvent.click(chip(/^ETH 2$/));
+    await openMoreFilters();
 
     // Venue counts fall to what ETH leaves; Bybit trades no ETH, so its chip
     // would add nothing and reads as a dead end. It stays in the tab order and
@@ -1243,15 +1272,18 @@ describe('OpportunitiesPanel — filters', () => {
     expect(chip(/^BTC 1$/)).toHaveAttribute('aria-disabled', 'false');
   });
 
-  it('applies the APR floor as a percent', async () => {
+  it('caps the tenor in days, keeping the card that prints exactly that number', async () => {
     server.use(opportunitiesHandler(multiPairResult()));
     renderWithClient(<OpportunitiesPanel />);
 
+    // Two 30-day ETH cards and one 90-day BTC card.
     await waitFor(() => expect(toggles()).toHaveLength(3));
-    await userEvent.type(screen.getByLabelText('Min APR'), '5');
+    await openMoreFilters();
+    await userEvent.type(screen.getByLabelText('Matures within'), '30');
 
+    // The 90-day cohort goes; "(30 days)" is inside a 30-day cap, not outside.
     await waitFor(() => expect(toggles()).toHaveLength(2));
-    expect(screen.queryByText('4.0% APR')).not.toBeInTheDocument();
+    expect(screen.queryByText('8.0% APR')).not.toBeInTheDocument();
   });
 
   it('offers no filter row for a dimension that cannot exclude anything', async () => {
@@ -1259,12 +1291,129 @@ describe('OpportunitiesPanel — filters', () => {
     renderWithClient(<OpportunitiesPanel />);
 
     await waitFor(() => expect(toggles()).toHaveLength(1));
-    // A single card: its one asset and one maturity are obviously no choice —
-    // and neither are its TWO venue chips, since the card carries both legs, so
-    // picking either leaves exactly the card already on screen.
+    // A single card: its one asset is obviously no choice.
     expect(screen.queryByText('Asset')).not.toBeInTheDocument();
+    // Nor, once unfolded, its one maturity — nor its TWO venue chips, since the
+    // card carries both legs, so picking either leaves what is already there.
+    await openMoreFilters();
     expect(screen.queryByText('Matures')).not.toBeInTheDocument();
     expect(screen.queryByText('Venue')).not.toBeInTheDocument();
+  });
+
+  it('opens the refinements in a popover, dismissed by Escape, ✕ or a click outside', async () => {
+    server.use(opportunitiesHandler(multiPairResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    const trigger = screen.getByRole('button', { name: 'Filters' });
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await openMoreFilters();
+    const popover = screen.getByRole('dialog', { name: /venue, maturity and APR/i });
+    expect(trigger).toHaveAttribute('aria-controls', popover.id);
+    expect(within(popover).getByText('Venue')).toBeInTheDocument();
+    expect(within(popover).getByLabelText('Matures within')).toBeInTheDocument();
+    // The APR floor is gone — the hero APR is what the list is already sorted
+    // by, so a second way to say "at least this much" earned nothing.
+    expect(within(popover).queryByLabelText('Min APR')).not.toBeInTheDocument();
+
+    // Escape hands the caret back to the icon that opened it.
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(trigger).toHaveFocus();
+
+    await openMoreFilters();
+    await userEvent.click(screen.getByRole('button', { name: 'dismiss' }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+    // The scrim behind it closes on a click anywhere outside.
+    await openMoreFilters();
+    await userEvent.click(document.querySelector('[role="presentation"]') as HTMLElement);
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it('restores last session\u2019s selection, and keeps it visible while it narrows', async () => {
+    localStorage.setItem(
+      OPPORTUNITY_FILTERS_STORAGE_KEY,
+      JSON.stringify({ assets: ['BTC'], venues: ['GATE'], maxDaysText: '' }),
+    );
+    server.use(opportunitiesHandler(multiPairResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    // Applied on the first render, not after a click.
+    await waitFor(() => expect(toggles()).toHaveLength(1));
+    expect(screen.getByText('showing 1 of 3')).toBeInTheDocument();
+    // And ANNOUNCED: the asset chip is pressed, and the folded venue filter is
+    // a count on the icon. A restored filter the reader cannot see reads as an
+    // empty market, which is the whole risk of persisting one.
+    expect(chip(/^BTC 1$/)).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Filters, 1 active' })).toBeInTheDocument();
+  });
+
+  it('keeps a restored selection releasable when today\u2019s data no longer has it', async () => {
+    // SOL priced yesterday; today it does not.
+    localStorage.setItem(
+      OPPORTUNITY_FILTERS_STORAGE_KEY,
+      JSON.stringify({ assets: ['SOL'], venues: [], maxDaysText: '' }),
+    );
+    server.use(opportunitiesHandler(multiPairResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() =>
+      expect(screen.getByText('No opportunity matches these filters')).toBeInTheDocument(),
+    );
+    // The chip survives at count 0 so the reader can see WHAT is hiding the
+    // list, and release it without the blanket Clear.
+    expect(chip(/^SOL 0$/)).toHaveAttribute('aria-pressed', 'true');
+    expect(chip(/^SOL 0$/)).toHaveAttribute('aria-disabled', 'false');
+
+    await userEvent.click(chip(/^SOL 0$/));
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+  });
+
+  it('persists a change so the next mount opens with it', async () => {
+    server.use(opportunitiesHandler(multiPairResult()));
+    const { unmount } = renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    await userEvent.click(chip(/^BTC 1$/));
+    await waitFor(() => expect(toggles()).toHaveLength(1));
+    unmount();
+
+    renderWithClient(<OpportunitiesPanel />);
+    await waitFor(() => expect(toggles()).toHaveLength(1));
+    expect(chip(/^BTC 1$/)).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('badges the icon when a folded refinement is armed, and unbadges on Clear', async () => {
+    server.use(opportunitiesHandler(multiPairResult()));
+    renderWithClient(<OpportunitiesPanel />);
+
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    // Nothing armed behind the fold: the icon carries no count.
+    expect(screen.getByRole('button', { name: 'Filters' })).toBeInTheDocument();
+
+    await openMoreFilters();
+    await userEvent.click(chip(/^Gate 2$/));
+    await waitFor(() => expect(toggles()).toHaveLength(2));
+
+    // Toggling a chip must not close the popover — a reader refining by venue
+    // is usually picking more than one.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Folded away, the armed venue filter must still be visible AS a count —
+    // otherwise the list is narrowed for no reason the reader can see.
+    await userEvent.click(screen.getByRole('button', { name: 'dismiss' }));
+    expect(screen.queryByText('Venue')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Filters, 1 active' })).toBeInTheDocument();
+
+    await openMoreFilters();
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', { name: 'Clear filters' }),
+    );
+    await waitFor(() => expect(toggles()).toHaveLength(3));
+    expect(screen.getByRole('button', { name: 'Filters' })).toBeInTheDocument();
   });
 
   it('keeps a selected chip listed and releasable after its rows leave the data', async () => {
@@ -1302,7 +1451,8 @@ describe('OpportunitiesPanel — filters', () => {
     renderWithClient(<OpportunitiesPanel />);
 
     await waitFor(() => expect(toggles()).toHaveLength(3));
-    await userEvent.type(screen.getByLabelText('Min APR'), '99');
+    await openMoreFilters();
+    await userEvent.type(screen.getByLabelText('Matures within'), '1');
 
     await waitFor(() =>
       expect(screen.getByText('No opportunity matches these filters')).toBeInTheDocument(),
@@ -1312,10 +1462,8 @@ describe('OpportunitiesPanel — filters', () => {
     expect(screen.getByText('showing 0 of 3')).toBeInTheDocument();
 
     await userEvent.click(
-      within(screen.getByText('No opportunity matches these filters').parentElement!).getByRole(
-        'button',
-        { name: 'Clear filters' },
-      ),
+      within(screen.getByText('No opportunity matches these filters').parentElement as HTMLElement)
+        .getByRole('button', { name: 'Clear filters' }),
     );
     await waitFor(() => expect(toggles()).toHaveLength(3));
   });

--- a/web/src/panels/OpportunitiesPanel.tsx
+++ b/web/src/panels/OpportunitiesPanel.tsx
@@ -68,7 +68,9 @@ import { canChartCapital, canChartProfit, OpportunityWaterfall } from './Opportu
 import {
   applyFilters,
   hasActiveFilter,
+  loadFilters,
   NO_FILTERS,
+  saveFilters,
   toRows,
   type OpportunityFilters,
 } from './opportunityFilters';
@@ -762,10 +764,16 @@ export function OpportunitiesPanel({ unconfigured = false }: { unconfigured?: bo
   const debouncedSize = useDebounced(sizeStr, 400);
   // Deliberately NOT persisted: the strip explains itself once and folds away.
   const [assumptionsOpen, setAssumptionsOpen] = useState(false);
-  // Also deliberately NOT persisted — unlike the assumptions, a filter changes
-  // WHAT IS MISSING from the list, and a hidden one carried over from last week
-  // would read as "there are no BTC opportunities".
-  const [filters, setFilters] = useState<OpportunityFilters>(NO_FILTERS);
+  // Persisted, like the assumptions. A filter is the louder of the two — it
+  // changes what is MISSING rather than how it is priced — so restoring one
+  // leans on the affordances that keep it visible: the ✓ on a selected asset
+  // chip, the count on the filter icon, and a selected value that still renders
+  // at count 0 when the data no longer has it. See `loadFilters`.
+  const [filters, setFilters] = useState<OpportunityFilters>(loadFilters);
+  const updateFilters = useCallback((next: OpportunityFilters) => {
+    setFilters(next);
+    saveFilters(next);
+  }, []);
   const shownKeysRef = useRef<ReadonlySet<string>>(new Set());
   const flow = useTradeFlowOptional();
   const sizeId = useId();
@@ -1051,7 +1059,7 @@ export function OpportunitiesPanel({ unconfigured = false }: { unconfigured?: bo
         <OpportunityFilterBar
           rows={rows}
           filters={filters}
-          onChange={setFilters}
+          onChange={updateFilters}
           shown={visible.length}
         />
       )}
@@ -1073,7 +1081,7 @@ export function OpportunitiesPanel({ unconfigured = false }: { unconfigured?: bo
           hint={`All ${rows.length} priced ${rows.length === 1 ? 'opportunity is' : 'opportunities are'} filtered out. Drop a filter to bring them back.`}
           action={
             hasActiveFilter(filters) ? (
-              <button type="button" className="btn" onClick={() => setFilters(NO_FILTERS)}>
+              <button type="button" className="btn" onClick={() => updateFilters(NO_FILTERS)}>
                 Clear filters
               </button>
             ) : undefined

--- a/web/src/panels/OpportunitiesPanel.tsx
+++ b/web/src/panels/OpportunitiesPanel.tsx
@@ -1,9 +1,11 @@
 /**
- * Forward-looking fixed-return opportunities — one collapsible card per Boros
- * arb group, in the server's ranking (never re-sorted here).
- *   Collapsed — the net fixed APR ON CAPITAL as the hero (the Positions view's
- *               basis), the capital / return / notional line, the asset and its
- *               two venue legs, warning chips, Details + Execute.
+ * Forward-looking fixed-return opportunities — one collapsible card per viable
+ * Boros PAIR (a group with three markets offers three of them), best APR first,
+ * narrowed by the facet bar above the list.
+ *   Collapsed — an identity band (asset, the two venue legs, warning chips)
+ *               over the net fixed APR ON CAPITAL as the hero (the Positions
+ *               view's basis) beside labelled capital / return / notional
+ *               stats, Details + Execute.
  *   Expanded  — the four legs the trade opens, the spread it locks, and the
  *               profit + capital waterfalls.
  * Owns the persisted assumptions — notional, Boros entry, perp entry, exit and
@@ -11,7 +13,17 @@
  * drive. Executing only PREFILLS the pair ticket — submission stays behind its
  * hold-to-confirm control.
  */
-import { useEffect, useId, useState, type MouseEvent, type ReactNode } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent,
+  type ReactNode,
+} from 'react';
 import { amountError } from '../lib/amount';
 import {
   isValidOpportunityNotional,
@@ -37,12 +49,29 @@ import { Skeleton } from '../components/Skeleton';
 import { microLabelClass } from '../components/Th';
 import { SideVenue } from '../components/VenueChip';
 import { borosMarketUrl } from '../lib/boros';
-import { fmtAge, fmtDateUtc, fmtNotionalShort, fmtPct, fmtTokenQty, fmtUsd, sig } from '../lib/fmt';
+import {
+  fmtAge,
+  fmtDateUtc,
+  fmtNotionalShort,
+  fmtPct,
+  fmtTokenQty,
+  fmtUsd,
+  prettyVenue,
+  sig,
+} from '../lib/fmt';
 import { readJson, writeJson } from '../lib/storage';
 import { useDebounced } from '../lib/useDebounced';
 import { useTradeFlowOptional } from '../trade/TradeFlow';
 import { StrategyFreshness } from './HomeControls';
+import { OpportunityFilterBar } from './OpportunityFilterBar';
 import { canChartCapital, canChartProfit, OpportunityWaterfall } from './OpportunityWaterfall';
+import {
+  applyFilters,
+  hasActiveFilter,
+  NO_FILTERS,
+  toRows,
+  type OpportunityFilters,
+} from './opportunityFilters';
 
 export const OPPORTUNITIES_STORAGE_KEY = 'crossex.opportunities.v2';
 
@@ -213,11 +242,29 @@ export function loadControls(base: StoredControls = DEFAULTS): StoredControls {
   });
 }
 
+/** The value when it is a real number, else null. Covers a key that is ABSENT
+ * as well as one that is explicitly null: the API response is cast, not
+ * validated, and `fmtUsd(undefined)` prints the literal string "undefined". */
+const finite = (v: number | null | undefined): number | null =>
+  typeof v === 'number' && Number.isFinite(v) ? v : null;
+
 /** Missing number → an em dash carrying the reason, never "NaN". */
 function Dash({ why }: { why: string }) {
   return (
     <span className="num text-ink-500" title={why}>
       —
+    </span>
+  );
+}
+
+/** One labelled figure of the collapsed card's stat row. Label over value puts
+ * every card's CAPITAL / RETURN / NOTIONAL at the same x, so a column of cards
+ * reads as a table — the inline sentence it replaces couldn't line up. */
+function Stat({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <span className="flex flex-col gap-1">
+      <span className={microLabelClass}>{label}</span>
+      <span className="num text-sm leading-none text-ink-100">{children}</span>
     </span>
   );
 }
@@ -238,16 +285,8 @@ const THIN_BOOK_WHY = "The Boros books can't lock this size — no net APR is qu
  * The server's warnings are full prose sentences, not codes — they read as the
  * notes they are, in the hero's title, never squeezed into an inline badge.
  */
-function cardChips(pair: OpportunityPair | null): CardChip[] {
+function cardChips(pair: OpportunityPair): CardChip[] {
   const chips: CardChip[] = [];
-  if (!pair) {
-    chips.push({
-      key: 'no-pair',
-      label: 'no pairable legs',
-      title: 'No two markets in this group can carry a perp leg on CrossEx',
-    });
-    return chips;
-  }
   if (pair.execSpreadApr === null) {
     chips.push({ key: 'thin', label: 'thin book', title: THIN_BOOK_WHY });
   }
@@ -342,13 +381,18 @@ function LegRow({
   );
 }
 
-function OpportunityCard({
+const OpportunityCard = memo(function OpportunityCard({
   group,
+  pair,
   notionalUsd,
   onExecute,
   unconfigured,
 }: {
+  /** The cohort the pair belongs to — collateral, maturity, underlying. */
   group: OpportunityGroup;
+  /** THE trade this card is about. One group serves several: every viable venue
+   * combination in it is its own card. */
+  pair: OpportunityPair;
   /** The notional the RESPONSE priced — the waterfall converts APRs with it. */
   notionalUsd: number;
   /** null when there is no trade-flow provider — the button then explains itself. */
@@ -358,15 +402,16 @@ function OpportunityCard({
   unconfigured: boolean;
 }) {
   const [open, setOpen] = useState(false);
-  const pair = group.bestPair ?? group.pairs[0] ?? null;
   const chips = cardChips(pair);
   // Only the PAIR's own reasons — they explain this card's own numbers. The
   // group's warnings are about the other markets in the cohort ("… has no
   // CrossEx perp venue"), and those rows stopped being displayed with the
   // markets table.
-  const reasons = [...new Set(pair?.reasons ?? [])];
-  const base = pair?.base || group.underlying;
-  const capitalApr = pair?.netFixedAprOnCapital ?? null;
+  const reasons = [...new Set(pair.reasons)];
+  const base = pair.base || group.underlying;
+  const capitalApr = pair.netFixedAprOnCapital;
+  const capitalUsd = finite(pair.capitalUsd);
+  const estProfitUsd = finite(pair.estProfitUsd);
   // A resting maker leg or an extrapolated book still prices a number, so these
   // caveats have no dash to hang off — without a chip they would be invisible.
   if (capitalApr !== null && reasons.length > 0) {
@@ -387,28 +432,22 @@ function OpportunityCard({
   // Both legs unmapped ⇒ the ticket would arm nothing; one missing is fine (it
   // leaves that leg unselected by design). Fungible groups can collapse two
   // different assets, and the ticket only takes one base.
-  const basesDiffer = pair !== null && pair.shortLeg.base !== pair.longLeg.base;
-  const noSymbols = pair !== null && !pair.shortLeg.crossexSymbol && !pair.longLeg.crossexSymbol;
-  const executeDisabled =
-    pair === null || (noSymbols && !unconfigured) || basesDiffer || onExecute === null;
-  const executeTitle =
-    pair === null
-      ? 'No pairable legs in this group'
-      : basesDiffer
-        ? `The legs trade different assets (${pair.shortLeg.base} vs ${pair.longLeg.base}) — the pair ticket takes one base`
-        : unconfigured
-          ? 'Add your Gate API key in the setup guide on the right — clicking stages this pair for the ticket'
-          : noSymbols
-            ? `Neither ${pair.shortLeg.venue} nor ${pair.longLeg.venue} lists a CrossEx perp for ${pair.base}`
-            : 'Prefills the pair ticket with these perp legs — you still confirm the order there';
+  const basesDiffer = pair.shortLeg.base !== pair.longLeg.base;
+  const noSymbols = !pair.shortLeg.crossexSymbol && !pair.longLeg.crossexSymbol;
+  const executeDisabled = (noSymbols && !unconfigured) || basesDiffer || onExecute === null;
+  const executeTitle = basesDiffer
+    ? `The legs trade different assets (${pair.shortLeg.base} vs ${pair.longLeg.base}) — the pair ticket takes one base`
+    : unconfigured
+      ? 'Add your Gate API key in the setup guide on the right — clicking stages this pair for the ticket'
+      : noSymbols
+        ? `Neither ${pair.shortLeg.venue} nor ${pair.longLeg.venue} lists a CrossEx perp for ${pair.base}`
+        : 'Prefills the pair ticket with these perp legs — you still confirm the order there';
   const detailsDisabled =
-    pair === null || (!canChartProfit(pair) && !canChartCapital(pair) && pair.execSpreadApr === null);
+    !canChartProfit(pair) && !canChartCapital(pair) && pair.execSpreadApr === null;
   const detailsTitle = detailsDisabled
-    ? pair === null
-      ? 'No pairable legs in this group'
-      : 'This pair prices neither a spread nor a capital stack — there is nothing to break down'
+    ? 'This pair prices neither a spread nor a capital stack — there is nothing to break down'
     : undefined;
-  const chartable = pair !== null && (canChartProfit(pair) || canChartCapital(pair));
+  const chartable = canChartProfit(pair) || canChartCapital(pair);
 
   // The whole card toggles the details, not just the Details button — but never
   // when the click was really for a control inside it, or was a text selection
@@ -423,260 +462,277 @@ function OpportunityCard({
 
   return (
     <div
-      className={`card p-4 ${detailsDisabled ? '' : 'cursor-pointer'}`}
+      // overflow-hidden lets the identity band's darker ground clip cleanly at
+      // the card's rounded corners.
+      className={`card overflow-hidden ${detailsDisabled ? '' : 'cursor-pointer transition-colors hover:border-ink-600'}`}
       onClick={toggleFromCard}
     >
-      {/* Stacked on phones: the shrink-0 button group is 184px, which left the
-          APR hero and the capital line ~112px to fight over and spilling. */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-5">
-        <div className="flex min-w-0 flex-1 flex-col gap-2">
-          <div className="flex flex-wrap items-baseline gap-2">
-            {capitalApr === null || !Number.isFinite(capitalApr) ? (
-              <span
-                className="num text-3xl font-bold leading-none tracking-tight text-ink-400"
-                title={reasons.length > 0 ? reasons.join('\n') : CAPITAL_WHY}
-              >
-                —% APR
-              </span>
-            ) : (
-              <span
-                className={`num text-3xl font-bold leading-none tracking-tight ${
-                  capitalApr < 0 ? 'text-rose-400' : 'text-emerald-400'
-                }`}
-                title={
-                  reasons.length > 0
-                    ? `${CAPITAL_APR_TITLE}\n\n${reasons.join('\n')}`
-                    : CAPITAL_APR_TITLE
-                }
-              >
-                {(capitalApr * 100).toFixed(1)}% APR
-              </span>
-            )}
-            <span className="text-[13px] text-ink-300" title={maturityTitle}>
-              ({days} {days === 1 ? 'day' : 'days'})
-            </span>
+      {/* Identity band — WHAT the trade is, before how much it pays: ticker,
+          the two legs, warnings pushed right. Its darker ground and hairline
+          give the list a ledger rhythm and keep warnings out of the hero's
+          way. */}
+      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5 border-b border-ink-800 bg-ink-950/40 px-4 py-2">
+        <span
+          className="num text-[13px] font-semibold tracking-wide text-ink-100"
+          title={`${base} funding rate`}
+        >
+          {base}
+        </span>
+        <SideVenue side="SHORT" venue={pair.shortLeg.venue} />
+        <SideVenue side="LONG" venue={pair.longLeg.venue} />
+        {chips.length > 0 && (
+          <span className="ml-auto flex flex-wrap items-center gap-1.5">
             {chips.map((c) => (
               <Chip key={c.key} sm tone={c.tone ?? 'amber'} title={c.title}>
                 {c.label}
               </Chip>
             ))}
-          </div>
+          </span>
+        )}
+      </div>
 
-          <div className="num flex flex-wrap items-baseline gap-1.5 text-[13px]">
-            <span className="text-ink-400">Capital</span>
-            {pair?.capitalUsd === undefined || pair.capitalUsd === null ? (
-              <Dash why={CAPITAL_WHY} />
-            ) : (
-              <span
-                className="text-ink-100"
-                title="The modelled minimum this trade posts across the four legs — expand for the breakdown"
-              >
-                ~{fmtUsd(pair.capitalUsd, 0)}
-              </span>
-            )}
-            <span className="px-1 text-ink-500">·</span>
-            <span className="text-ink-400">Return</span>
-            {pair?.estProfitUsd === undefined || pair.estProfitUsd === null ? (
-              <Dash why="No net APR — nothing to project" />
-            ) : (
-              <span
-                className={pair.estProfitUsd < 0 ? 'text-rose-400' : 'text-ink-100'}
-                title={`Estimated profit by maturity on ${fmtUsd(notionalUsd, 0)} per leg`}
-              >
-                {fmtUsd(pair.estProfitUsd, 0)}
-              </span>
-            )}
-            <span className="px-1 text-ink-500">·</span>
-            <span className="text-ink-400">Notional</span>
-            <span
-              className="text-cyan-400/85"
-              title={`${fmtUsd(notionalUsd, 0)} per leg${collateralQty ? ` ≈ ${sig(collateralQty.qty)} ${collateralQty.symbol}` : ''}`}
-            >
-              {fmtNotionalShort(notionalUsd)}
-              {collateralQty && (
-                <span className="text-cyan-400/60">
-                  {' '}
-                  ({fmtTokenQty(collateralQty.qty, collateralQty.symbol)})
+      <div className="p-4">
+        {/* Stacked on phones: the shrink-0 button group is 184px, which left
+            the APR hero and the stat row ~112px to fight over and spilling. */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between sm:gap-5">
+          {/* Hero + stats share one baseline (items-end): the APR leads, the
+              labelled figures columnize across cards. */}
+          <div className="flex min-w-0 flex-wrap items-end gap-x-7 gap-y-3">
+            {/* basis-full below xl: the hero takes its own row and the stats a
+                second one, so every card keeps the same shape at the same
+                viewport. The switch must hang on the VIEWPORT, never on fit:
+                token-margined groups render "$10k (4.16 ETH)" where USDT ones
+                render "$10k", and a fit-driven wrap would break only those
+                cards, un-aligning the list. xl is where the content column
+                (viewport less ~400px of rail chrome) fits hero + stats + the
+                buttons on one line even with the token bracket — the same
+                geometry that gates the expanded section's two-column grid. The
+                xl min-width then starts every card's stat columns at the same
+                x, however wide its APR. */}
+            <span className="flex basis-full items-baseline gap-2 xl:basis-auto xl:min-w-[15rem]">
+              {capitalApr === null || !Number.isFinite(capitalApr) ? (
+                <span
+                  className="num text-3xl font-bold leading-none tracking-tight text-ink-400"
+                  title={reasons.length > 0 ? reasons.join('\n') : CAPITAL_WHY}
+                >
+                  —% APR
+                </span>
+              ) : (
+                <span
+                  className={`num text-3xl font-bold leading-none tracking-tight ${
+                    capitalApr < 0 ? 'text-rose-400' : 'text-emerald-400'
+                  }`}
+                  title={
+                    reasons.length > 0
+                      ? `${CAPITAL_APR_TITLE}\n\n${reasons.join('\n')}`
+                      : CAPITAL_APR_TITLE
+                  }
+                >
+                  {(capitalApr * 100).toFixed(1)}% APR
                 </span>
               )}
+              <span className="text-[13px] text-ink-300" title={maturityTitle}>
+                ({days} {days === 1 ? 'day' : 'days'})
+              </span>
             </span>
+
+            <Stat label="Capital">
+              {capitalUsd === null ? (
+                <Dash why={CAPITAL_WHY} />
+              ) : (
+                <span title="The modelled minimum this trade posts across the four legs — expand for the breakdown">
+                  ~{fmtUsd(capitalUsd, 0)}
+                </span>
+              )}
+            </Stat>
+            <Stat label="Return">
+              {estProfitUsd === null ? (
+                <Dash why="No net APR — nothing to project" />
+              ) : (
+                <span
+                  className={estProfitUsd < 0 ? 'text-rose-400' : undefined}
+                  title={`Estimated profit by maturity on ${fmtUsd(notionalUsd, 0)} per leg`}
+                >
+                  {fmtUsd(estProfitUsd, 0)}
+                </span>
+              )}
+            </Stat>
+            <Stat label="Notional">
+              <span
+                className="text-cyan-400/85"
+                title={`${fmtUsd(notionalUsd, 0)} per leg${collateralQty ? ` ≈ ${sig(collateralQty.qty)} ${collateralQty.symbol}` : ''}`}
+              >
+                {fmtNotionalShort(notionalUsd)}
+                {collateralQty && (
+                  <span className="text-cyan-400/60">
+                    {' '}
+                    ({fmtTokenQty(collateralQty.qty, collateralQty.symbol)})
+                  </span>
+                )}
+              </span>
+            </Stat>
             {/* The net story needs fees/books/leverage; when those are missing
                 (Gate down or unconfigured) the raw Boros spread is still the
                 headline worth showing — it is what the trade captures. */}
-            {pair && pair.netFixedApr === null && Number.isFinite(pair.grossSpreadApr) && (
-              <>
-                <span className="px-1 text-ink-500">·</span>
-                <span className="text-ink-400">Gross spread</span>
+            {pair.netFixedApr === null && Number.isFinite(pair.grossSpreadApr) && (
+              <Stat label="Gross spread">
                 <span
                   className="text-amber-400"
                   title="midApr(short) − midApr(long) — the raw Boros spread, before execution and costs"
                 >
                   {fmtPct(pair.grossSpreadApr, 1)}
-                </span>
-                <span className="text-ink-400">only</span>
+                </span>{' '}
+                <span className="text-[10px] text-amber-400/80">only</span>
+              </Stat>
+            )}
+          </div>
+
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              type="button"
+              className="btn-ghost"
+              aria-expanded={open}
+              aria-label={`${open ? 'Hide' : 'Show'} details for ${base} short ${prettyVenue(pair.shortLeg.venue)} / long ${prettyVenue(pair.longLeg.venue)}, ${group.collateral}-margined ${fmtDateUtc(group.maturity)}`}
+              disabled={detailsDisabled}
+              title={detailsTitle}
+              onClick={() => setOpen((v) => !v)}
+            >
+              {open ? 'Hide details' : 'Details'}
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary px-4 font-semibold"
+              // Many cards per cohort now differ only by their legs, so the
+              // bare "Execute it" no longer identifies which trade is being
+              // staged — same identity the Details button carries.
+              aria-label={`Execute ${base} short ${prettyVenue(pair.shortLeg.venue)} / long ${prettyVenue(pair.longLeg.venue)}, ${group.collateral}-margined ${fmtDateUtc(group.maturity)}`}
+              disabled={executeDisabled}
+              title={executeTitle}
+              onClick={() => onExecute?.(pair)}
+            >
+              Execute it
+            </button>
+          </div>
+        </div>
+
+        {open && (
+          // Clicks inside the expanded breakdown must not collapse it — closing
+          // is the header's or the Hide-details button's job.
+          <div
+            className="mt-4 flex cursor-auto flex-col gap-3.5 border-t border-ink-800 pt-4 text-xs"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className={microLabelClass}>How it works — you open 4 legs</div>
+            {/* Two columns only from xl: the content column is the viewport less
+                ~400px of chrome (page padding + the 340px trade rail), so at md
+                each leg box would be ~175px and the rows below would overflow. */}
+            <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
+              <div className="flex min-w-0 flex-col gap-2 rounded-lg border border-ink-700 bg-ink-950 p-3">
+                <div className="text-[11px] font-semibold uppercase tracking-wider text-ink-300">
+                  On CrossEx{' '}
+                  <span className="font-normal normal-case tracking-normal text-ink-400">
+                    (perp legs)
+                  </span>
+                </div>
+                <div className="flex flex-col gap-2 sm:grid sm:grid-cols-[max-content_max-content_max-content_minmax(0,1fr)] sm:items-center sm:gap-x-2.5 sm:gap-y-1.5">
+                  <LegRow
+                    notionalUsd={notionalUsd}
+                    collateral={collateralQty}
+                    side="short"
+                    label={`Short ${base}`}
+                    venue={pair.shortLeg.crossexVenue || pair.shortLeg.venue}
+                    note={
+                      pair.capital.shortLeverageMax === null
+                        ? ''
+                        : `up to ${pair.capital.shortLeverageMax}× leverage`
+                    }
+                  />
+                  <LegRow
+                    notionalUsd={notionalUsd}
+                    collateral={collateralQty}
+                    side="long"
+                    label={`Long ${base}`}
+                    venue={pair.longLeg.crossexVenue || pair.longLeg.venue}
+                    note={
+                      pair.capital.longLeverageMax === null
+                        ? ''
+                        : `up to ${pair.capital.longLeverageMax}× leverage`
+                    }
+                  />
+                </div>
+                <div className="text-[11px] leading-relaxed text-ink-300">
+                  The terminal opens both legs delta-neutral in one cross-margin account — minimal
+                  liquidation risk.
+                </div>
+              </div>
+  
+              <div className="flex min-w-0 flex-col gap-2 rounded-lg border border-ink-700 bg-ink-950 p-3">
+                <div className="text-[11px] font-semibold uppercase tracking-wider text-ink-300">
+                  On Boros{' '}
+                  <span className="font-normal normal-case tracking-normal text-ink-400">
+                    (rate legs)
+                  </span>
+                </div>
+                <div className="flex flex-col gap-2 sm:grid sm:grid-cols-[max-content_max-content_max-content_minmax(0,1fr)] sm:items-center sm:gap-x-2.5 sm:gap-y-1.5">
+                  <LegRow
+                    notionalUsd={notionalUsd}
+                    collateral={collateralQty}
+                    side="short"
+                    label={`Short ${base} funding`}
+                    venue={pair.shortLeg.venue}
+                    note={<RateNote midApr={pair.shortLeg.midApr} execApr={pair.shortLeg.execApr} />}
+                    href={borosMarketUrl(pair.shortLeg.marketId, 'short')}
+                  />
+                  <LegRow
+                    notionalUsd={notionalUsd}
+                    collateral={collateralQty}
+                    side="long"
+                    label={`Long ${base} funding`}
+                    venue={pair.longLeg.venue}
+                    note={<RateNote midApr={pair.longLeg.midApr} execApr={pair.longLeg.execApr} />}
+                    href={borosMarketUrl(pair.longLeg.marketId, 'long')}
+                  />
+                </div>
+              </div>
+            </div>
+  
+            {pair.execSpreadApr !== null &&
+              pair.netFixedAprOnCapital !== null &&
+              pair.capitalUsd !== null && (
+                <div
+                  className={`rounded-lg border px-3.5 py-2.5 text-[12.5px] leading-relaxed text-ink-100 ${
+                    netNegative
+                      ? 'border-rose-500/20 bg-rose-500/5'
+                      : 'border-emerald-500/20 bg-emerald-500/5'
+                  }`}
+                >
+                  <span
+                    className={`${microLabelClass} mr-2 ${netNegative ? '!text-rose-400' : '!text-emerald-400'}`}
+                  >
+                    Net effect
+                  </span>
+                  Locks a <span className={`num ${netTone}`}>{fmtPct(pair.execSpreadApr, 1)}</span>{' '}
+                  funding spread → After leverage:{' '}
+                  <span className={`num font-semibold ${netTone}`}>
+                    {(pair.netFixedAprOnCapital * 100).toFixed(1)}% APR
+                  </span>{' '}
+                  on <span className={`num ${netTone}`}>{fmtNotionalShort(pair.capitalUsd)}</span>{' '}
+                  capital
+                </div>
+              )}
+  
+            {chartable && (
+              <>
+                <div className={microLabelClass}>PnL &amp; capital breakdown</div>
+                <OpportunityWaterfall pair={pair} notionalUsd={notionalUsd} />
               </>
             )}
           </div>
-
-          <div className="flex flex-wrap items-center gap-2.5">
-            <span
-              className="num flex h-6 w-6 items-center justify-center rounded-md border border-ink-700 bg-ink-800 text-[9px] font-semibold leading-none text-ink-300"
-              title={`${base} funding rate`}
-            >
-              {base}
-            </span>
-            {pair ? (
-              <span className="flex flex-col gap-0.5">
-                <SideVenue side="SHORT" venue={pair.shortLeg.venue} />
-                <SideVenue side="LONG" venue={pair.longLeg.venue} />
-              </span>
-            ) : (
-              <span className="text-xs text-ink-500">no pairable legs</span>
-            )}
-          </div>
-        </div>
-
-        <div className="flex shrink-0 items-start gap-2">
-          <button
-            type="button"
-            className="btn-ghost"
-            aria-expanded={open}
-            aria-label={`${open ? 'Hide' : 'Show'} details for ${group.underlying} ${group.collateral}-margined ${fmtDateUtc(group.maturity)}`}
-            disabled={detailsDisabled}
-            title={detailsTitle}
-            onClick={() => setOpen((v) => !v)}
-          >
-            {open ? 'Hide details' : 'Details'}
-          </button>
-          <button
-            type="button"
-            className="btn btn-primary px-4 font-semibold"
-            disabled={executeDisabled}
-            title={executeTitle}
-            onClick={() => pair && onExecute?.(pair)}
-          >
-            Execute it
-          </button>
-        </div>
+        )}
       </div>
-
-      {open && pair && (
-        // Clicks inside the expanded breakdown must not collapse it — closing is
-        // the header's or the Hide-details button's job.
-        <div
-          className="mt-4 flex cursor-auto flex-col gap-3.5 border-t border-ink-800 pt-4 text-xs"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <div className={microLabelClass}>How it works — you open 4 legs</div>
-          {/* Two columns only from xl: the content column is the viewport less
-              ~400px of chrome (page padding + the 340px trade rail), so at md
-              each leg box would be ~175px and the rows below would overflow. */}
-          <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
-            <div className="flex min-w-0 flex-col gap-2 rounded-lg border border-ink-700 bg-ink-950 p-3">
-              <div className="text-[11px] font-semibold uppercase tracking-wider text-ink-300">
-                On CrossEx{' '}
-                <span className="font-normal normal-case tracking-normal text-ink-400">
-                  (perp legs)
-                </span>
-              </div>
-              <div className="flex flex-col gap-2 sm:grid sm:grid-cols-[max-content_max-content_max-content_minmax(0,1fr)] sm:items-center sm:gap-x-2.5 sm:gap-y-1.5">
-                <LegRow
-                  notionalUsd={notionalUsd}
-                  collateral={collateralQty}
-                  side="short"
-                  label={`Short ${base}`}
-                  venue={pair.shortLeg.crossexVenue || pair.shortLeg.venue}
-                  note={
-                    pair.capital.shortLeverageMax === null
-                      ? ''
-                      : `up to ${pair.capital.shortLeverageMax}× leverage`
-                  }
-                />
-                <LegRow
-                  notionalUsd={notionalUsd}
-                  collateral={collateralQty}
-                  side="long"
-                  label={`Long ${base}`}
-                  venue={pair.longLeg.crossexVenue || pair.longLeg.venue}
-                  note={
-                    pair.capital.longLeverageMax === null
-                      ? ''
-                      : `up to ${pair.capital.longLeverageMax}× leverage`
-                  }
-                />
-              </div>
-              <div className="text-[11px] leading-relaxed text-ink-300">
-                The terminal opens both legs delta-neutral in one cross-margin account — minimal
-                liquidation risk.
-              </div>
-            </div>
-
-            <div className="flex min-w-0 flex-col gap-2 rounded-lg border border-ink-700 bg-ink-950 p-3">
-              <div className="text-[11px] font-semibold uppercase tracking-wider text-ink-300">
-                On Boros{' '}
-                <span className="font-normal normal-case tracking-normal text-ink-400">
-                  (rate legs)
-                </span>
-              </div>
-              <div className="flex flex-col gap-2 sm:grid sm:grid-cols-[max-content_max-content_max-content_minmax(0,1fr)] sm:items-center sm:gap-x-2.5 sm:gap-y-1.5">
-                <LegRow
-                  notionalUsd={notionalUsd}
-                  collateral={collateralQty}
-                  side="short"
-                  label={`Short ${base} funding`}
-                  venue={pair.shortLeg.venue}
-                  note={<RateNote midApr={pair.shortLeg.midApr} execApr={pair.shortLeg.execApr} />}
-                  href={borosMarketUrl(pair.shortLeg.marketId, 'short')}
-                />
-                <LegRow
-                  notionalUsd={notionalUsd}
-                  collateral={collateralQty}
-                  side="long"
-                  label={`Long ${base} funding`}
-                  venue={pair.longLeg.venue}
-                  note={<RateNote midApr={pair.longLeg.midApr} execApr={pair.longLeg.execApr} />}
-                  href={borosMarketUrl(pair.longLeg.marketId, 'long')}
-                />
-              </div>
-            </div>
-          </div>
-
-          {pair.execSpreadApr !== null &&
-            pair.netFixedAprOnCapital !== null &&
-            pair.capitalUsd !== null && (
-              <div
-                className={`rounded-lg border px-3.5 py-2.5 text-[12.5px] leading-relaxed text-ink-100 ${
-                  netNegative
-                    ? 'border-rose-500/20 bg-rose-500/5'
-                    : 'border-emerald-500/20 bg-emerald-500/5'
-                }`}
-              >
-                <span
-                  className={`${microLabelClass} mr-2 ${netNegative ? '!text-rose-400' : '!text-emerald-400'}`}
-                >
-                  Net effect
-                </span>
-                Locks a <span className={`num ${netTone}`}>{fmtPct(pair.execSpreadApr, 1)}</span>{' '}
-                funding spread → After leverage:{' '}
-                <span className={`num font-semibold ${netTone}`}>
-                  {(pair.netFixedAprOnCapital * 100).toFixed(1)}% APR
-                </span>{' '}
-                on <span className={`num ${netTone}`}>{fmtNotionalShort(pair.capitalUsd)}</span>{' '}
-                capital
-              </div>
-            )}
-
-          {chartable && (
-            <>
-              <div className={microLabelClass}>PnL &amp; capital breakdown</div>
-              <OpportunityWaterfall pair={pair} notionalUsd={notionalUsd} />
-            </>
-          )}
-        </div>
-      )}
     </div>
   );
-}
+});
 
 /** "at 8.0% → 7.8% after impact" — the Boros leg's mid rate and what it locks. */
 function RateNote({ midApr, execApr }: { midApr: number; execApr: number | null }) {
@@ -706,6 +762,11 @@ export function OpportunitiesPanel({ unconfigured = false }: { unconfigured?: bo
   const debouncedSize = useDebounced(sizeStr, 400);
   // Deliberately NOT persisted: the strip explains itself once and folds away.
   const [assumptionsOpen, setAssumptionsOpen] = useState(false);
+  // Also deliberately NOT persisted — unlike the assumptions, a filter changes
+  // WHAT IS MISSING from the list, and a hidden one carried over from last week
+  // would read as "there are no BTC opportunities".
+  const [filters, setFilters] = useState<OpportunityFilters>(NO_FILTERS);
+  const shownKeysRef = useRef<ReadonlySet<string>>(new Set());
   const flow = useTradeFlowOptional();
   const sizeId = useId();
   const feeTierId = useId();
@@ -751,16 +812,42 @@ export function OpportunitiesPanel({ unconfigured = false }: { unconfigured?: bo
   });
   const data = query.data;
 
-  const execute =
-    flow &&
-    ((pair: OpportunityPair) =>
-      flow.prefillPair({
+  // Every viable PAIR, not one per group: a cohort with three markets offers
+  // three venue combinations, and the two the group's best pair outranked are
+  // still real trades — often on the only venue a given reader can reach.
+  // `data.groups`, not `data`: meta.asOfSec moves on every poll, so keying on
+  // the whole response would rebuild every card even when no number changed.
+  const rows = useMemo(
+    () => toRows(data?.groups ?? [], shownKeysRef.current),
+    [data?.groups],
+  );
+  const visible = useMemo(() => applyFilters(rows, filters), [rows, filters]);
+
+  // What the NEXT toRows call treats as already on screen — the hysteresis band
+  // that stops near-zero pairs flickering in and out under the reader's cursor.
+  useEffect(() => {
+    shownKeysRef.current = new Set(rows.map((r) => r.key));
+  }, [rows]);
+
+  // The notional the RESPONSE priced, never the live control: during a size
+  // change `keepPreviousData` shows cards costed at the OLD notional, and
+  // arming the ticket at the new one would stage a trade none of the numbers
+  // on screen describe. The cards read from this too.
+  const pricedNotionalUsd = data?.meta.notionalUsd ?? notionalUsd;
+
+  // Stable identity, or every card re-renders on each keystroke and the memo
+  // above buys nothing.
+  const execute = useCallback(
+    (pair: OpportunityPair) =>
+      flow?.prefillPair({
         base: pair.base,
         longVenue: pair.longLeg.crossexVenue,
         shortVenue: pair.shortLeg.crossexVenue,
-        notionalUsd,
+        notionalUsd: pricedNotionalUsd,
         mode: entryMode === 'maker-hedge' ? 'maker' : 'market',
-      }));
+      }),
+    [flow, pricedNotionalUsd, entryMode],
+  );
 
   const summary = assumptionsOpen
     ? ''
@@ -930,9 +1017,14 @@ export function OpportunitiesPanel({ unconfigured = false }: { unconfigured?: bo
         {controls}
         <div className="flex flex-col gap-3">
           {[0, 1, 2].map((i) => (
-            <div key={i} className="card flex flex-col gap-3 p-4">
-              <Skeleton className="h-3 w-64" />
-              <Skeleton className="h-7 w-40" />
+            <div key={i} className="card overflow-hidden">
+              <div className="border-b border-ink-800 bg-ink-950/40 px-4 py-2.5">
+                <Skeleton className="h-3 w-56" />
+              </div>
+              <div className="flex items-end gap-7 p-4">
+                <Skeleton className="h-8 w-36" />
+                <Skeleton className="hidden h-8 w-64 sm:block" />
+              </div>
             </div>
           ))}
         </div>
@@ -949,42 +1041,57 @@ export function OpportunitiesPanel({ unconfigured = false }: { unconfigured?: bo
     );
   }
 
-  // Only VIABLE opportunities are shown. The server still serves groups whose
-  // best pair prices no net APR on capital (degraded inputs) or a negative one
-  // (costs swallow the spread) — those are noise in a list of things worth
-  // executing, so they are dropped here, keeping the server's order otherwise.
-  const groups = (data?.groups ?? []).filter((g) => {
-    const pair = g.bestPair ?? g.pairs[0] ?? null;
-    const apr = pair?.netFixedAprOnCapital ?? null;
-    return apr !== null && Number.isFinite(apr) && apr >= 0;
-  });
-
   return (
     <div>
       {controls}
       {data && <Notes items={data.warnings} className="mb-2" />}
-      {groups.length === 0 ? (
+      {/* The bar only exists to narrow a list — with nothing to narrow it would
+          be a row of dead chips above an empty state. */}
+      {rows.length > 0 && (
+        <OpportunityFilterBar
+          rows={rows}
+          filters={filters}
+          onChange={setFilters}
+          shown={visible.length}
+        />
+      )}
+      {rows.length === 0 ? (
         <EmptyState
           icon="◎"
           title="No fixed-return opportunities"
-          hint={`No Boros arb group prices out at ${fmtUsd(notionalUsd, 0)} notional with a Boros entry ${
+          hint={`No Boros arb pair prices out at ${fmtUsd(notionalUsd, 0)} notional with a Boros entry ${
             borosEntry === 'mark' ? 'at mark rate' : 'at market size'
           }, ${ENTRY_MODE_PROSE[entryMode]} perp entry and ${EXIT_MODE_PROSE[exitMode]}. Try another notional or another assumption.`}
+        />
+      ) : visible.length === 0 ? (
+        // Distinct from the one above: the assumptions DO price opportunities,
+        // the filters are just hiding all of them — so the fix is here, not in
+        // the assumptions strip.
+        <EmptyState
+          icon="◎"
+          title="No opportunity matches these filters"
+          hint={`All ${rows.length} priced ${rows.length === 1 ? 'opportunity is' : 'opportunities are'} filtered out. Drop a filter to bring them back.`}
+          action={
+            hasActiveFilter(filters) ? (
+              <button type="button" className="btn" onClick={() => setFilters(NO_FILTERS)}>
+                Clear filters
+              </button>
+            ) : undefined
+          }
         />
       ) : (
         <div
           className={`flex flex-col gap-3 transition-opacity ${query.isPlaceholderData ? 'opacity-50' : ''}`}
         >
-          {/* Server order IS the ranking — never re-sort here. */}
-          {groups.map((g) => (
+          {/* Ranked by the server's own primary key (net fixed APR on capital),
+              which is the only order that survives flattening the groups. */}
+          {visible.map((row) => (
             <OpportunityCard
-              key={`${g.tokenId}:${g.maturity}:${g.underlying}`}
-              group={g}
-              // The response's own notional, not the live control: during a
-              // size change `keepPreviousData` shows costs priced at the OLD
-              // notional, and the chart must convert with the same one.
-              notionalUsd={data?.meta.notionalUsd ?? notionalUsd}
-              onExecute={execute || null}
+              key={row.key}
+              group={row.group}
+              pair={row.pair}
+              notionalUsd={pricedNotionalUsd}
+              onExecute={flow ? execute : null}
               unconfigured={unconfigured}
             />
           ))}

--- a/web/src/panels/OpportunityFilterBar.tsx
+++ b/web/src/panels/OpportunityFilterBar.tsx
@@ -1,0 +1,219 @@
+/**
+ * The opportunities list's facet toolbar — one quiet wrapping line between the
+ * assumptions strip and the first card, not a boxed form. Every chip carries
+ * the number of cards it would leave standing given the OTHER active filters,
+ * so a dead end is visible before it is clicked — and a chip that would add
+ * nothing is disabled rather than silently inert. Selected chips wear a ✓ as
+ * well as the cyan, so selection never rides on colour alone.
+ *
+ * A dimension with fewer than two options isn't a choice, so it stays hidden: a
+ * lone "ETH" chip can only narrow the list to what it already shows.
+ */
+import { useEffect, useId, useRef, useState } from 'react';
+import { microLabelClass } from '../components/Th';
+import { fmtDateUtc } from '../lib/fmt';
+import { useDebounced } from '../lib/useDebounced';
+import {
+  facets,
+  hasActiveFilter,
+  minApr,
+  NO_FILTERS,
+  toggleValue,
+  type FacetOption,
+  type OpportunityFilters,
+  type OpportunityRow,
+} from './opportunityFilters';
+
+function FilterChip<T extends string | number>({
+  option,
+  title,
+  onToggle,
+}: {
+  option: FacetOption<T>;
+  title?: string;
+  onToggle: (value: T) => void;
+}) {
+  const { label, count, selected, value } = option;
+  const dead = count === 0 && !selected;
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      // Unselected and worth nothing: picking it would add no card. Selected
+      // chips stay live at any count — they must always be releasable.
+      // `aria-disabled` rather than `disabled`: a native disabled button leaves
+      // the tab order and stops dispatching pointer events, so the `title`
+      // explaining WHY it is a dead end becomes unreachable by exactly the
+      // people who need it. Inert is enforced in the handler instead.
+      aria-disabled={dead}
+      title={title}
+      onClick={() => !dead && onToggle(value)}
+      className={`num rounded-md border px-2 py-0.5 text-[11px] font-medium transition-colors ${
+        dead ? 'cursor-not-allowed opacity-40' : ''
+      } ${
+        selected
+          ? 'border-cyan-500/50 bg-cyan-500/10 text-cyan-300'
+          : `border-ink-700 bg-ink-900 text-ink-300 ${dead ? '' : 'hover:border-ink-500 hover:text-ink-100'}`
+      }`}
+    >
+      {/* Shape marks the selection alongside the cyan; hidden from the
+          accessible name — aria-pressed already says it. */}
+      {selected && (
+        <span aria-hidden="true" className="mr-1 text-[9px] text-cyan-400">
+          ✓
+        </span>
+      )}
+      {label}{' '}
+      <span className={selected ? 'text-cyan-400/70' : 'text-ink-500'}>{count}</span>
+    </button>
+  );
+}
+
+/** One facet: its micro-label and chips, flowing inline with its siblings. */
+function FacetGroup<T extends string | number>({
+  label,
+  options,
+  poolSize,
+  titleOf,
+  onToggle,
+}: {
+  label: string;
+  options: FacetOption<T>[];
+  /** Rows the counts are measured against — see `OpportunityFacets.poolSize`. */
+  poolSize: number;
+  titleOf?: (value: T) => string;
+  onToggle: (value: T) => void;
+}) {
+  // A dimension earns its row when some option would actually exclude
+  // something. Option COUNT can't answer that: every row carries two venue
+  // keys, so a one-card list has two venue chips that between them exclude
+  // nothing. A dimension holding a live selection always shows, whatever the
+  // data now says — otherwise the filter stays armed with no chip to release.
+  const narrows = options.some((o) => o.count < poolSize);
+  const hasSelection = options.some((o) => o.selected);
+  if (!narrows && !hasSelection) return null;
+  return (
+    <span className="flex flex-wrap items-center gap-1.5">
+      <span className={`${microLabelClass} mr-0.5`}>{label}</span>
+      {options.map((o) => (
+        <FilterChip
+          key={String(o.value)}
+          option={o}
+          title={titleOf?.(o.value)}
+          onToggle={onToggle}
+        />
+      ))}
+    </span>
+  );
+}
+
+export function OpportunityFilterBar({
+  rows,
+  filters,
+  onChange,
+  shown,
+}: {
+  /** Every viable row, unfiltered — the facets count against this. */
+  rows: OpportunityRow[];
+  filters: OpportunityFilters;
+  onChange: (next: OpportunityFilters) => void;
+  /** How many cards survive `filters` — the "showing N of M" numerator. */
+  shown: number;
+}) {
+  const minAprId = useId();
+  // The field types LOCALLY and lands debounced: every keystroke straight into
+  // `filters` re-renders the whole card list synchronously, which at 100 cards
+  // costs ~14ms a character (and mounts rows the next character removes).
+  const [minAprText, setMinAprText] = useState(filters.minAprPct);
+  const debouncedMinApr = useDebounced(minAprText, 250);
+  // What we last pushed up, so an echo of our own value is not mistaken for the
+  // parent resetting the field (Clear filters).
+  const pushed = useRef(filters.minAprPct);
+
+  useEffect(() => {
+    if (debouncedMinApr === pushed.current) return;
+    pushed.current = debouncedMinApr;
+    onChange({ ...filters, minAprPct: debouncedMinApr });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedMinApr]);
+
+  // Clear filters (or any other outside write) wins over the local text.
+  useEffect(() => {
+    if (filters.minAprPct === pushed.current) return;
+    pushed.current = filters.minAprPct;
+    setMinAprText(filters.minAprPct);
+  }, [filters.minAprPct]);
+
+  const f = facets(rows, filters);
+  const active = hasActiveFilter(filters);
+  // Judged on what the reader has TYPED, not on the debounced value the list is
+  // filtered by — the red border must answer the keystroke, not trail it.
+  const minAprBad = minAprText.trim() !== '' && minApr({ ...filters, minAprPct: minAprText }) === null;
+
+  return (
+    <div
+      className="mb-3 flex flex-wrap items-center gap-x-6 gap-y-2 px-0.5"
+      role="group"
+      aria-label="Filter opportunities"
+    >
+      <FacetGroup
+        label="Asset"
+        options={f.assets}
+        poolSize={f.poolSize.assets}
+        onToggle={(v) => onChange({ ...filters, assets: toggleValue(filters.assets, v) })}
+      />
+      <FacetGroup
+        label="Venue"
+        options={f.venues}
+        poolSize={f.poolSize.venues}
+        titleOf={(v) => `Opportunities with either leg on ${v}`}
+        onToggle={(v) => onChange({ ...filters, venues: toggleValue(filters.venues, v) })}
+      />
+      <FacetGroup
+        label="Matures"
+        options={f.maturities}
+        poolSize={f.poolSize.maturities}
+        titleOf={(v) => `Matures ${fmtDateUtc(v)} UTC`}
+        onToggle={(v) => onChange({ ...filters, maturities: toggleValue(filters.maturities, v) })}
+      />
+
+      <span className="flex items-center gap-1.5">
+        <label htmlFor={minAprId} className={`${microLabelClass} mr-0.5`}>
+          Min APR
+        </label>
+        <input
+          id={minAprId}
+          type="text"
+          inputMode="decimal"
+          autoComplete="off"
+          placeholder="any"
+          value={minAprText}
+          onChange={(e) => setMinAprText(e.target.value)}
+          title="Hide anything under this net APR on capital — a plain decimal, e.g. 7.5"
+          aria-invalid={minAprBad}
+          aria-describedby={minAprBad ? `${minAprId}-err` : undefined}
+          className={`input num h-[26px] w-16 !px-2 !py-0 text-[11px] ${
+            minAprBad ? 'border-rose-500/60' : ''
+          }`}
+        />
+        <span className="text-[11px] text-ink-400">%</span>
+        {minAprBad && (
+          <span id={`${minAprId}-err`} role="alert" className="text-[11px] text-rose-300">
+            needs a plain number
+          </span>
+        )}
+      </span>
+
+      <span className="ml-auto flex items-center gap-2">
+        <span className="num text-[11px] text-ink-400" aria-live="polite">
+          showing {shown} of {rows.length}
+        </span>
+        {active && (
+          <button type="button" className="btn-ghost-xs" onClick={() => onChange(NO_FILTERS)}>
+            Clear filters
+          </button>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/web/src/panels/OpportunityFilterBar.tsx
+++ b/web/src/panels/OpportunityFilterBar.tsx
@@ -1,6 +1,10 @@
 /**
- * The opportunities list's facet toolbar — one quiet wrapping line between the
- * assumptions strip and the first card, not a boxed form. Every chip carries
+ * The opportunities list's facet toolbar — one quiet line between the
+ * assumptions strip and the first card, not a boxed form. ASSET rides that line
+ * (it is what a reader scans by); venue, maturity and the APR floor fold behind
+ * a filter icon on the right that carries a count whenever one of them is
+ * armed, and open in a popover anchored to it — which is also where the blanket
+ * Clear lives, since a chip on the bar is released by clicking it. Every chip carries
  * the number of cards it would leave standing given the OTHER active filters,
  * so a dead end is visible before it is clicked — and a chip that would add
  * nothing is disabled rather than silently inert. Selected chips wear a ✓ as
@@ -9,14 +13,21 @@
  * A dimension with fewer than two options isn't a choice, so it stays hidden: a
  * lone "ETH" chip can only narrow the list to what it already shows.
  */
-import { useEffect, useId, useRef, useState } from 'react';
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from 'react';
 import { microLabelClass } from '../components/Th';
-import { fmtDateUtc } from '../lib/fmt';
 import { useDebounced } from '../lib/useDebounced';
 import {
   facets,
   hasActiveFilter,
-  minApr,
+  maxDays,
   NO_FILTERS,
   toggleValue,
   type FacetOption,
@@ -107,6 +118,96 @@ function FacetGroup<T extends string | number>({
   );
 }
 
+const POPOVER_WIDTH = 320;
+const MARGIN = 8;
+
+/**
+ * The refinements, anchored under the filter icon on the right of the bar. Same shape as
+ * `trade/ClosePopover`: a click-catching scrim, a viewport-CLAMPED fixed
+ * dialog, Escape to dismiss — and it re-anchors on scroll/resize because the
+ * coordinates are viewport-relative and the body scrolls under it.
+ */
+function FilterPopover({
+  id,
+  anchorRef,
+  onDismiss,
+  children,
+}: {
+  /** Target of the trigger's `aria-controls`. */
+  id: string;
+  /** A live ref, not a rect — the trigger moves as the page scrolls. */
+  anchorRef: RefObject<HTMLElement> | null;
+  onDismiss: () => void;
+  children: ReactNode;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onDismiss();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onDismiss]);
+
+  // Below-LEFT of the trigger (it sits on the left of the bar), clamped so a
+  // narrow viewport can't push it off-screen where a fixed element is
+  // unreachable. It also GROWS as chips wrap, hence the ResizeObserver.
+  useLayoutEffect(() => {
+    if (!anchorRef) return; // no anchor (tests) → keep the static fallback
+    const reposition = () => {
+      const btn = anchorRef.current;
+      const dlg = dialogRef.current;
+      if (!btn || !dlg) return;
+      const r = btn.getBoundingClientRect();
+      const top = Math.max(
+        MARGIN,
+        Math.min(r.bottom + 6, window.innerHeight - dlg.offsetHeight - MARGIN),
+      );
+      // Right-EDGE aligned: the trigger sits on the right of the bar, so
+      // hanging the popover off its left edge would push it off-screen.
+      const left = Math.max(
+        MARGIN,
+        Math.min(r.right - POPOVER_WIDTH, window.innerWidth - POPOVER_WIDTH - MARGIN),
+      );
+      setPos((prev) => (prev && prev.top === top && prev.left === left ? prev : { top, left }));
+    };
+    reposition();
+    window.addEventListener('scroll', reposition, true);
+    window.addEventListener('resize', reposition);
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(reposition) : null;
+    if (ro && dialogRef.current) ro.observe(dialogRef.current);
+    return () => {
+      window.removeEventListener('scroll', reposition, true);
+      window.removeEventListener('resize', reposition);
+      ro?.disconnect();
+    };
+  }, [anchorRef]);
+
+  return (
+    <div className="fixed inset-0 z-50" role="presentation" onClick={onDismiss}>
+      <div
+        id={id}
+        ref={dialogRef}
+        role="dialog"
+        aria-label="Filter opportunities by venue, maturity and APR"
+        className="fixed max-h-[calc(100vh-16px)] w-[320px] overflow-y-auto rounded-xl border border-ink-600 bg-ink-900 p-3 shadow-2xl"
+        style={pos ?? { top: 96, left: 16 }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-2.5 flex items-center justify-between gap-2">
+          <span className="text-xs font-semibold text-ink-100">Filters</span>
+          <button type="button" aria-label="dismiss" className="btn-ghost-xs px-1.5" onClick={onDismiss}>
+            ✕
+          </button>
+        </div>
+        <div className="flex flex-col gap-3">{children}</div>
+      </div>
+    </div>
+  );
+}
+
 export function OpportunityFilterBar({
   rows,
   filters,
@@ -120,100 +221,144 @@ export function OpportunityFilterBar({
   /** How many cards survive `filters` — the "showing N of M" numerator. */
   shown: number;
 }) {
-  const minAprId = useId();
+  const maxDaysId = useId();
+  const moreId = useId();
+  // Asset is the dimension a reader SCANS by; venue, maturity and the APR floor
+  // are refinements they reach for. Only the first stays on the line.
+  // Deliberately not persisted — it is a disclosure, not a preference.
+  const [moreOpen, setMoreOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  // Dismissing returns the caret to the icon that opened it, so a keyboard user
+  // is not dropped back at the top of the document.
+  const dismiss = () => {
+    setMoreOpen(false);
+    triggerRef.current?.focus();
+  };
   // The field types LOCALLY and lands debounced: every keystroke straight into
   // `filters` re-renders the whole card list synchronously, which at 100 cards
   // costs ~14ms a character (and mounts rows the next character removes).
-  const [minAprText, setMinAprText] = useState(filters.minAprPct);
-  const debouncedMinApr = useDebounced(minAprText, 250);
+  const [maxDaysText, setMaxDaysText] = useState(filters.maxDaysText);
+  const debouncedMaxDays = useDebounced(maxDaysText, 250);
   // What we last pushed up, so an echo of our own value is not mistaken for the
   // parent resetting the field (Clear filters).
-  const pushed = useRef(filters.minAprPct);
+  const pushed = useRef(filters.maxDaysText);
 
   useEffect(() => {
-    if (debouncedMinApr === pushed.current) return;
-    pushed.current = debouncedMinApr;
-    onChange({ ...filters, minAprPct: debouncedMinApr });
+    if (debouncedMaxDays === pushed.current) return;
+    pushed.current = debouncedMaxDays;
+    onChange({ ...filters, maxDaysText: debouncedMaxDays });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedMinApr]);
+  }, [debouncedMaxDays]);
 
   // Clear filters (or any other outside write) wins over the local text.
   useEffect(() => {
-    if (filters.minAprPct === pushed.current) return;
-    pushed.current = filters.minAprPct;
-    setMinAprText(filters.minAprPct);
-  }, [filters.minAprPct]);
+    if (filters.maxDaysText === pushed.current) return;
+    pushed.current = filters.maxDaysText;
+    setMaxDaysText(filters.maxDaysText);
+  }, [filters.maxDaysText]);
 
   const f = facets(rows, filters);
   const active = hasActiveFilter(filters);
+  // A refinement that is ACTIVE while folded away has to announce itself, or
+  // the list is narrowed for no reason the reader can see — the same trap a
+  // vanishing chip sets. The badge is what stands in for the hidden chips.
+  const hiddenActive = filters.venues.length + (maxDays(filters) === null ? 0 : 1);
   // Judged on what the reader has TYPED, not on the debounced value the list is
   // filtered by — the red border must answer the keystroke, not trail it.
-  const minAprBad = minAprText.trim() !== '' && minApr({ ...filters, minAprPct: minAprText }) === null;
+  const maxDaysBad =
+    maxDaysText.trim() !== '' && maxDays({ ...filters, maxDaysText }) === null;
 
   return (
     <div
-      className="mb-3 flex flex-wrap items-center gap-x-6 gap-y-2 px-0.5"
+      className="mb-3 flex flex-col gap-2 px-0.5"
       role="group"
       aria-label="Filter opportunities"
     >
-      <FacetGroup
-        label="Asset"
-        options={f.assets}
-        poolSize={f.poolSize.assets}
-        onToggle={(v) => onChange({ ...filters, assets: toggleValue(filters.assets, v) })}
-      />
-      <FacetGroup
-        label="Venue"
-        options={f.venues}
-        poolSize={f.poolSize.venues}
-        titleOf={(v) => `Opportunities with either leg on ${v}`}
-        onToggle={(v) => onChange({ ...filters, venues: toggleValue(filters.venues, v) })}
-      />
-      <FacetGroup
-        label="Matures"
-        options={f.maturities}
-        poolSize={f.poolSize.maturities}
-        titleOf={(v) => `Matures ${fmtDateUtc(v)} UTC`}
-        onToggle={(v) => onChange({ ...filters, maturities: toggleValue(filters.maturities, v) })}
-      />
-
-      <span className="flex items-center gap-1.5">
-        <label htmlFor={minAprId} className={`${microLabelClass} mr-0.5`}>
-          Min APR
-        </label>
-        <input
-          id={minAprId}
-          type="text"
-          inputMode="decimal"
-          autoComplete="off"
-          placeholder="any"
-          value={minAprText}
-          onChange={(e) => setMinAprText(e.target.value)}
-          title="Hide anything under this net APR on capital — a plain decimal, e.g. 7.5"
-          aria-invalid={minAprBad}
-          aria-describedby={minAprBad ? `${minAprId}-err` : undefined}
-          className={`input num h-[26px] w-16 !px-2 !py-0 text-[11px] ${
-            minAprBad ? 'border-rose-500/60' : ''
-          }`}
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+        <FacetGroup
+          label="Asset"
+          options={f.assets}
+          poolSize={f.poolSize.assets}
+          onToggle={(v) => onChange({ ...filters, assets: toggleValue(filters.assets, v) })}
         />
-        <span className="text-[11px] text-ink-400">%</span>
-        {minAprBad && (
-          <span id={`${minAprId}-err`} role="alert" className="text-[11px] text-rose-300">
-            needs a plain number
-          </span>
-        )}
-      </span>
 
-      <span className="ml-auto flex items-center gap-2">
-        <span className="num text-[11px] text-ink-400" aria-live="polite">
-          showing {shown} of {rows.length}
-        </span>
-        {active && (
-          <button type="button" className="btn-ghost-xs" onClick={() => onChange(NO_FILTERS)}>
-            Clear filters
+        <span className="ml-auto flex items-center gap-2">
+          <span className="num text-[11px] text-ink-400" aria-live="polite">
+            showing {shown} of {rows.length}
+          </span>
+          <button
+            ref={triggerRef}
+            type="button"
+            aria-haspopup="dialog"
+            aria-expanded={moreOpen}
+            aria-controls={moreOpen ? moreId : undefined}
+            aria-label={hiddenActive > 0 ? `Filters, ${hiddenActive} active` : 'Filters'}
+            title="Venue and how far out it matures"
+            onClick={() => setMoreOpen((v) => !v)}
+            className={`flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-medium transition-colors ${
+              hiddenActive > 0
+                ? 'border-cyan-500/50 bg-cyan-500/10 text-cyan-300'
+                : 'border-ink-700 bg-ink-900 text-ink-300 hover:border-ink-500 hover:text-ink-100'
+            }`}
+          >
+            <svg viewBox="0 0 16 16" className="h-3 w-3" fill="currentColor" aria-hidden="true">
+              <path d="M2 3h12L9.5 8.6V14L6.5 12.4V8.6z" />
+            </svg>
+            Filters
+            {hiddenActive > 0 && (
+              <span className="num rounded bg-cyan-500/20 px-1 text-[10px] leading-4 text-cyan-200">
+                {hiddenActive}
+              </span>
+            )}
           </button>
-        )}
-      </span>
+        </span>
+      </div>
+
+      {moreOpen && (
+        <FilterPopover id={moreId} anchorRef={triggerRef} onDismiss={dismiss}>
+          <FacetGroup
+            label="Venue"
+            options={f.venues}
+            poolSize={f.poolSize.venues}
+            titleOf={(v) => `Opportunities with either leg on ${v}`}
+            onToggle={(v) => onChange({ ...filters, venues: toggleValue(filters.venues, v) })}
+          />
+          <span className="flex flex-wrap items-center gap-1.5">
+            <label htmlFor={maxDaysId} className={`${microLabelClass} mr-0.5`}>
+              Matures within
+            </label>
+            <input
+              id={maxDaysId}
+              type="text"
+              inputMode="numeric"
+              autoComplete="off"
+              placeholder="any"
+              value={maxDaysText}
+              onChange={(e) => setMaxDaysText(e.target.value)}
+              title="Longest tenor to keep, in days — a plain number, e.g. 60"
+              aria-invalid={maxDaysBad}
+              aria-describedby={maxDaysBad ? `${maxDaysId}-err` : undefined}
+              className={`input num h-[26px] w-16 !px-2 !py-0 text-[11px] ${
+                maxDaysBad ? 'border-rose-500/60' : ''
+              }`}
+            />
+            <span className="text-[11px] text-ink-400">days</span>
+            {maxDaysBad && (
+              <span id={`${maxDaysId}-err`} role="alert" className="text-[11px] text-rose-300">
+                needs a plain number
+              </span>
+            )}
+          </span>
+
+          {active && (
+            <div className="flex justify-end border-t border-ink-800 pt-2.5">
+              <button type="button" className="btn-ghost-xs" onClick={() => onChange(NO_FILTERS)}>
+                Clear filters
+              </button>
+            </div>
+          )}
+        </FilterPopover>
+      )}
     </div>
   );
 }

--- a/web/src/panels/opportunityFilters.test.ts
+++ b/web/src/panels/opportunityFilters.test.ts
@@ -14,8 +14,11 @@ import {
   applyFilters,
   facets,
   hasActiveFilter,
-  minApr,
+  loadFilters,
+  maxDays,
   NO_FILTERS,
+  OPPORTUNITY_FILTERS_STORAGE_KEY,
+  saveFilters,
   toggleValue,
   toRows,
   type OpportunityFilters,
@@ -109,7 +112,6 @@ describe('toRows', () => {
 
     expect(rows[0].venueKeys).toEqual(['HYPERLIQUID', 'BINANCE']);
     expect(rows[0].asset).toBe('ETH');
-    expect(rows[0].maturity).toBe(OPP_MATURITY);
     expect(rows[0].days).toBe(30);
     expect(rows[0].key).toContain(String(rows[0].pair.shortLeg.marketId));
   });
@@ -175,47 +177,36 @@ describe('applyFilters', () => {
     expect(applyFilters(rows, filters({ venues: ['HYPERLIQUID'] }))).toHaveLength(2);
   });
 
-  it('filters on maturity', () => {
+  it('caps the tenor by DAYS, inclusive of the number the card prints', () => {
     const rows = toRows(book());
-    expect(applyFilters(rows, filters({ maturities: [OPP_MATURITY] }))).toHaveLength(2);
+    // The book is two 30-day ETH rows and one 90-day BTC row.
+    expect(rows.map((r) => r.days)).toEqual([30, 90, 30]);
+
+    expect(applyFilters(rows, filters({ maxDaysText: '30' })).map((r) => r.days)).toEqual([30, 30]);
+    expect(applyFilters(rows, filters({ maxDaysText: '90' }))).toHaveLength(3);
+    expect(applyFilters(rows, filters({ maxDaysText: '29' }))).toHaveLength(0);
   });
 
-  it('reads the APR floor as a percent, and ignores one it cannot parse', () => {
+  it('ignores a tenor cap it cannot parse', () => {
     const rows = toRows(book());
-
-    expect(applyFilters(rows, filters({ minAprPct: '5' })).map((r) => r.apr)).toEqual([0.12, 0.08]);
-    expect(applyFilters(rows, filters({ minAprPct: '12' }))).toHaveLength(1);
     // A half-typed entry must never blank the list.
-    expect(applyFilters(rows, filters({ minAprPct: '1.2e' }))).toHaveLength(3);
-    expect(applyFilters(rows, filters({ minAprPct: '  ' }))).toHaveLength(3);
-  });
-
-  it('floors on the APR the CARD PRINTS, not the raw fraction', () => {
-    // 0.11996 renders "12.0% APR"; a reader who types 12 to keep everything at
-    // 12%-or-better must not watch that very card vanish.
-    const rows = toRows([
-      makeOpportunityGroup({ pairs: [pair(0.11996, 'HYPERLIQUID', 'BINANCE')] }),
-    ]);
-    expect((0.11996 * 100).toFixed(1)).toBe('12.0');
-
-    expect(applyFilters(rows, filters({ minAprPct: '12' }))).toHaveLength(1);
-    // Genuinely below the printed floor still goes.
-    expect(applyFilters(rows, filters({ minAprPct: '12.1' }))).toHaveLength(0);
+    expect(applyFilters(rows, filters({ maxDaysText: '3e' }))).toHaveLength(3);
+    expect(applyFilters(rows, filters({ maxDaysText: '  ' }))).toHaveLength(3);
   });
 
   it('rejects every numeric literal that is not a plain decimal', () => {
     const rows = toRows(book());
     // `Number()` alone happily reads all of these, each as a silently wrong
-    // floor that Number.isFinite would wave through.
+    // cap that Number.isFinite would wave through.
     for (const text of ['0x10', '0o17', '0b11', '+5', '-5', '1e3', 'Infinity']) {
-      expect(minApr(filters({ minAprPct: text }))).toBeNull();
-      expect(applyFilters(rows, filters({ minAprPct: text }))).toHaveLength(3);
-      expect(hasActiveFilter(filters({ minAprPct: text }))).toBe(false);
+      expect(maxDays(filters({ maxDaysText: text }))).toBeNull();
+      expect(applyFilters(rows, filters({ maxDaysText: text }))).toHaveLength(3);
+      expect(hasActiveFilter(filters({ maxDaysText: text }))).toBe(false);
     }
-    // Plain decimals still read, in every shape a person types them.
-    expect(minApr(filters({ minAprPct: '7.5' }))).toBeCloseTo(0.075, 12);
-    expect(minApr(filters({ minAprPct: '.5' }))).toBeCloseTo(0.005, 12);
-    expect(minApr(filters({ minAprPct: '12.' }))).toBeCloseTo(0.12, 12);
+    // Plain numbers still read, in every shape a person types them.
+    expect(maxDays(filters({ maxDaysText: '60' }))).toBe(60);
+    expect(maxDays(filters({ maxDaysText: '.5' }))).toBeCloseTo(0.5, 12);
+    expect(maxDays(filters({ maxDaysText: '30.' }))).toBe(30);
   });
 });
 
@@ -295,7 +286,7 @@ describe('facets', () => {
     const rows = toRows(book());
     const f = facets(rows, NO_FILTERS);
 
-    expect(f.poolSize).toEqual({ assets: 3, venues: 3, maturities: 3 });
+    expect(f.poolSize).toEqual({ assets: 3, venues: 3 });
     // Every row carries BOTH its venues, so no single venue chip excludes
     // anything in a one-row list — which is how the bar knows not to show it.
     const one = toRows([makeOpportunityGroup({ pairs: [pair(0.12, 'HYPERLIQUID', 'BINANCE')] })]);
@@ -306,20 +297,56 @@ describe('facets', () => {
 
   it('lists every option even when a filter excludes it, so it stays releasable', () => {
     const rows = toRows(book());
-    const f = facets(rows, filters({ minAprPct: '100' }));
+    const f = facets(rows, filters({ maxDaysText: '0' }));
 
     expect(f.assets.map((o) => o.value)).toEqual(['ETH', 'BTC']);
     expect(f.assets.every((o) => o.count === 0)).toBe(true);
   });
 
-  it('ranks venues by their overall frequency and maturities by date', () => {
+  it('ranks venues by their overall frequency', () => {
     const rows = toRows(book());
     const f = facets(rows, NO_FILTERS);
 
     // Gate and Hyperliquid appear twice each (alphabetical tiebreak), then the
     // singletons.
     expect(f.venues.map((o) => o.value)).toEqual(['GATE', 'HYPERLIQUID', 'BINANCE', 'BYBIT']);
-    expect(f.maturities.map((o) => o.label)).toEqual(['30d', '90d']);
+  });
+});
+
+describe('persistence', () => {
+  it('round-trips a selection', () => {
+    const chosen = filters({ assets: ['BTC'], venues: ['GATE'], maxDaysText: '60' });
+    saveFilters(chosen);
+
+    expect(loadFilters()).toEqual(chosen);
+  });
+
+  it('falls back to no filters on a missing, corrupt or foreign blob', () => {
+    expect(loadFilters()).toEqual(NO_FILTERS);
+
+    localStorage.setItem(OPPORTUNITY_FILTERS_STORAGE_KEY, '{not json');
+    expect(loadFilters()).toEqual(NO_FILTERS);
+
+    localStorage.setItem(OPPORTUNITY_FILTERS_STORAGE_KEY, JSON.stringify({ assets: 'ETH' }));
+    expect(loadFilters()).toEqual(NO_FILTERS);
+
+    // A v1 blob carrying the fields this version dropped keeps what it can.
+    localStorage.setItem(
+      OPPORTUNITY_FILTERS_STORAGE_KEY,
+      JSON.stringify({ assets: ['ETH', 7, null], venues: ['GATE'], maturities: [123], minAprPct: '5' }),
+    );
+    expect(loadFilters()).toEqual(filters({ assets: ['ETH'], venues: ['GATE'] }));
+  });
+
+  it('re-normalizes venue keys and drops a tenor cap it could not parse', () => {
+    localStorage.setItem(
+      OPPORTUNITY_FILTERS_STORAGE_KEY,
+      JSON.stringify({ assets: [], venues: ['Gate', 'hyperliquid'], maxDaysText: '0x10' }),
+    );
+
+    // Restored as a red field the reader never typed into would be worse than
+    // restored as no cap at all.
+    expect(loadFilters()).toEqual(filters({ venues: ['GATE', 'HYPERLIQUID'] }));
   });
 });
 
@@ -329,16 +356,16 @@ describe('filter state helpers', () => {
     expect(toggleValue(['ETH', 'BTC'], 'ETH')).toEqual(['BTC']);
   });
 
-  it('minApr converts percent to the fraction the rows carry', () => {
-    expect(minApr(filters({ minAprPct: '7.5' }))).toBeCloseTo(0.075, 12);
-    expect(minApr(NO_FILTERS)).toBeNull();
-    expect(minApr(filters({ minAprPct: 'abc' }))).toBeNull();
+  it('maxDays reads the cap in the same unit the rows carry', () => {
+    expect(maxDays(filters({ maxDaysText: '60' }))).toBe(60);
+    expect(maxDays(NO_FILTERS)).toBeNull();
+    expect(maxDays(filters({ maxDaysText: 'abc' }))).toBeNull();
   });
 
-  it('hasActiveFilter ignores an unparseable APR floor', () => {
+  it('hasActiveFilter ignores an unparseable tenor cap', () => {
     expect(hasActiveFilter(NO_FILTERS)).toBe(false);
     expect(hasActiveFilter(filters({ venues: ['GATE'] }))).toBe(true);
-    expect(hasActiveFilter(filters({ minAprPct: '0' }))).toBe(true);
-    expect(hasActiveFilter(filters({ minAprPct: 'x' }))).toBe(false);
+    expect(hasActiveFilter(filters({ maxDaysText: '0' }))).toBe(true);
+    expect(hasActiveFilter(filters({ maxDaysText: 'x' }))).toBe(false);
   });
 });

--- a/web/src/panels/opportunityFilters.test.ts
+++ b/web/src/panels/opportunityFilters.test.ts
@@ -1,0 +1,344 @@
+/** The flattening + facet logic behind the opportunities list. The panel test
+ * covers the wiring; these cover the rules — what counts as viable, how the two
+ * legs feed one venue dimension, and what a facet count actually counts. */
+import { describe, expect, it } from 'vitest';
+import type { OpportunityGroup, OpportunityPair } from '../api/types';
+import {
+  makeOpportunityGroup,
+  makeOpportunityLeg,
+  makeOpportunityPair,
+  OPP_MATURITY,
+} from '../test/fixtures';
+
+import {
+  applyFilters,
+  facets,
+  hasActiveFilter,
+  minApr,
+  NO_FILTERS,
+  toggleValue,
+  toRows,
+  type OpportunityFilters,
+} from './opportunityFilters';
+
+/** Distinct id per (side, venue) — deriving ids from the venue NAME's length
+ * collapsed two venues of equal length onto one id, and the two market ids are
+ * the whole discriminator in a row's key. */
+const marketIds = new Map<string, number>();
+const marketIdFor = (side: 'short' | 'long', venue: string): number => {
+  const k = `${side}:${venue}`;
+  if (!marketIds.has(k)) marketIds.set(k, 1000 + marketIds.size);
+  return marketIds.get(k) as number;
+};
+
+/** A pair pinned to an APR and a pair of venues. The legs' CrossEx mapping
+ * tracks the venue: the server never pairs two markets that map to the SAME
+ * CrossEx venue, so leaving both at the default would build a shape it cannot
+ * emit. */
+function pair(
+  apr: number | null,
+  shortVenue: string,
+  longVenue: string,
+  over: Partial<OpportunityPair> = {},
+): OpportunityPair {
+  const leg = (side: 'short' | 'long', venue: string) =>
+    makeOpportunityLeg({
+      marketId: marketIdFor(side, venue),
+      venue,
+      crossexVenue: venue,
+      crossexSymbol: `${venue}_FUTURE_ETH_${venue === 'HYPERLIQUID' ? 'USDC' : 'USDT'}`,
+    });
+  return makeOpportunityPair({
+    shortLeg: leg('short', shortVenue),
+    longLeg: leg('long', longVenue),
+    netFixedAprOnCapital: apr,
+    ...over,
+  });
+}
+
+const filters = (over: Partial<OpportunityFilters> = {}): OpportunityFilters => ({
+  ...NO_FILTERS,
+  ...over,
+});
+
+describe('toRows', () => {
+  it('emits one row per pair, not one per group', () => {
+    const group = makeOpportunityGroup({
+      pairs: [
+        pair(0.09, 'HYPERLIQUID', 'BINANCE'),
+        pair(0.05, 'HYPERLIQUID', 'GATE'),
+        pair(0.02, 'BYBIT', 'GATE'),
+      ],
+    });
+
+    expect(toRows([group]).map((r) => r.apr)).toEqual([0.09, 0.05, 0.02]);
+  });
+
+  it('drops the pairs that price nothing or price a loss', () => {
+    const group = makeOpportunityGroup({
+      pairs: [
+        pair(0.09, 'HYPERLIQUID', 'BINANCE'),
+        pair(null, 'HYPERLIQUID', 'GATE'),
+        pair(-0.01, 'BYBIT', 'GATE'),
+        pair(Number.NaN, 'OKX', 'GATE'),
+      ],
+    });
+
+    expect(toRows([group])).toHaveLength(1);
+  });
+
+  it('ranks across groups on the APR, not on the server’s per-group order', () => {
+    const eth = makeOpportunityGroup({
+      tokenId: 3,
+      underlying: 'ETH',
+      pairs: [pair(0.09, 'HYPERLIQUID', 'BINANCE'), pair(0.01, 'HYPERLIQUID', 'GATE')],
+    });
+    const btc = makeOpportunityGroup({
+      tokenId: 4,
+      underlying: 'BTC',
+      pairs: [pair(0.05, 'BYBIT', 'GATE', { base: 'BTC' })],
+    });
+
+    expect(toRows([eth, btc]).map((r) => r.apr)).toEqual([0.09, 0.05, 0.01]);
+  });
+
+  it('keys rows per pair and normalizes both legs’ venues', () => {
+    const rows = toRows([
+      makeOpportunityGroup({ pairs: [pair(0.09, 'Hyperliquid', 'Binance')] }),
+    ]);
+
+    expect(rows[0].venueKeys).toEqual(['HYPERLIQUID', 'BINANCE']);
+    expect(rows[0].asset).toBe('ETH');
+    expect(rows[0].maturity).toBe(OPP_MATURITY);
+    expect(rows[0].days).toBe(30);
+    expect(rows[0].key).toContain(String(rows[0].pair.shortLeg.marketId));
+  });
+
+  it('keys the asset on the cohort underlying, never a leg ticker', () => {
+    // A fungible cohort: the server collapses XAU into GOLD, so one of its
+    // pairs reports base 'XAU' and another 'GOLD'. Both belong to ONE chip.
+    const rows = toRows([
+      makeOpportunityGroup({
+        underlying: 'GOLD',
+        pairs: [
+          pair(0.09, 'HYPERLIQUID', 'BINANCE', { base: 'XAU' }),
+          pair(0.04, 'HYPERLIQUID', 'GATE', { base: 'GOLD' }),
+        ],
+      }),
+    ]);
+
+    expect(rows.map((r) => r.asset)).toEqual(['GOLD', 'GOLD']);
+  });
+});
+
+// A three-asset, four-venue book the filter rules can be read off directly.
+function book(): OpportunityGroup[] {
+  return [
+    makeOpportunityGroup({
+      tokenId: 3,
+      underlying: 'ETH',
+      pairs: [
+        pair(0.12, 'HYPERLIQUID', 'BINANCE'),
+        pair(0.04, 'HYPERLIQUID', 'GATE'),
+      ],
+    }),
+    makeOpportunityGroup({
+      tokenId: 4,
+      underlying: 'BTC',
+      maturity: OPP_MATURITY + 86_400 * 60,
+      secondsToMaturity: 30 * 86_400 + 60 * 86_400,
+      pairs: [pair(0.08, 'BYBIT', 'GATE', { base: 'BTC' })],
+    }),
+  ];
+}
+
+describe('applyFilters', () => {
+  it('passes everything through when nothing is selected', () => {
+    const rows = toRows(book());
+    expect(applyFilters(rows, NO_FILTERS)).toHaveLength(3);
+  });
+
+  it('ORs within a dimension and ANDs across them', () => {
+    const rows = toRows(book());
+
+    expect(applyFilters(rows, filters({ assets: ['ETH'] }))).toHaveLength(2);
+    expect(applyFilters(rows, filters({ assets: ['ETH', 'BTC'] }))).toHaveLength(3);
+    // ETH ∩ Gate — the ETH/Gate pair only.
+    expect(applyFilters(rows, filters({ assets: ['ETH'], venues: ['GATE'] }))).toHaveLength(1);
+  });
+
+  it('matches a venue on either leg', () => {
+    const rows = toRows(book());
+    // Gate is the LONG leg of ETH/Gate and of BTC/Gate.
+    expect(applyFilters(rows, filters({ venues: ['GATE'] })).map((r) => r.apr)).toEqual([0.08, 0.04]);
+    // Hyperliquid is the SHORT leg of both ETH pairs.
+    expect(applyFilters(rows, filters({ venues: ['HYPERLIQUID'] }))).toHaveLength(2);
+  });
+
+  it('filters on maturity', () => {
+    const rows = toRows(book());
+    expect(applyFilters(rows, filters({ maturities: [OPP_MATURITY] }))).toHaveLength(2);
+  });
+
+  it('reads the APR floor as a percent, and ignores one it cannot parse', () => {
+    const rows = toRows(book());
+
+    expect(applyFilters(rows, filters({ minAprPct: '5' })).map((r) => r.apr)).toEqual([0.12, 0.08]);
+    expect(applyFilters(rows, filters({ minAprPct: '12' }))).toHaveLength(1);
+    // A half-typed entry must never blank the list.
+    expect(applyFilters(rows, filters({ minAprPct: '1.2e' }))).toHaveLength(3);
+    expect(applyFilters(rows, filters({ minAprPct: '  ' }))).toHaveLength(3);
+  });
+
+  it('floors on the APR the CARD PRINTS, not the raw fraction', () => {
+    // 0.11996 renders "12.0% APR"; a reader who types 12 to keep everything at
+    // 12%-or-better must not watch that very card vanish.
+    const rows = toRows([
+      makeOpportunityGroup({ pairs: [pair(0.11996, 'HYPERLIQUID', 'BINANCE')] }),
+    ]);
+    expect((0.11996 * 100).toFixed(1)).toBe('12.0');
+
+    expect(applyFilters(rows, filters({ minAprPct: '12' }))).toHaveLength(1);
+    // Genuinely below the printed floor still goes.
+    expect(applyFilters(rows, filters({ minAprPct: '12.1' }))).toHaveLength(0);
+  });
+
+  it('rejects every numeric literal that is not a plain decimal', () => {
+    const rows = toRows(book());
+    // `Number()` alone happily reads all of these, each as a silently wrong
+    // floor that Number.isFinite would wave through.
+    for (const text of ['0x10', '0o17', '0b11', '+5', '-5', '1e3', 'Infinity']) {
+      expect(minApr(filters({ minAprPct: text }))).toBeNull();
+      expect(applyFilters(rows, filters({ minAprPct: text }))).toHaveLength(3);
+      expect(hasActiveFilter(filters({ minAprPct: text }))).toBe(false);
+    }
+    // Plain decimals still read, in every shape a person types them.
+    expect(minApr(filters({ minAprPct: '7.5' }))).toBeCloseTo(0.075, 12);
+    expect(minApr(filters({ minAprPct: '.5' }))).toBeCloseTo(0.005, 12);
+    expect(minApr(filters({ minAprPct: '12.' }))).toBeCloseTo(0.12, 12);
+  });
+});
+
+describe('toRows ranking + hysteresis', () => {
+  it('breaks an APR tie on the server\u2019s own secondary keys, across groups', () => {
+    // Group A ranks first, but its 0.05 pair is strictly worse than group B's
+    // 0.05 pair. Insertion order is group-major, so stability alone would put
+    // the worse trade first.
+    const eth = makeOpportunityGroup({
+      tokenId: 3,
+      underlying: 'ETH',
+      pairs: [
+        pair(0.1, 'HYPERLIQUID', 'BINANCE'),
+        pair(0.05, 'HYPERLIQUID', 'GATE', { netFixedApr: 0.001 }),
+      ],
+    });
+    const btc = makeOpportunityGroup({
+      tokenId: 4,
+      underlying: 'BTC',
+      pairs: [pair(0.05, 'BYBIT', 'GATE', { netFixedApr: 0.049 })],
+    });
+
+    expect(toRows([eth, btc]).map((r) => r.pair.netFixedApr)).toEqual([
+      makeOpportunityPair().netFixedApr,
+      0.049,
+      0.001,
+    ]);
+  });
+
+  it('holds a row already on screen just below zero, but never admits a new one', () => {
+    const groups = [makeOpportunityGroup({ pairs: [pair(-0.002, 'HYPERLIQUID', 'BINANCE')] })];
+
+    // Nothing shown yet: a negative pair has to clear zero to earn a slot.
+    expect(toRows(groups)).toHaveLength(0);
+
+    // Already on screen: it holds its place rather than flickering out and
+    // shifting every row below it under the reader's cursor.
+    const key = toRows([makeOpportunityGroup({ pairs: [pair(0.01, 'HYPERLIQUID', 'BINANCE')] })])[0]
+      .key;
+    expect(toRows(groups, new Set([key]))).toHaveLength(1);
+
+    // The band is not a licence to show real losses.
+    const loss = [makeOpportunityGroup({ pairs: [pair(-0.03, 'HYPERLIQUID', 'BINANCE')] })];
+    expect(toRows(loss, new Set([key]))).toHaveLength(0);
+  });
+});
+
+describe('facets', () => {
+  it('counts each option against the OTHER dimensions, never against its own', () => {
+    const rows = toRows(book());
+    // With ETH picked, the ASSET chips still count over every row (so BTC reads
+    // 1, the cards it would add) while the VENUE chips count within ETH only.
+    const f = facets(rows, filters({ assets: ['ETH'] }));
+
+    expect(f.assets).toEqual([
+      { value: 'ETH', label: 'ETH', count: 2, selected: true },
+      { value: 'BTC', label: 'BTC', count: 1, selected: false },
+    ]);
+    expect(f.venues.find((o) => o.value === 'BYBIT')).toMatchObject({ count: 0, selected: false });
+    expect(f.venues.find((o) => o.value === 'GATE')).toMatchObject({ count: 1, label: 'Gate' });
+    expect(f.venues.find((o) => o.value === 'HYPERLIQUID')).toMatchObject({ count: 2 });
+  });
+
+  it('keeps a SELECTED value listed after it leaves the data entirely', () => {
+    // The poll drops every BTC row while the BTC chip is still armed. Without
+    // the chip there is nothing on screen saying why the list is narrowed, and
+    // nothing to click to undo it.
+    const rows = toRows([
+      makeOpportunityGroup({ tokenId: 3, underlying: 'ETH', pairs: [pair(0.12, 'HYPERLIQUID', 'BINANCE')] }),
+    ]);
+    const f = facets(rows, filters({ assets: ['BTC'] }));
+
+    expect(f.assets.find((o) => o.value === 'BTC')).toMatchObject({ count: 0, selected: true });
+  });
+
+  it('reports the pool each dimension is counted against', () => {
+    const rows = toRows(book());
+    const f = facets(rows, NO_FILTERS);
+
+    expect(f.poolSize).toEqual({ assets: 3, venues: 3, maturities: 3 });
+    // Every row carries BOTH its venues, so no single venue chip excludes
+    // anything in a one-row list — which is how the bar knows not to show it.
+    const one = toRows([makeOpportunityGroup({ pairs: [pair(0.12, 'HYPERLIQUID', 'BINANCE')] })]);
+    const g = facets(one, NO_FILTERS);
+    expect(g.venues).toHaveLength(2);
+    expect(g.venues.every((o) => o.count === g.poolSize.venues)).toBe(true);
+  });
+
+  it('lists every option even when a filter excludes it, so it stays releasable', () => {
+    const rows = toRows(book());
+    const f = facets(rows, filters({ minAprPct: '100' }));
+
+    expect(f.assets.map((o) => o.value)).toEqual(['ETH', 'BTC']);
+    expect(f.assets.every((o) => o.count === 0)).toBe(true);
+  });
+
+  it('ranks venues by their overall frequency and maturities by date', () => {
+    const rows = toRows(book());
+    const f = facets(rows, NO_FILTERS);
+
+    // Gate and Hyperliquid appear twice each (alphabetical tiebreak), then the
+    // singletons.
+    expect(f.venues.map((o) => o.value)).toEqual(['GATE', 'HYPERLIQUID', 'BINANCE', 'BYBIT']);
+    expect(f.maturities.map((o) => o.label)).toEqual(['30d', '90d']);
+  });
+});
+
+describe('filter state helpers', () => {
+  it('toggleValue adds then removes', () => {
+    expect(toggleValue(['ETH'], 'BTC')).toEqual(['ETH', 'BTC']);
+    expect(toggleValue(['ETH', 'BTC'], 'ETH')).toEqual(['BTC']);
+  });
+
+  it('minApr converts percent to the fraction the rows carry', () => {
+    expect(minApr(filters({ minAprPct: '7.5' }))).toBeCloseTo(0.075, 12);
+    expect(minApr(NO_FILTERS)).toBeNull();
+    expect(minApr(filters({ minAprPct: 'abc' }))).toBeNull();
+  });
+
+  it('hasActiveFilter ignores an unparseable APR floor', () => {
+    expect(hasActiveFilter(NO_FILTERS)).toBe(false);
+    expect(hasActiveFilter(filters({ venues: ['GATE'] }))).toBe(true);
+    expect(hasActiveFilter(filters({ minAprPct: '0' }))).toBe(true);
+    expect(hasActiveFilter(filters({ minAprPct: 'x' }))).toBe(false);
+  });
+});

--- a/web/src/panels/opportunityFilters.ts
+++ b/web/src/panels/opportunityFilters.ts
@@ -1,0 +1,302 @@
+/**
+ * The opportunities list is a flat list of PAIRS, not one card per group. A
+ * group with three markets offers three different venue combinations, each its
+ * own executable trade at its own APR — collapsing them to the group's best hid
+ * every runner-up, including ones on venues the reader can actually reach.
+ *
+ * This module owns the flattening, the viability rule (a card must price a
+ * non-negative net APR on capital) and the facet filtering the bar drives. All
+ * pure, so the panel stays a rendering concern.
+ */
+import type { OpportunityGroup, OpportunityPair } from '../api/types';
+
+/** One card's worth of data: the pair, plus the group context it renders in. */
+export interface OpportunityRow {
+  /** Stable per-pair identity — the group plus the two Boros markets it joins. */
+  key: string;
+  group: OpportunityGroup;
+  pair: OpportunityPair;
+  /** netFixedAprOnCapital — finite and ≥ 0 by construction of `toRows`. */
+  apr: number;
+  /** The asset traded (the group underlying when the legs' bases differ). */
+  asset: string;
+  /** Both Boros legs' venues, upper-cased and deduped: the filter's key space. */
+  venueKeys: string[];
+  maturity: number;
+  /** Days to maturity, rounded exactly as the card's "(35 days)" is. */
+  days: number;
+}
+
+/** Boros platformName → one venue key space ("Hyperliquid" and "HYPERLIQUID"
+ * are the same venue to a filter). */
+export const venueKey = (venue: string): string => venue.trim().toUpperCase();
+
+/** Days to maturity as the cards show it, so a chip and a card never disagree. */
+export const maturityDays = (secondsToMaturity: number): number =>
+  Math.max(1, Math.round(secondsToMaturity / 86_400));
+
+/** Once shown, a row survives this far below zero before it drops out. Without
+ * the band a pair hovering at 0% flips in and out on every poll, and every row
+ * below it shifts a full card — under the reader's cursor, mid-click. */
+const HYSTERESIS_APR = -0.005;
+
+/** Descending, nulls last — mirrors the server's own `byValueDesc`, so the flat
+ * list reproduces its ranking instead of keeping only the primary key. */
+const byValueDesc = (a: number | null, b: number | null): number => {
+  if (a === b) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  return b - a;
+};
+
+/**
+ * Every viable pair across every group, best first.
+ *
+ * Viable means the pair prices a real, non-negative net APR on capital: the
+ * server still serves pairs whose inputs degraded to null, and ones whose costs
+ * swallow the whole spread, and neither belongs in a list of things worth
+ * executing.
+ *
+ * The server ranks WITHIN a group; a flat list needs one order across ALL of
+ * them, so the rows re-rank on the server's whole comparator, not just its
+ * primary key. Stability alone would not do it: the pre-sort array is
+ * group-major, so a cross-group tie on APR would break by GROUP rank rather
+ * than by the pair-level tiebreak, ranking a strictly worse trade first.
+ */
+export function toRows(
+  groups: OpportunityGroup[],
+  /** Keys shown on the previous render — see `HYSTERESIS_APR`. */
+  shownKeys?: ReadonlySet<string>,
+): OpportunityRow[] {
+  const rows: OpportunityRow[] = [];
+  for (const group of groups) {
+    for (const pair of group.pairs) {
+      const apr = pair.netFixedAprOnCapital;
+      if (apr === null || !Number.isFinite(apr)) continue;
+      const key = `${group.tokenId}:${group.maturity}:${pair.shortLeg.marketId}:${pair.longLeg.marketId}`;
+      // A pair already on screen holds its place down to the band; a new one
+      // still has to clear zero to earn a slot.
+      if (apr < (shownKeys?.has(key) ? HYSTERESIS_APR : 0)) continue;
+      rows.push({
+        key,
+        group,
+        pair,
+        apr,
+        // The COHORT's underlying, not the pair's `base`: the server collapses
+        // fungible tickers (XAU into GOLD), and keying on the leg would split
+        // one cohort across an "XAU" chip and a "GOLD" chip that no single
+        // selection could reunite.
+        asset: group.underlying,
+        venueKeys: [...new Set([venueKey(pair.shortLeg.venue), venueKey(pair.longLeg.venue)])],
+        maturity: group.maturity,
+        days: maturityDays(group.secondsToMaturity),
+      });
+    }
+  }
+  return rows.sort(
+    (x, y) =>
+      y.apr - x.apr ||
+      byValueDesc(x.pair.netFixedApr, y.pair.netFixedApr) ||
+      byValueDesc(x.pair.execSpreadApr, y.pair.execSpreadApr) ||
+      y.pair.grossSpreadApr - x.pair.grossSpreadApr,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Filter state
+// ---------------------------------------------------------------------------
+
+/** Each list is OR within its dimension and AND across dimensions; an empty
+ * list is no constraint at all. */
+export interface OpportunityFilters {
+  assets: string[];
+  /** Venue KEYS (see `venueKey`) — a row matches on either of its two legs. */
+  venues: string[];
+  /** Group maturities, unix seconds. */
+  maturities: number[];
+  /** Raw field text, in PERCENT ("5" means 5% APR); '' = no floor. */
+  minAprPct: string;
+}
+
+export const NO_FILTERS: OpportunityFilters = {
+  assets: [],
+  venues: [],
+  maturities: [],
+  minAprPct: '',
+};
+
+/** A plain decimal, and nothing else. `Number()` alone also takes `0x10`,
+ * `0o17`, `0b11`, `1e3` and a leading sign — each of which would land as a
+ * silently wrong floor that `Number.isFinite` is perfectly happy with. A
+ * negative floor is rejected too: no row is ever below zero by more than the
+ * hysteresis band, so it could only mislead. */
+const DECIMAL_ONLY = /^(?:\d+(?:\.\d*)?|\.\d+)$/;
+
+/** The typed floor as a PERCENT, exactly as the user typed it; null when the
+ * field is blank or holds something that isn't a plain decimal (a half-typed
+ * "1.2e" must not blank the list). */
+export function minAprPct(filters: OpportunityFilters): number | null {
+  const text = filters.minAprPct.trim();
+  if (text === '' || !DECIMAL_ONLY.test(text)) return null;
+  const n = Number(text);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** The same floor as a FRACTION, matching `OpportunityRow.apr`. */
+export function minApr(filters: OpportunityFilters): number | null {
+  const pct = minAprPct(filters);
+  return pct === null ? null : pct / 100;
+}
+
+/** True once anything is narrowing the list — drives the Clear affordance. */
+export const hasActiveFilter = (filters: OpportunityFilters): boolean =>
+  filters.assets.length > 0 ||
+  filters.venues.length > 0 ||
+  filters.maturities.length > 0 ||
+  minApr(filters) !== null;
+
+/** Add or remove one value from a dimension's selection. */
+export function toggleValue<T>(list: T[], value: T): T[] {
+  return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+}
+
+// ---------------------------------------------------------------------------
+// Applying + facet counts
+// ---------------------------------------------------------------------------
+
+/** The APR a card shows: one decimal place of percent (`OpportunitiesPanel`'s
+ * `(apr * 100).toFixed(1)`). */
+const displayPct = (apr: number): number => Number((apr * 100).toFixed(1));
+
+type Dimension = 'assets' | 'venues' | 'maturities' | 'minApr';
+
+const PREDICATES: Record<Dimension, (row: OpportunityRow, f: OpportunityFilters) => boolean> = {
+  assets: (row, f) => f.assets.length === 0 || f.assets.includes(row.asset),
+  venues: (row, f) => f.venues.length === 0 || row.venueKeys.some((v) => f.venues.includes(v)),
+  maturities: (row, f) => f.maturities.length === 0 || f.maturities.includes(row.maturity),
+  minApr: (row, f) => {
+    const floor = minAprPct(f);
+    // Against the APR the CARD PRINTS, not the raw fraction: 0.11996 renders
+    // "12.0% APR", and a reader who types 12 to keep everything at 12%-or-better
+    // must not watch that very card disappear.
+    return floor === null || displayPct(row.apr) >= floor;
+  },
+};
+
+const DIMENSIONS = Object.keys(PREDICATES) as Dimension[];
+
+/** Rows passing every dimension but one. Facet counts answer "how many cards
+ * would this chip leave standing", which is a question about the OTHER
+ * filters — counting a dimension against itself would just echo the selection. */
+const rowsPassing = (rows: OpportunityRow[], f: OpportunityFilters, except?: Dimension) =>
+  rows.filter((row) => DIMENSIONS.every((d) => d === except || PREDICATES[d](row, f)));
+
+export const applyFilters = (rows: OpportunityRow[], f: OpportunityFilters): OpportunityRow[] =>
+  rowsPassing(rows, f);
+
+export interface FacetOption<T> {
+  value: T;
+  label: string;
+  /** Cards this option would show, given every OTHER active filter. */
+  count: number;
+  selected: boolean;
+}
+
+export interface OpportunityFacets {
+  assets: FacetOption<string>[];
+  venues: FacetOption<string>[];
+  maturities: FacetOption<number>[];
+  /** Rows each dimension's counts were measured against. A dimension is only a
+   * CHOICE when some option leaves fewer rows than this — counting options is
+   * not enough, since every row contributes two venue keys, so a one-card list
+   * always has two venue chips that between them exclude nothing. */
+  poolSize: { assets: number; venues: number; maturities: number };
+}
+
+/**
+ * One dimension's chips. Options come from ALL viable rows plus every SELECTED
+ * value, never the filtered pool: a selected chip has to stay listed to be
+ * unselectable, and a chip that vanishes as you narrow can't be reasoned about.
+ * Seeding the selection matters across refetches too — a value that drops out
+ * of the response would otherwise take its chip with it and leave the filter
+ * armed with nothing on screen to release it.
+ */
+function facetOptions<T>(
+  all: OpportunityRow[],
+  pool: OpportunityRow[],
+  keysOf: (row: OpportunityRow) => T[],
+  label: (value: T) => string,
+  selected: T[],
+  /** Ranks the chips over EVERY viable row, not the pool: the counts move as
+   * filters change, and chips that reorder under the cursor are unclickable. */
+  rank: (a: { value: T; total: number }, b: { value: T; total: number }) => number,
+): FacetOption<T>[] {
+  const tally = (rows: OpportunityRow[]) => {
+    const counts = new Map<T, number>();
+    for (const row of rows) {
+      for (const key of keysOf(row)) counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return counts;
+  };
+  const total = tally(all);
+  for (const value of selected) if (!total.has(value)) total.set(value, 0);
+  const count = tally(pool);
+  return [...total.entries()]
+    .map(([value, t]) => ({ value, total: t }))
+    .sort(rank)
+    .map(({ value }) => ({
+      value,
+      label: label(value),
+      count: count.get(value) ?? 0,
+      selected: selected.includes(value),
+    }));
+}
+
+/** Commonest first, ties alphabetical — the reader scans the big venues first. */
+const byFrequency = <T,>(a: { value: T; total: number }, b: { value: T; total: number }) =>
+  b.total - a.total || String(a.value).localeCompare(String(b.value));
+
+/** "GATE" → "Gate", "OKX" stays upper (fmt.prettyVenue's rule, on our keys). */
+const venueLabel = (key: string): string =>
+  key.length <= 3 ? key : key.charAt(0) + key.slice(1).toLowerCase();
+
+export function facets(rows: OpportunityRow[], f: OpportunityFilters): OpportunityFacets {
+  // One pass instead of a `rows.find` per maturity option.
+  const daysByMaturity = new Map(rows.map((r) => [r.maturity, r.days]));
+  const assetPool = rowsPassing(rows, f, 'assets');
+  const venuePool = rowsPassing(rows, f, 'venues');
+  const maturityPool = rowsPassing(rows, f, 'maturities');
+  return {
+    poolSize: {
+      assets: assetPool.length,
+      venues: venuePool.length,
+      maturities: maturityPool.length,
+    },
+    assets: facetOptions(
+      rows,
+      assetPool,
+      (row) => [row.asset],
+      (asset) => asset,
+      f.assets,
+      byFrequency,
+    ),
+    venues: facetOptions(
+      rows,
+      venuePool,
+      (row) => row.venueKeys,
+      venueLabel,
+      f.venues,
+      byFrequency,
+    ),
+    maturities: facetOptions(
+      rows,
+      maturityPool,
+      (row) => [row.maturity],
+      // Chips read in the card's own unit; the exact date is the chip's title.
+      (maturity) => `${daysByMaturity.get(maturity) ?? 0}d`,
+      f.maturities,
+      // Soonest first — maturity is a timeline, not a popularity contest.
+      (a, b) => a.value - b.value,
+    ),
+  };
+}

--- a/web/src/panels/opportunityFilters.ts
+++ b/web/src/panels/opportunityFilters.ts
@@ -5,10 +5,12 @@
  * every runner-up, including ones on venues the reader can actually reach.
  *
  * This module owns the flattening, the viability rule (a card must price a
- * non-negative net APR on capital) and the facet filtering the bar drives. All
- * pure, so the panel stays a rendering concern.
+ * non-negative net APR on capital) and the facet filtering the bar drives —
+ * all pure, so the panel stays a rendering concern. The one exception is the
+ * pair at the bottom that reads and writes the persisted selection.
  */
 import type { OpportunityGroup, OpportunityPair } from '../api/types';
+import { readJson, writeJson } from '../lib/storage';
 
 /** One card's worth of data: the pair, plus the group context it renders in. */
 export interface OpportunityRow {
@@ -22,7 +24,6 @@ export interface OpportunityRow {
   asset: string;
   /** Both Boros legs' venues, upper-cased and deduped: the filter's key space. */
   venueKeys: string[];
-  maturity: number;
   /** Days to maturity, rounded exactly as the card's "(35 days)" is. */
   days: number;
 }
@@ -88,7 +89,6 @@ export function toRows(
         // selection could reunite.
         asset: group.underlying,
         venueKeys: [...new Set([venueKey(pair.shortLeg.venue), venueKey(pair.longLeg.venue)])],
-        maturity: group.maturity,
         days: maturityDays(group.secondsToMaturity),
       });
     }
@@ -112,48 +112,38 @@ export interface OpportunityFilters {
   assets: string[];
   /** Venue KEYS (see `venueKey`) — a row matches on either of its two legs. */
   venues: string[];
-  /** Group maturities, unix seconds. */
-  maturities: number[];
-  /** Raw field text, in PERCENT ("5" means 5% APR); '' = no floor. */
-  minAprPct: string;
+  /** Raw field text: the longest tenor to keep, in DAYS; '' = no cap. A tenor
+   * is a span, so it takes a number rather than picking exact maturities — the
+   * reader caps how long their capital is locked, and does not care that two
+   * cohorts happen to settle on different dates inside that span. */
+  maxDaysText: string;
 }
 
 export const NO_FILTERS: OpportunityFilters = {
   assets: [],
   venues: [],
-  maturities: [],
-  minAprPct: '',
+  maxDaysText: '',
 };
 
 /** A plain decimal, and nothing else. `Number()` alone also takes `0x10`,
  * `0o17`, `0b11`, `1e3` and a leading sign — each of which would land as a
- * silently wrong floor that `Number.isFinite` is perfectly happy with. A
- * negative floor is rejected too: no row is ever below zero by more than the
- * hysteresis band, so it could only mislead. */
+ * silently wrong cap that `Number.isFinite` is perfectly happy with. Negatives
+ * are rejected too: no row has a tenor below one day, so a negative could only
+ * blank the list without saying why. */
 const DECIMAL_ONLY = /^(?:\d+(?:\.\d*)?|\.\d+)$/;
 
-/** The typed floor as a PERCENT, exactly as the user typed it; null when the
- * field is blank or holds something that isn't a plain decimal (a half-typed
- * "1.2e" must not blank the list). */
-export function minAprPct(filters: OpportunityFilters): number | null {
-  const text = filters.minAprPct.trim();
+/** The typed tenor cap in DAYS; null when the field is blank or holds something
+ * that isn't a plain decimal (a half-typed "3e" must not blank the list). */
+export function maxDays(filters: OpportunityFilters): number | null {
+  const text = filters.maxDaysText.trim();
   if (text === '' || !DECIMAL_ONLY.test(text)) return null;
   const n = Number(text);
   return Number.isFinite(n) ? n : null;
 }
 
-/** The same floor as a FRACTION, matching `OpportunityRow.apr`. */
-export function minApr(filters: OpportunityFilters): number | null {
-  const pct = minAprPct(filters);
-  return pct === null ? null : pct / 100;
-}
-
 /** True once anything is narrowing the list — drives the Clear affordance. */
 export const hasActiveFilter = (filters: OpportunityFilters): boolean =>
-  filters.assets.length > 0 ||
-  filters.venues.length > 0 ||
-  filters.maturities.length > 0 ||
-  minApr(filters) !== null;
+  filters.assets.length > 0 || filters.venues.length > 0 || maxDays(filters) !== null;
 
 /** Add or remove one value from a dimension's selection. */
 export function toggleValue<T>(list: T[], value: T): T[] {
@@ -164,22 +154,17 @@ export function toggleValue<T>(list: T[], value: T): T[] {
 // Applying + facet counts
 // ---------------------------------------------------------------------------
 
-/** The APR a card shows: one decimal place of percent (`OpportunitiesPanel`'s
- * `(apr * 100).toFixed(1)`). */
-const displayPct = (apr: number): number => Number((apr * 100).toFixed(1));
-
-type Dimension = 'assets' | 'venues' | 'maturities' | 'minApr';
+type Dimension = 'assets' | 'venues' | 'maxDays';
 
 const PREDICATES: Record<Dimension, (row: OpportunityRow, f: OpportunityFilters) => boolean> = {
   assets: (row, f) => f.assets.length === 0 || f.assets.includes(row.asset),
   venues: (row, f) => f.venues.length === 0 || row.venueKeys.some((v) => f.venues.includes(v)),
-  maturities: (row, f) => f.maturities.length === 0 || f.maturities.includes(row.maturity),
-  minApr: (row, f) => {
-    const floor = minAprPct(f);
-    // Against the APR the CARD PRINTS, not the raw fraction: 0.11996 renders
-    // "12.0% APR", and a reader who types 12 to keep everything at 12%-or-better
-    // must not watch that very card disappear.
-    return floor === null || displayPct(row.apr) >= floor;
+  maxDays: (row, f) => {
+    const cap = maxDays(f);
+    // Against the tenor the CARD PRINTS — `row.days` is `maturityDays`, the
+    // same rounding behind "(35 days)" — so a card reading 35 survives a cap
+    // of 35 rather than being cut by hours the reader never sees.
+    return cap === null || row.days <= cap;
   },
 };
 
@@ -205,12 +190,11 @@ export interface FacetOption<T> {
 export interface OpportunityFacets {
   assets: FacetOption<string>[];
   venues: FacetOption<string>[];
-  maturities: FacetOption<number>[];
   /** Rows each dimension's counts were measured against. A dimension is only a
    * CHOICE when some option leaves fewer rows than this — counting options is
    * not enough, since every row contributes two venue keys, so a one-card list
    * always has two venue chips that between them exclude nothing. */
-  poolSize: { assets: number; venues: number; maturities: number };
+  poolSize: { assets: number; venues: number };
 }
 
 /**
@@ -252,6 +236,51 @@ function facetOptions<T>(
     }));
 }
 
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+export const OPPORTUNITY_FILTERS_STORAGE_KEY = 'crossex.opportunities.filters.v1';
+
+const stringList = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+
+/**
+ * The selection from last session.
+ *
+ * A restored filter is louder than a restored preference: it changes what is
+ * MISSING from the list, and a forgotten one reads as "there are no BTC
+ * opportunities today". Three things already standing keep that honest — the
+ * asset chips wear a ✓, the icon carries a count for the folded refinements,
+ * and a selection that now matches nothing still renders (at count 0) because
+ * `facetOptions` seeds the selected values. Restoring is safe BECAUSE of those;
+ * if any of them goes, this should go with it.
+ */
+export function loadFilters(): OpportunityFilters {
+  return readJson<OpportunityFilters>(
+    OPPORTUNITY_FILTERS_STORAGE_KEY,
+    NO_FILTERS,
+    (parsed) => {
+      const p = parsed as { assets?: unknown; venues?: unknown; maxDaysText?: unknown } | null;
+      return {
+        assets: stringList(p?.assets),
+        // Re-normalized on the way in: a blob written before `venueKey` existed
+        // — or hand-edited — must not sit in the state space as "Gate".
+        venues: stringList(p?.venues).map(venueKey),
+        // Anything unparseable restores as no cap rather than as a red field
+        // the reader never typed into.
+        maxDaysText:
+          typeof p?.maxDaysText === 'string' && maxDays({ ...NO_FILTERS, maxDaysText: p.maxDaysText }) !== null
+            ? p.maxDaysText
+            : '',
+      };
+    },
+  );
+}
+
+export const saveFilters = (filters: OpportunityFilters): void =>
+  writeJson(OPPORTUNITY_FILTERS_STORAGE_KEY, filters);
+
 /** Commonest first, ties alphabetical — the reader scans the big venues first. */
 const byFrequency = <T,>(a: { value: T; total: number }, b: { value: T; total: number }) =>
   b.total - a.total || String(a.value).localeCompare(String(b.value));
@@ -261,17 +290,10 @@ const venueLabel = (key: string): string =>
   key.length <= 3 ? key : key.charAt(0) + key.slice(1).toLowerCase();
 
 export function facets(rows: OpportunityRow[], f: OpportunityFilters): OpportunityFacets {
-  // One pass instead of a `rows.find` per maturity option.
-  const daysByMaturity = new Map(rows.map((r) => [r.maturity, r.days]));
   const assetPool = rowsPassing(rows, f, 'assets');
   const venuePool = rowsPassing(rows, f, 'venues');
-  const maturityPool = rowsPassing(rows, f, 'maturities');
   return {
-    poolSize: {
-      assets: assetPool.length,
-      venues: venuePool.length,
-      maturities: maturityPool.length,
-    },
+    poolSize: { assets: assetPool.length, venues: venuePool.length },
     assets: facetOptions(
       rows,
       assetPool,
@@ -287,16 +309,6 @@ export function facets(rows: OpportunityRow[], f: OpportunityFilters): Opportuni
       venueLabel,
       f.venues,
       byFrequency,
-    ),
-    maturities: facetOptions(
-      rows,
-      maturityPool,
-      (row) => [row.maturity],
-      // Chips read in the card's own unit; the exact date is the chip's title.
-      (maturity) => `${daysByMaturity.get(maturity) ?? 0}d`,
-      f.maturities,
-      // Soonest first — maturity is a timeline, not a popularity contest.
-      (a, b) => a.value - b.value,
     ),
   };
 }


### PR DESCRIPTION
## What

The Opportunities page showed **one card per Boros arb group**, rendered from that group's `bestPair`. But a group with three markets offers three venue combinations, and each is its own executable trade — every runner-up was invisible, including ones on the only venue a given reader can reach.

Against live data at the time: 7 cohorts, 25 pairs, 6–7 viable. The page showed **3**.

The list is now flat — one card per viable pair across every group — with a facet bar to narrow it, since going from 3 cards to 25+ is what makes a scannable list need filtering.

## The core change

The viability test moved from the group to the pair. Before:

```ts
const pair = g.bestPair ?? g.pairs[0] ?? null;
const apr  = pair?.netFixedAprOnCapital ?? null;
return apr !== null && Number.isFinite(apr) && apr >= 0;
```

After, in the new `opportunityFilters.ts`:

```ts
for (const group of groups)
  for (const pair of group.pairs)
    if (pair prices a finite, non-negative APR) → one row
```

**Nothing changed on the server for this.** It already sent every pair, ranked, in `group.pairs` — the client was collapsing them. `bestPair` is simply no longer read by this page.

Three consequences the flattening forced:

- **Identity** — the React key is now per-pair (`tokenId:maturity:shortMarketId:longMarketId`); a group can produce several cards.
- **Ordering** — the server ranks *within* a group and ranks groups against each other, neither of which orders a flat list. `toRows` reproduces the server's four-key comparator. Sorting on APR alone isn't enough: the pre-sort array is group-major, so a cross-group tie would break by group rank and float a strictly worse trade to the top.
- **Card contract** — `OpportunityCard` takes `pair` as a required prop instead of deriving it, which let the "no pairable legs" branches go.

## The filter bar

One quiet 23px line: **Asset** chips on the left — the dimension a reader scans by — then `showing N of M` and a filter icon on the right. **Venue** and a **matures within N days** cap fold behind that icon, opening in a popover anchored to it (the same shape as `trade/ClosePopover`: scrim, viewport-clamped fixed dialog, Escape / ✕ / outside-click to dismiss, focus returned to the trigger).

Each chip carries the count it would leave standing *given the other active filters*, so a dead end is visible before it's clicked. Folding a filter away risks the exact trap a vanishing chip sets — a list narrowed for no reason the reader can see — so the icon carries a count of the armed refinements to stand in for the hidden chips.

Maturity is a **span, not a set of dates**: the reader caps how long their capital is locked and doesn't care that two cohorts settle on different days inside that window. The cap compares against `row.days`, the same rounding behind the card's "(35 days)", so a card printing 30 survives a cap of 30 rather than being cut by hours it never shows.

There is no APR floor. The hero APR is what the list is already ranked by, so a second way to say "at least this much" earned little.

**Clear filters** lives in the popover, not on the bar: a chip on the bar is its own undo, and the folded filters are what actually needed a blanket release. The empty state keeps its own, since that's the case with no cards left to reason from.

The selection **persists** (`crossex.opportunities.filters.v1`). A restored filter is louder than a restored preference — it changes what's *missing* — so it leans on three things: the ✓ on a selected asset chip, the count on the icon, and a selected value that still renders at count 0 when today's data no longer has it. `loadFilters` says as much, and says to drop persistence if any of those goes. The loader re-normalizes venue keys, ignores fields from the previous shape, and restores an unparseable cap as *no cap* rather than as a red field the reader never typed into.

## Card redesign

Reworked around the longer list: an identity band (ticker + both legs) answers *what the trade is* before *what it pays*, and the APR hero sits at a fixed width so Capital / Return / Notional columnize across cards. Below `xl` the hero takes its own row, so cards keep a uniform height whether or not their notional carries a collateral-token bracket.

## Correctness work

Most of these came out of a review pass over the change:

- A selected facet chip stays listed at count 0, so a value that leaves the data can't strand an armed filter with nothing on screen to release it.
- A dimension hides only when no option would exclude anything. Counting options never worked for venues — every row carries both of its legs.
- Rows already on screen hold their place to −0.5%, so pairs hovering at zero stop flickering out and shifting every row below them mid-click.
- The Asset facet keys on the cohort underlying; keying on the leg split fungible cohorts (XAU/GOLD) across two chips no selection could reunite.
- Execute names the pair it stages, and arms the notional the response was priced at rather than the live control.
- A missing (not merely null) field dashes instead of rendering `~undefined` — the API response is cast, not validated.
- Dead-end chips use `aria-disabled`, keeping the tooltip that explains them reachable by keyboard.
- The tenor cap parses a plain decimal only; bare `Number()` also reads `0x10` as a cap of 16, and `Number.isFinite` waves it through unflagged.
- **Server:** a failed CrossEx risk-limit read now warns. One shared call backs every symbol, so an outage emptied the list while the empty state blamed the notional — advice no notional could act on. (Pre-existing; the flattening made it easier to hit.)

## Notes for reviewers

- **Two pre-existing bugs are fixed here** rather than in separate PRs, since the diff re-exposed them: the Execute-notional closure and the silent risk-limit outage. Both are called out above.
- **Several test assertions changed** because fixes legitimately invalidated them — the Execute accessible name, chips moving to `aria-disabled`, and the Venue row correctly hiding for a single-card list. That last one had been asserting the bug as intended behaviour.
- `api/types.ts`'s "never re-sort client-side" contract comment was updated; it's no longer true for a view that flattens the groups, and the replacement says what such a view must do instead.
- **Known, not addressed:** mobile (375px) overflows horizontally because `OnboardingGuide.tsx`'s `w-[360px] shrink-0` rail squeezes the content column to zero. Pre-existing and untouched by this branch.

## Verification

`yarn verify` green — 529 server/unit + 402 web tests, typecheck clean on both projects.

Also verified against live Boros data in a browser: uniform card heights and identical stat-column x at 1024 / 1180 / 1280 / 1440; Execute buttons read `Execute ETH short Hyperliquid / long Gate, ETH-margined 2026-09-25`; the popover anchors to the icon's right edge and stays in the viewport; typing a 60-day cap drops the 123-day cohort and badges the icon; dead chips stay tabbable and keep their tooltips with clicks inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
