### PR TITLE
Fix local API token disclosure in unauthenticated HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 Only substantial releases are listed here — each one bumps `version.json` (which is what the
 in-app update check compares against).
 
+## Unreleased
+
+- **The public app shell no longer exposes the local API bearer.** The installed macOS
+  launcher and Windows shortcut now read the owner-protected token file at click time and
+  pass the token in a URL fragment, without storing it in the launcher. The app removes
+  the fragment immediately, validates it through a protected read-only endpoint, and
+  saves it only after success for ordinary reloads. Unauthenticated `/` and `/index.html`
+  now contain no token to scrape and replay.
+
 ## 1.3.0 — 2026-08-07
 
 Share a position, explain a stopped deal, and a Windows service that stays hidden.
@@ -61,9 +70,9 @@ Security pass, acting on an external audit (its findings, and what remains open,
 
 - **The local API requires a token.** Binding to loopback never stopped another local
   process from trading; every `/api` route except the installer's health probe now needs a
-  per-install token stored 0600 beside your keys. Your browser gets it from the page, so the
-  bookmarked http://localhost:6688 is unchanged. Scripting the API needs the `x-arb-token`
-  header — see the README.
+  per-install token stored 0600 beside your keys. In this release the browser received it
+  from the page; the Unreleased security fix above replaces that disclosure with the
+  protected launcher bootstrap. Scripting the API needs the `x-arb-token` header — see the README.
 - **Hand-cancelling can no longer abandon a live deal.** The refusal guard now covers the
   client-text id the venue also accepts, and the window where an order is live on the venue
   before our ledger knows its id. Either path previously read as a deliberate STOP and gave up

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ press Return:
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/install.sh)"
 ```
 
-When it finishes (a few minutes the first time), the terminal opens in your browser at
-**http://localhost:6688** — bookmark it. From then on the app is always running in the
-background, even after you restart your Mac. You'll also find a **"CrossEx-Boros
-Terminal"** launcher in your `~/Applications` folder.
+When it finishes (a few minutes the first time), the **"Arbitrage with CrossEx"**
+launcher in `~/Applications` opens the terminal securely in your browser. The app stays
+running in the background, even after you restart your Mac. After that first launcher
+open, ordinary reloads and a bookmark for **<http://localhost:6688>** work too.
 
 Everything lands in one folder: `~/.boros-crossex`.
 
@@ -56,9 +56,10 @@ PowerShell** is fine — no need to install anything first). Press `Win`, type
 irm https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/install.ps1 | iex
 ```
 
-When it finishes, the terminal opens in your browser at **http://localhost:6688** —
-bookmark it. The app then starts on its own every time you sign in, and you'll find a
-**"CrossEx-Boros Terminal"** shortcut in your Start Menu.
+When it finishes, the **"Arbitrage with CrossEx"** shortcut in your Start Menu opens the
+terminal securely in your browser. The app then starts on its own every time you sign in.
+After that first shortcut open, ordinary reloads and a bookmark for
+**<http://localhost:6688>** work too.
 
 Everything lands in one folder: `%LOCALAPPDATA%\CrossEx-Boros`.
 
@@ -77,8 +78,8 @@ Everything lands in one folder: `%LOCALAPPDATA%\CrossEx-Boros`.
 - Registers a background service that keeps the app running and restarts it after crashes
   and reboots: a standard **LaunchAgent** on macOS, a per-user **Scheduled Task** on
   Windows.
-- Opens the app in your browser and creates the launcher (an app in `~/Applications`, or a
-  Start Menu shortcut).
+- Opens the app securely in your browser and creates the launcher (an app in
+  `~/Applications`, or a Start Menu shortcut).
 - **It never asks for your exchange keys in the terminal** — those are entered later, in
   the app itself.
 
@@ -113,8 +114,8 @@ for a Gate.io API key:
 
 ### Everyday use
 
-- Open **http://localhost:6688** (or the launcher app / Start Menu shortcut) any time —
-  the server is already running.
+- Open the launcher app / Start Menu shortcut any time. After its first secure open, an
+  ordinary **<http://localhost:6688>** reload or bookmark works too.
 - **Update** to the latest version by re-running the same install command for your
   platform. It stops the previous version first, so an old copy never lingers. Your keys
   and trade history are never touched by updates. When a new version is published, the
@@ -139,7 +140,7 @@ for a Gate.io API key:
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main/uninstall.sh)"
 ```
 
-Keys and trade history in `~/.boros-crossex` are kept; append ` -- --purge` to remove
+Keys and trade history in `~/.boros-crossex` are kept; append `-- --purge` to remove
 those too (or `rm -rf ~/.boros-crossex`).
 
 **Windows**
@@ -182,12 +183,16 @@ trade journal out from under a live process that is still placing orders.
   network; it does not stop another local process from simply calling the API. So every
   request that can read your account or trade must carry a random token, created on
   first run and stored — readable only by you — in `~/.boros-crossex/config/api-token`
-  (macOS) or `%LOCALAPPDATA%\CrossEx-Boros\config\api-token` (Windows). Your browser
-  gets it automatically from the page. The same limit as your keys applies, and it is
-  worth saying plainly: **anything running as you can read both.** Scripting the API
-  yourself:
+  (macOS) or `%LOCALAPPDATA%\CrossEx-Boros\config\api-token` (Windows). The public HTML
+  contains no token. Instead, the installed launcher reads the protected file when you
+  click it and opens a `#token=…` URL; URL fragments are not sent to the server. The app
+  removes the fragment immediately, validates it with a read-only protected request, and
+  only then saves it in browser storage scoped to that exact origin and port. Later
+  reloads reuse that validated value. The launcher and shortcut never store the bearer.
+  The same limit as your keys applies, and it is worth saying plainly: **anything running
+  as you can read both.** Scripting the API yourself:
   `curl -H "x-arb-token: $(cat ~/.boros-crossex/config/api-token)" http://localhost:6688/api/positions`.
-  Rotate it by deleting the file and restarting the app (open tabs then need a reload).
+  Rotate it by deleting the file, restarting the app, and opening the launcher again.
 - **It can't withdraw your funds** — and if you created the key as described above,
   Gate.io enforces that at the account level too.
 

--- a/install.ps1
+++ b/install.ps1
@@ -12,9 +12,9 @@
     3. Installs the app's dependencies and builds its web interface.
     4. Registers a background Scheduled Task so the app is always running for
        you, even after you restart Windows.
-    5. Opens http://localhost:6688 in your browser and puts a shortcut in your
-       Start Menu. Your Gate.io API keys are entered later, in the browser -
-       never in this terminal.
+    5. Opens the app securely in your browser and puts a shortcut in your Start
+       Menu. Your Gate.io API keys are entered later, in the browser - never in
+       this terminal.
 
   Re-running this command updates the app in place - it stops the previously
   running version first (including any orphaned/wedged copy), so an old version
@@ -55,6 +55,7 @@ $LogDir   = Join-Path $Root 'logs'
 
 $ServerEntry = Join-Path $Root 'app\src\server\index.ts'
 $RunnerPath  = Join-Path $Root 'run-server.ps1'
+$LauncherPath = Join-Path $Root 'open-app.ps1'
 $Tmp = $null
 
 function Say  { param([string]$m) Write-Host '==> ' -ForegroundColor Cyan -NoNewline; Write-Host $m }
@@ -637,17 +638,49 @@ the app never started listening on port $Port.
 }
 
 function New-Launcher {
-  # A plain internet shortcut in the Start Menu - nothing to sign, nothing for
-  # SmartScreen to object to.
+  # The script and shortcut contain only the token FILE path (relative to the
+  # install root). Every click reads the current owner-protected value and URL-
+  # encodes it into a fragment, which browsers never send in the HTTP request.
+  $launcherScript = @'
+param()
+$ErrorActionPreference = 'Stop'
+$tokenFile = Join-Path $PSScriptRoot 'config\api-token'
+try {
+  $apiToken = [IO.File]::ReadAllText($tokenFile).Trim()
+  if ($apiToken -cnotmatch '^[0-9a-f]{64}$') {
+    throw "The local API token is missing or invalid: $tokenFile"
+  }
+  $encodedToken = [Uri]::EscapeDataString($apiToken)
+  Start-Process "http://localhost:__PORT__/#token=$encodedToken" | Out-Null
+} catch {
+  $message = "CrossEx-Boros could not read its local API token. Re-run the installer or restart the service, then use this launcher again.`n`n$($_.Exception.Message)"
+  try {
+    $shell = New-Object -ComObject WScript.Shell
+    $null = $shell.Popup($message, 0, 'CrossEx-Boros launcher', 48)
+  } catch {}
+  Start-Process "http://localhost:__PORT__/" | Out-Null
+}
+'@
+  $launcherScript = $launcherScript.Replace('__PORT__', [string]$Port)
+  Set-Content -Path $LauncherPath -Value $launcherScript -Encoding UTF8
+
   $programs = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
   New-Item -ItemType Directory -Force -Path $programs | Out-Null
-  # Shortcuts left by a previous product name - otherwise the Start Menu keeps
-  # one entry per name this app has ever had, all pointing at the same port.
-  foreach ($legacy in $LegacyTitles) {
-    Remove-Item -Path (Join-Path $programs "$legacy.url") -Force -ErrorAction SilentlyContinue
+  # Remove both the retired .url launchers and generated .lnk launchers from
+  # every previous product name before creating the current shortcut.
+  foreach ($title in @($AppTitle) + $LegacyTitles) {
+    foreach ($extension in @('url', 'lnk')) {
+      Remove-Item -Path (Join-Path $programs "$title.$extension") -Force -ErrorAction SilentlyContinue
+    }
   }
-  $lnk = Join-Path $programs "$AppTitle.url"
-  "[InternetShortcut]`r`nURL=http://localhost:$Port`r`n" | Set-Content -Path $lnk -Encoding ASCII
+
+  $lnk = Join-Path $programs "$AppTitle.lnk"
+  $shell = New-Object -ComObject WScript.Shell
+  $shortcut = $shell.CreateShortcut($lnk)
+  $shortcut.TargetPath = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+  $shortcut.Arguments = "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$LauncherPath`""
+  $shortcut.WorkingDirectory = $Root
+  $shortcut.Save()
 }
 
 # ---------------------------------------------------------------------------
@@ -667,15 +700,15 @@ try {
   Wait-ForServer
   New-Launcher
   Write-Host ''
-  Say "Done! Opening http://localhost:$Port ..."
+  Say "Done! Opening $AppTitle ..."
   Write-Host ''
   Write-Host "  * The app now runs in the background, and starts again when you sign in."
-  Write-Host "  * Open it any time at http://localhost:$Port (bookmark it!) or via"
-  Write-Host "    `"$AppTitle`" in your Start Menu."
+  Write-Host "  * Open it any time via `"$AppTitle`" in your Start Menu."
+  Write-Host "    After that first secure launch, an ordinary http://localhost:$Port reload works too."
   Write-Host '  * First time? The app will ask for your Gate.io API keys in the browser.'
   Write-Host '  * Update any time by re-running the install command.'
   Write-Host ''
-  Start-Process "http://localhost:$Port" | Out-Null
+  & $LauncherPath
 } finally {
   Remove-Temp
 }

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@
 #   3. Installs the app's dependencies and builds its web interface.
 #   4. Registers a background service (a standard macOS "LaunchAgent") so the
 #      app is always running for you, even after you restart your Mac.
-#   5. Opens http://localhost:6688 in your browser and puts a launcher app in
+#   5. Opens the app securely in your browser and puts a launcher app in
 #      ~/Applications. Your Gate.io API keys are entered later, in the browser —
 #      never in this terminal.
 #
@@ -344,16 +344,30 @@ wait_for_server() {
 }
 
 make_launcher() {
-  # A tiny local .app that opens the terminal in your browser. Created locally,
-  # so macOS Gatekeeper has no reason to block it.
+  # The compiled app contains only the owner-protected token FILE path. Every
+  # click reads the current value, validates its shape, and transfers it in a
+  # URL fragment (never an HTTP request). A 64-character lowercase hex token is
+  # already URL-encoded byte-for-byte, so no escaping can change it.
+  #
   # The extra paths are the launcher names this app shipped under before. The
   # .app is keyed by name, so each rename would otherwise leave a stale launcher
   # in ~/Applications. APPEND the outgoing name on every rename; never replace.
   rm -rf "$HOME/Applications/$APP_TITLE.app" \
     "$HOME/Applications/CrossEx-Boros Terminal.app" \
     "$HOME/Applications/Boros CrossEx Terminal.app"
-  osacompile -e "do shell script \"open http://localhost:$PORT\"" \
-    -o "$HOME/Applications/$APP_TITLE.app" >/dev/null 2>&1 || true
+
+  local token_file escaped_token_file
+  token_file="$ROOT/config/api-token"
+  escaped_token_file="$(printf '%s' "$token_file" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+  cat > "$TMP/open-app.applescript" <<APPLESCRIPT
+on run
+  set tokenFile to "$escaped_token_file"
+  set apiToken to do shell script "/bin/cat " & quoted form of tokenFile
+  do shell script "/usr/bin/printf %s " & quoted form of apiToken & " | /usr/bin/grep -Eq '^[0-9a-f]{64}$'"
+  open location ("http://localhost:$PORT/#token=" & apiToken)
+end run
+APPLESCRIPT
+  osacompile -o "$HOME/Applications/$APP_TITLE.app" "$TMP/open-app.applescript" >/dev/null
 }
 
 main() {
@@ -371,15 +385,15 @@ main() {
   wait_for_server
   make_launcher
   echo
-  say "Done! Opening http://localhost:$PORT …"
+  say "Done! Opening $APP_TITLE …"
   echo
   echo "  • The app now runs in the background, even after you restart your Mac."
-  echo "  • Open it any time at http://localhost:$PORT (bookmark it!) or via"
-  echo "    \"$APP_TITLE\" in your ~/Applications folder."
+  echo "  • Open it any time via \"$APP_TITLE\" in your ~/Applications folder."
+  echo "    After that first secure launch, an ordinary http://localhost:$PORT reload works too."
   echo "  • First time? The app will ask for your Gate.io API keys in the browser."
   echo "  • Update any time by re-running the install command."
   echo
-  open "http://localhost:$PORT" 2>/dev/null || true
+  open "$HOME/Applications/$APP_TITLE.app" 2>/dev/null || true
 }
 
 main "$@"

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -142,8 +142,8 @@ export function buildApp(deps: AppDeps): FastifyInstance {
     }
 
     // The token gate. Scoped to /api DELIBERATELY: this hook runs before the
-    // static plugin, and the page + assets are what DELIVER the token — a
-    // broader check would 401 the very HTML that carries it.
+    // static plugin, and the public page + assets must load before the
+    // fragment bootstrap can validate a launcher-supplied token.
     //
     // /api/health stays open: the installers poll it to decide whether the
     // service came up (install.sh hard-fails on it), and it exposes nothing.
@@ -164,7 +164,7 @@ export function buildApp(deps: AppDeps): FastifyInstance {
             category: 'auth',
             message: 'missing or invalid API token',
             retryable: false,
-            hint: 'Reload the page. Scripting the API? Send the x-arb-token header — see the README.',
+            hint: 'Open the installed launcher again. Scripting the API? Send the x-arb-token header — see the README.',
           },
         });
       }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -17,7 +17,7 @@ import type { Clock, VenuePort } from '../engine/types';
 import { buildApp } from './app';
 import { TtlCache } from './cache';
 import { readOrCreateApiToken } from './authToken';
-import { tokenizedIndexHtml } from './spa';
+import { registerSpaShell } from './spa';
 import { restrictToOwner } from './secretFile';
 import { readInstallInfo, readLocalVersion } from './version';
 
@@ -138,20 +138,10 @@ const app = buildApp(appDeps);
 
 // Serve the built SPA when present (`yarn start`); in dev, Vite proxies /api here.
 if (fs.existsSync(path.join(webDist, 'index.html'))) {
-  // The HTML is served BY US so the token can be injected; the hashed assets
-  // still go through the static plugin. no-store (and no ETag) because a
-  // cached copy could otherwise revive a page carrying a stale token.
-  // @fastify/static registers only a wildcard, so these explicit routes win.
-  if (appDeps.authToken) {
-    const token = appDeps.authToken;
-    const serveIndex = async (_req: unknown, reply: { header: (k: string, v: string) => typeof reply; type: (t: string) => typeof reply; send: (b: string) => unknown }) =>
-      reply
-        .header('cache-control', 'no-store')
-        .type('text/html; charset=utf-8')
-        .send(tokenizedIndexHtml(webDist, token));
-    app.get('/', serveIndex);
-    app.get('/index.html', serveIndex);
-  }
+  // The shell is public by design but contains no credentials. The installed
+  // launcher transfers the API token in a URL fragment, which never reaches
+  // this route; the SPA validates it before saving it in origin-scoped storage.
+  registerSpaShell(app, webDist);
   app.register(fastifyStatic, { root: webDist });
 }
 

--- a/src/server/spa.ts
+++ b/src/server/spa.ts
@@ -1,23 +1,23 @@
 /**
- * Serving the SPA with its API token baked in.
+ * Register the public SPA shell without injecting install credentials.
  *
- * The browser has to learn the per-install token somehow, and the one channel
- * that needs no user action and no new URL — so the bookmarked
- * http://localhost:6688 keeps working — is the HTML the server itself hands
- * out. The page carries the token in a meta tag; the client echoes it back on
- * every /api call.
+ * GET / and /index.html must remain unauthenticated so the browser can load.
+ * The installed launcher transfers the API token in a URL fragment instead;
+ * fragments are not sent in HTTP requests.
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
-const PLACEHOLDER = '__ARB_TOKEN__';
+export function registerSpaShell(app: FastifyInstance, webDist: string): void {
+  const html = fs.readFileSync(path.join(webDist, 'index.html'), 'utf8');
+  const serveIndex = async (_request: FastifyRequest, reply: FastifyReply) =>
+    reply
+      .header('cache-control', 'no-store')
+      .type('text/html; charset=utf-8')
+      .send(html);
 
-/** index.html with the token injected. A dist built before the placeholder
- * existed still gets the meta tag inserted — an old build must degrade to
- * "works", never to "401s every request". The token is hex, so there is
- * nothing to escape. */
-export function tokenizedIndexHtml(webDist: string, token: string): string {
-  const raw = fs.readFileSync(path.join(webDist, 'index.html'), 'utf8');
-  if (raw.includes(PLACEHOLDER)) return raw.replaceAll(PLACEHOLDER, token);
-  return raw.replace('</head>', `    <meta name="arb-token" content="${token}" />\n  </head>`);
+  // @fastify/static registers only a wildcard, so these explicit routes win.
+  app.get('/', serveIndex);
+  app.get('/index.html', serveIndex);
 }

--- a/tests/server/launcher-security.test.ts
+++ b/tests/server/launcher-security.test.ts
@@ -1,0 +1,39 @@
+import * as fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+const ACTUAL_BEARER = 'deadbeef'.repeat(8);
+
+function source(name: string): string {
+  return fs.readFileSync(`${repoRoot}/${name}`, 'utf8');
+}
+
+describe('installed browser launchers', () => {
+  it('macOS launcher reads api-token at click time instead of compiling a bearer', () => {
+    const installer = source('install.sh');
+
+    expect(installer).not.toContain(ACTUAL_BEARER);
+    expect(installer).toContain('set apiToken to do shell script "/bin/cat " & quoted form of tokenFile');
+    expect(installer).toContain('open location ("http://localhost:$PORT/#token=" & apiToken)');
+    expect(installer).toContain('open "$HOME/Applications/$APP_TITLE.app"');
+    expect(installer).not.toContain('osacompile -e "do shell script \\"open http://localhost:$PORT');
+  });
+
+  it('Windows shortcut points to a click-time token reader instead of a tokenized URL', () => {
+    const installer = source('install.ps1');
+    const uninstaller = source('uninstall.ps1');
+
+    expect(installer).not.toContain(ACTUAL_BEARER);
+    expect(installer).toContain("$tokenFile = Join-Path $PSScriptRoot 'config\\api-token'");
+    expect(installer).toContain('$encodedToken = [Uri]::EscapeDataString($apiToken)');
+    expect(installer).toContain('Start-Process "http://localhost:__PORT__/#token=$encodedToken"');
+    expect(installer).toContain("$shell.Popup($message, 0, 'CrossEx-Boros launcher', 48)");
+    expect(installer).toContain('Start-Process "http://localhost:__PORT__/"');
+    expect(installer).toContain('$shortcut.Arguments = "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$LauncherPath`""');
+    expect(installer).toContain('& $LauncherPath');
+    expect(installer).not.toContain('[InternetShortcut]');
+    expect(uninstaller).toContain("$LauncherPath = Join-Path $Root 'open-app.ps1'");
+    expect(uninstaller).toContain("foreach ($extension in @('url', 'lnk'))");
+  });
+});

--- a/tests/server/spa.test.ts
+++ b/tests/server/spa.test.ts
@@ -1,0 +1,44 @@
+import { fileURLToPath } from 'node:url';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { registerSpaShell } from '../../src/server/spa';
+import { makeTestApp } from './helpers/gate-nock';
+
+const webRoot = fileURLToPath(new URL('../../web', import.meta.url));
+const BEARER = '0123456789abcdef'.repeat(4);
+
+describe('public SPA shell', () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it.each(['/', '/index.html'])('never discloses the API bearer from unauthenticated GET %s', async (url) => {
+    app = Fastify();
+    registerSpaShell(app, webRoot);
+
+    const response = await app.inject({ method: 'GET', url });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('text/html');
+    expect(response.headers['cache-control']).toBe('no-store');
+    expect(response.body).not.toContain(BEARER);
+    expect(response.body).not.toContain('__ARB_TOKEN__');
+    expect(response.body).not.toContain('name="arb-token"');
+  });
+
+  it('leaves the protected API at 401 after an unauthenticated page fetch', async () => {
+    app = makeTestApp({ authToken: BEARER });
+    registerSpaShell(app, webRoot);
+    const headers = { host: 'localhost:6688' };
+
+    const page = await app.inject({ method: 'GET', url: '/', headers });
+    expect(page.statusCode).toBe(200);
+    expect(page.body).not.toContain(BEARER);
+
+    const replay = await app.inject({ method: 'GET', url: '/api/credentials', headers });
+    expect(replay.statusCode).toBe(401);
+    expect(replay.json().error).toMatchObject({ category: 'auth', retryable: false });
+  });
+});

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -30,6 +30,7 @@ $AppTitle = 'Arbitrage with CrossEx'
 $LegacyTitles = @('CrossEx-Boros Terminal', 'Boros CrossEx Terminal')
 $ServerEntry = Join-Path $Root 'app\src\server\index.ts'
 $RunnerPath  = Join-Path $Root 'run-server.ps1'
+$LauncherPath = Join-Path $Root 'open-app.ps1'
 
 function Say { param([string]$m) Write-Host '==> ' -ForegroundColor Cyan -NoNewline; Write-Host $m }
 
@@ -165,13 +166,16 @@ foreach ($d in @('app', 'app.new', 'app.old', 'node', 'logs')) {
   $p = Join-Path $Root $d
   if (Test-Path $p) { Remove-Item -Recurse -Force $p -ErrorAction SilentlyContinue }
 }
-$runner = Join-Path $Root 'run-server.ps1'
-if (Test-Path $runner) { Remove-Item -Force $runner -ErrorAction SilentlyContinue }
+foreach ($script in @($RunnerPath, $LauncherPath)) {
+  if (Test-Path $script) { Remove-Item -Force $script -ErrorAction SilentlyContinue }
+}
 
 $programs = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
 foreach ($title in @($AppTitle) + $LegacyTitles) {
-  $lnk = Join-Path $programs "$title.url"
-  if (Test-Path $lnk) { Remove-Item -Force $lnk -ErrorAction SilentlyContinue }
+  foreach ($extension in @('url', 'lnk')) {
+    $lnk = Join-Path $programs "$title.$extension"
+    if (Test-Path $lnk) { Remove-Item -Force $lnk -ErrorAction SilentlyContinue }
+  }
 }
 
 if ($Purge) {

--- a/web/index.html
+++ b/web/index.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Arbitrage with CrossEx</title>
-    <!-- Replaced by the server with this install's API token; the client sends
-         it back on every /api call. Left as-is by the landing build. -->
-    <meta name="arb-token" content="__ARB_TOKEN__" />
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%230d0f13'/%3E%3Cpath d='M9 10h14M9 16h10M9 22h14' stroke='%2322d3ee' stroke-width='3' stroke-linecap='round'/%3E%3C/svg%3E" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,49 +1,171 @@
-/** The client attaches this install's API token to every /api call — and
- * attaches nothing when the page did not come from the terminal backend (dev,
- * where the Vite proxy adds it server-side, and the public landing build,
- * which has no token and must keep working). */
+/**
+ * The local terminal learns its bearer only from an installed-launcher
+ * fragment, validates it, then uses origin-scoped storage on later reloads.
+ * Public/dev pages and foreign origins must never send a token.
+ */
 import { http, HttpResponse } from 'msw';
-import { afterEach, describe, expect, it } from 'vitest';
-import { fetchJson } from './client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { bootstrapApiToken, fetchJson } from './client';
 import { env, server } from '../test/server';
 
-function setMeta(content: string | null): void {
-  document.head.querySelector('meta[name="arb-token"]')?.remove();
-  if (content === null) return;
-  const m = document.createElement('meta');
-  m.setAttribute('name', 'arb-token');
-  m.setAttribute('content', content);
-  document.head.appendChild(m);
+const TOKEN = 'a'.repeat(64);
+const OLD_TOKEN = 'b'.repeat(64);
+
+function memoryStorage(initial?: string) {
+  const values = new Map<string, string>();
+  if (initial) values.set('arb-api-token', initial);
+  return {
+    values,
+    storage: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        values.set(key, value);
+      },
+    },
+  };
 }
 
-/** Capture the token header the client sends on a request. */
-async function tokenSent(): Promise<string | null> {
+async function tokenSent(request = fetchJson): Promise<string | null> {
   let seen: string | null = null;
   server.use(
-    http.get('/api/health', ({ request }) => {
-      seen = request.headers.get('x-arb-token');
+    http.get('/api/health', ({ request: apiRequest }) => {
+      seen = apiRequest.headers.get('x-arb-token');
       return HttpResponse.json(env({ status: 'ok' }));
     }),
   );
-  await fetchJson('/health');
+  await request('/health');
   return seen;
 }
 
-afterEach(() => setMeta(null));
+afterEach(() => {
+  window.localStorage.clear();
+  window.history.replaceState({}, '', '/');
+  vi.restoreAllMocks();
+});
+
+describe('launcher token bootstrap', () => {
+  it('scrubs, validates, and persists an exact local fragment before using it', async () => {
+    const events: string[] = [];
+    const { storage, values } = memoryStorage();
+
+    const result = await bootstrapApiToken({
+      hostname: 'localhost',
+      hash: `#token=${TOKEN}`,
+      storage,
+      clearFragment: () => events.push('cleared'),
+      validate: async (candidate) => {
+        events.push(`validated:${candidate}`);
+        return true;
+      },
+    });
+
+    expect(events).toEqual(['cleared', `validated:${TOKEN}`]);
+    expect(result).toBe(TOKEN);
+    expect(values.get('arb-api-token')).toBe(TOKEN);
+  });
+
+  it.each([
+    ['too short', '#token=abc'],
+    ['uppercase', `#token=${'A'.repeat(64)}`],
+    ['extra fields', `#token=${TOKEN}&next=/`],
+    ['encoded text', `#token=${'%61'.repeat(64)}`],
+  ])('rejects a %s token fragment without validating it', async (_label, hash) => {
+    const validate = vi.fn(async () => true);
+    const clearFragment = vi.fn();
+    const { storage, values } = memoryStorage();
+
+    expect(await bootstrapApiToken({
+      hostname: '127.0.0.1',
+      hash,
+      storage,
+      clearFragment,
+      validate,
+    })).toBeNull();
+
+    expect(clearFragment).toHaveBeenCalledOnce();
+    expect(validate).not.toHaveBeenCalled();
+    expect(values.size).toBe(0);
+  });
+
+  it('preserves a previously validated token when a new candidate fails', async () => {
+    const { storage, values } = memoryStorage(OLD_TOKEN);
+
+    expect(await bootstrapApiToken({
+      hostname: 'localhost',
+      hash: `#token=${TOKEN}`,
+      storage,
+      clearFragment: vi.fn(),
+      validate: async () => false,
+    })).toBe(OLD_TOKEN);
+
+    expect(values.get('arb-api-token')).toBe(OLD_TOKEN);
+  });
+
+  it('scrubs but never validates, stores, or returns a bearer on a foreign origin', async () => {
+    const validate = vi.fn(async () => true);
+    const clearFragment = vi.fn();
+    const { storage, values } = memoryStorage(OLD_TOKEN);
+
+    expect(await bootstrapApiToken({
+      hostname: 'terminal.example.com',
+      hash: `#token=${TOKEN}`,
+      storage,
+      clearFragment,
+      validate,
+    })).toBeNull();
+
+    expect(clearFragment).toHaveBeenCalledOnce();
+    expect(validate).not.toHaveBeenCalled();
+    expect(values.get('arb-api-token')).toBe(OLD_TOKEN);
+  });
+
+  it('validates against protected GET /api/credentials before sending the bearer', async () => {
+    let validationMethod: string | null = null;
+    let validationToken: string | null = null;
+    let validationCredentials: RequestCredentials | null = null;
+    server.use(
+      http.get('/api/credentials', ({ request }) => {
+        validationMethod = request.method;
+        validationToken = request.headers.get('x-arb-token');
+        validationCredentials = request.credentials;
+        return HttpResponse.json(env({ configured: false, keyMasked: null }));
+      }),
+    );
+    window.history.replaceState({}, '', `/#token=${TOKEN}`);
+
+    // This test intentionally reloads the known module: fragment consumption is
+    // a module-start boundary and cannot be exercised through the static import.
+    vi.resetModules();
+    const freshClient = await import('./client');
+    expect(window.location.hash).toBe('');
+    expect(await tokenSent(freshClient.fetchJson)).toBe(TOKEN);
+    expect(validationMethod).toBe('GET');
+    expect(validationToken).toBe(TOKEN);
+    expect(validationCredentials).toBe('omit');
+    expect(window.localStorage.getItem('arb-api-token')).toBe(TOKEN);
+  });
+});
 
 describe('fetchJson auth header', () => {
-  it('sends the token from the injected meta tag', async () => {
-    setMeta('tok123');
-    expect(await tokenSent()).toBe('tok123');
+  it('uses validated origin-and-port storage on an ordinary reload', async () => {
+    window.localStorage.setItem('arb-api-token', TOKEN);
+    expect(await tokenSent()).toBe(TOKEN);
   });
 
-  it('sends nothing when there is no meta tag (landing build)', async () => {
-    setMeta(null);
+  it('sends nothing when the page has no validated local token', async () => {
     expect(await tokenSent()).toBeNull();
   });
 
-  it('sends nothing when the placeholder was never replaced (dev)', async () => {
-    setMeta('__ARB_TOKEN__');
-    expect(await tokenSent()).toBeNull();
+  it('never enables ambient cookie credentials, even when a caller requests them', async () => {
+    let credentials: RequestCredentials | null = null;
+    server.use(
+      http.get('/api/health', ({ request }) => {
+        credentials = request.credentials;
+        return HttpResponse.json(env({ status: 'ok' }));
+      }),
+    );
+
+    await fetchJson('/health', { credentials: 'include' });
+    expect(credentials).toBe('omit');
   });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -21,6 +21,20 @@ export class ApiError extends Error {
   }
 }
 
+const API_TOKEN_STORAGE_KEY = 'arb-api-token';
+const API_TOKEN_PATTERN = /^[0-9a-f]{64}$/;
+
+type TokenStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+function storedApiToken(storage: TokenStorage): string | null {
+  try {
+    const token = storage.getItem(API_TOKEN_STORAGE_KEY);
+    return token && API_TOKEN_PATTERN.test(token) ? token : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Resolve /api paths against the page origin so requests work in the browser
  * (Vite dev proxy → localhost:6688) AND in jsdom/msw tests (absolute URLs). */
 function apiUrl(path: string): string {
@@ -29,26 +43,87 @@ function apiUrl(path: string): string {
   return new URL(`/api${path}`, origin).toString();
 }
 
-/** The per-install API token, injected into index.html by the backend that
- * serves it. Absent in dev (the Vite proxy attaches the header server-side);
- * the untouched placeholder means the same thing —
- * this page did not come from the terminal backend, so send nothing. */
-function authHeader(): Record<string, string> {
-  const t =
-    typeof document === 'undefined'
-      ? null
-      : document.querySelector('meta[name="arb-token"]')?.getAttribute('content');
-  return t && t !== '__ARB_TOKEN__' ? { 'x-arb-token': t } : {};
+/**
+ * Consume a launcher fragment and return the token this page should use.
+ * Clearing happens before validation starts, so the bearer does not linger in
+ * the address bar or browser history. A failed candidate never overwrites a
+ * token that was successfully bootstrapped earlier.
+ */
+export async function bootstrapApiToken(options: {
+  hostname: string;
+  hash: string;
+  storage: TokenStorage;
+  clearFragment: () => void;
+  validate: (candidate: string) => Promise<boolean>;
+}): Promise<string | null> {
+  const local = options.hostname === 'localhost' || options.hostname === '127.0.0.1';
+  const match = local ? /^#token=([0-9a-f]{64})$/.exec(options.hash) : null;
+
+  // Scrub anything presented as a token even when malformed or on a foreign
+  // origin. Only an exact local match is ever validated or persisted.
+  if (options.hash.startsWith('#token=')) options.clearFragment();
+
+  const previous = local ? storedApiToken(options.storage) : null;
+  const candidate = match?.[1];
+  if (!candidate) return previous;
+
+  try {
+    if (!(await options.validate(candidate))) return previous;
+  } catch {
+    return previous;
+  }
+  try {
+    options.storage.setItem(API_TOKEN_STORAGE_KEY, candidate);
+  } catch {
+    // Storage can be unavailable in locked-down browsers. The validated token
+    // still authenticates this page load; the launcher can bootstrap the next.
+  }
+  return candidate;
+}
+
+const browserToken = typeof window === 'undefined'
+  ? Promise.resolve<string | null>(null)
+  : bootstrapApiToken({
+      hostname: window.location.hostname,
+      hash: window.location.hash,
+      storage: window.localStorage,
+      clearFragment: () => {
+        window.history.replaceState(window.history.state, '', `${window.location.pathname}${window.location.search}`);
+      },
+      validate: async (candidate) => {
+        try {
+          const response = await fetch(apiUrl('/credentials'), {
+            method: 'GET',
+            credentials: 'omit',
+            headers: { 'x-arb-token': candidate },
+          });
+          return response.ok;
+        } catch {
+          return false;
+        }
+      },
+    });
+
+async function authHeader(): Promise<Record<string, string>> {
+  const bootstrapped = await browserToken;
+  if (
+    typeof window === 'undefined' ||
+    (window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1')
+  ) {
+    return {};
+  }
+  const token = bootstrapped ?? storedApiToken(window.localStorage);
+  return token ? { 'x-arb-token': token } : {};
 }
 
 export async function fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {
   let resp: Response;
   try {
     resp = await fetch(apiUrl(path), {
-      credentials: 'same-origin',
       ...init,
+      credentials: 'omit',
       headers: {
-        ...authHeader(),
+        ...(await authHeader()),
         ...(init.body ? { 'content-type': 'application/json' } : {}),
         ...(init.headers ?? {}),
       },


### PR DESCRIPTION
## Problem

The local API token is stored in an owner-only file, but current main copies it into the unauthenticated HTML returned by `GET /` and `GET /index.html`. Loopback is host-scoped rather than OS-user-scoped, so another local process or account can fetch the page, extract the token, and replay it against live-money `/api/*` routes. The UI hold-to-confirm control does not protect direct API calls.

## Change

- Serve the SPA shell without embedding the bearer.
- Have installed launchers read the owner-protected token file at click time and place it in a URL fragment, which is not sent over HTTP.
- On loopback only, scrub the fragment immediately, validate the candidate through protected `GET /api/credentials`, and persist it only after success.
- Preserve an older validated token when a new candidate fails.
- Keep the existing explicit `x-arb-token`, Host/Origin, no-CORS, frame-denial, and public-health controls.
- Keep launcher artifacts free of the bearer and add visible Windows recovery when the token file is unavailable.
- Update install/uninstall paths, documentation, and focused server/web/launcher regression tests.

## Threat boundary

This closes access from other local OS accounts/processes that can reach loopback but cannot read the owner-protected config or browser profile. It does not claim protection from malware running as the owning user, root/admin, malicious browser extensions, or XSS in the trusted SPA.

## Verification

Run on the repository-supported Node 22 runtime:

- `yarn verify`
- 534 unit/server tests passed
- 369 web tests passed
- server and web TypeScript checks passed
- `git diff | gitleaks stdin --no-banner` found no secrets

The same disclosure flow remains in open PR #15, which adds Boros delegated-agent/order routes. Landing this first gives #15 a small, explicit auth rebase boundary.