### PR TITLE
Fail closed when CrossEx leverage limits are unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Only substantial releases are listed here — each one bumps `version.json` (which is what the
 in-app update check compares against).
 
+## Unreleased
+
+- **New deals no longer trust an unknown or silently clamped leverage.** Empty or
+  tierless risk-limit replies now block leverage writes before margin preflight,
+  while read-only views continue to show the maximum as unknown. A venue clamp
+  aborts deal creation and restores earlier leverage changes.
+
 ## 1.3.0 — 2026-08-07
 
 Share a position, explain a stopped deal, and a Windows service that stays hidden.
@@ -62,7 +69,7 @@ Security pass, acting on an external audit (its findings, and what remains open,
 - **The local API requires a token.** Binding to loopback never stopped another local
   process from trading; every `/api` route except the installer's health probe now needs a
   per-install token stored 0600 beside your keys. Your browser gets it from the page, so the
-  bookmarked http://localhost:6688 is unchanged. Scripting the API needs the `x-arb-token`
+  bookmarked <http://localhost:6688> is unchanged. Scripting the API needs the `x-arb-token`
   header — see the README.
 - **Hand-cancelling can no longer abandon a live deal.** The refusal guard now covers the
   client-text id the venue also accepts, and the window where an order is live on the venue

--- a/docs/REVIEW-FINDINGS.md
+++ b/docs/REVIEW-FINDINGS.md
@@ -33,10 +33,6 @@ line numbers are omitted deliberately (they drift).
   (bid+ask)/2 of the public book. When mid dislocates from the venue's mark by more than the
   band, every clip draws a hard price-limit reject and the close stops at the reject budget —
   exactly during the volatile conditions the band exists for. Honest stop + alert, no silent loss.
-- **Leverage upper bound fails open on an empty risk-limits reply** (`src/server/routes/deals.ts`):
-  a successful-but-tierless response yields max 0, which skips the bound — and the 0 is cached
-  for 10 minutes. An over-max leverage then reaches preflight, which under-reserves margin if the
-  venue clamps instead of rejecting.
 - **A sub-tick explicit re-peg BUY snaps to the string `"0"`** (`src/server/routes/deals.ts`):
   the raw input is validated `> 0`, then the directional snap floors it to `"0"`, which is truthy
   and gets pinned as the fixed intent price — burning the reject budget with a wrong recorded
@@ -102,3 +98,8 @@ line numbers are omitted deliberately (they drift).
 - **The bash installers killed by argv match alone** — an editor or `tail` holding the server
   path was SIGKILLed, and a relative-args server was missed. They now confirm by the
   process's executable and sweep the private runtime, mirroring the Windows scripts.
+- **Leverage upper bounds failed open on an empty risk-limits reply** — tierless
+  data was converted to 0 and cached for 10 minutes, and both leverage write
+  paths treated that 0 as permission to skip the maximum. Unknown caps now stay
+  absent and block writes before deal preflight; reads still report an honest
+  unknown maximum, and venue-clamped confirmations abort and roll back.

--- a/src/core/orders.ts
+++ b/src/core/orders.ts
@@ -1,6 +1,7 @@
 /** CrossEx order/domain helpers: sizing, pricing, leverage, and order construction. */
 import { CrossexLeverageRequest } from 'gate-api';
 import type { CrossExApi } from 'gate-api';
+import { CoreError } from './errors';
 import type { Clients } from './clients';
 import { coarsestLot, formatCrossPrice, roundToStep } from './numbers';
 
@@ -131,28 +132,42 @@ export function marketableClosePrice(
   return formatCrossPrice(markPrice * factor, closeSide, symbol, tickSize);
 }
 
-/** Max settable leverage per symbol (highest `leverage_max` across risk tiers).
- * One call covers many symbols (comma-joined). */
+/** Max settable leverage per symbol (highest positive `leverage_max` across
+ * risk tiers). Symbols with no usable tier stay absent: absence means unknown,
+ * never an artificial 0x cap. One call covers many symbols (comma-joined). */
 export async function getLeverageMax(crossEx: CrossExApi, symbols: string[]): Promise<Map<string, number>> {
   const { body } = await crossEx.listCrossexRuleRiskLimits(symbols.join(','));
   const map = new Map<string, number>();
   for (const r of body ?? []) {
-    const max = Math.max(0, ...(r.tiers ?? []).map((t) => Number(t.leverageMax) || 0));
-    if (r.symbol) map.set(r.symbol, max);
+    const tiers = (r.tiers ?? [])
+      .map((tier) => Number(tier.leverageMax))
+      .filter((leverage) => Number.isFinite(leverage) && leverage > 0);
+    if (r.symbol && tiers.length > 0) map.set(r.symbol, Math.max(...tiers));
   }
   return map;
 }
 
-/** Set position leverage for a symbol; returns the confirmed {symbol, leverage}. */
+/** Set position leverage and require the venue to confirm the requested value.
+ * A successful HTTP response may still carry a lower, venue-clamped leverage;
+ * treating that as success would make margin preflight under-reserve. */
 export async function setLeverage(
   crossEx: CrossExApi,
   symbol: string,
   leverage: number | string,
 ): Promise<{ symbol: string; leverage: string }> {
+  const requested = Number(leverage);
   const lev = new CrossexLeverageRequest();
   lev.symbol = symbol;
-  lev.leverage = String(Number(leverage));
+  lev.leverage = String(requested);
   const { body } = await crossEx.updateCrossexPositionsLeverage({ crossexLeverageRequest: lev });
+  const confirmed = Number(body?.leverage);
+  if (body?.symbol !== symbol || !Number.isFinite(confirmed) || confirmed !== requested) {
+    const got = Number.isFinite(confirmed) ? `${confirmed}x` : 'no verifiable leverage';
+    throw new CoreError(
+      `venue confirmed ${got} instead of requested ${requested}x for ${symbol}`,
+      'leverage',
+    );
+  }
   return body;
 }
 

--- a/src/server/routes/deals.ts
+++ b/src/server/routes/deals.ts
@@ -43,13 +43,43 @@ export function dealsRoutes(deps: AppDeps) {
           },
         });
       }
-      const body = req.body as DealRequest & { leverage?: { a?: number; b?: number } };
+      const body = req.body as DealRequest;
       if (!body?.id) throw new CoreError('deal id is required');
       // Idempotency: the client id is the dedup key — a lost-response retry
       // must never create a second deal.
       if (deps.engine!.store.getPair(body.id)) {
         return reply.code(202).ok({ id: body.id, duplicate: true });
       }
+
+      // Validate every requested leverage before resolveDeal performs its live
+      // account/rules preflight. Risk-limit absence is unknown, not permission
+      // to skip the upper bound; no venue write or intent may follow it.
+      const levs: Array<{ contract: string; lev: unknown }> = [];
+      if (body.leverage?.a !== undefined) {
+        if (typeof body.a?.symbol !== 'string') {
+          throw new CoreError('leverage leg a requires a symbol', 'validation');
+        }
+        levs.push({ contract: body.a.symbol.toUpperCase(), lev: body.leverage.a });
+      }
+      if (body.leverage?.b !== undefined) {
+        if (typeof body.b?.symbol !== 'string') {
+          throw new CoreError('leverage leg b requires a symbol', 'validation');
+        }
+        levs.push({ contract: body.b.symbol.toUpperCase(), lev: body.leverage.b });
+      }
+      for (const { contract, lev } of levs) {
+        if (typeof lev !== 'number' || !Number.isFinite(lev)) {
+          throw new CoreError(`leverage for ${contract} must be a number`, 'validation');
+        }
+        const leverageMax = await leverageMaxFor(deps, contract, false);
+        if (lev < 1 || lev > leverageMax) {
+          throw new CoreError(
+            `leverage ${lev}x must be between 1 and ${leverageMax}x for ${contract}`,
+            'leverage',
+          );
+        }
+      }
+
       const clients = deps.getClients();
       const getAccount = async () =>
         (await deps.cache.get('account', TTL.live, async () => (await clients.crossEx.getCrossexAccount()).body)).value;
@@ -62,37 +92,9 @@ export function dealsRoutes(deps: AppDeps) {
         refPriceA,
       });
 
-      // Leverage phase: applied BEFORE the intent exists — a failure aborts with
-      // nothing created and nothing sent (mirrors the abort-pre-send semantics).
-      const levs: Array<{ contract: string; lev: unknown }> = [];
-      if (body.leverage?.a) levs.push({ contract: row.a.contract, lev: body.leverage.a });
-      if (body.leverage?.b && row.b) levs.push({ contract: row.b.contract, lev: body.leverage.b });
-
-      // Validate EVERY leg before touching the venue, with the same rules the
-      // sibling PUT /leverage/:symbol enforces. These arrived as raw JSON: with
-      // no checks, {a: true} silently set 1x and {a: '50'} set 50x (setLeverage
-      // coerces with String(Number(...))), and an over-max value could be
-      // CLAMPED by the venue while create.ts's preflight sized initial margin
-      // against the number we asked for — under-reserving, which is exactly how
-      // a hedge leg gets rejected for margin and leaves the other leg naked.
-      for (const { contract, lev } of levs) {
-        if (typeof lev !== 'number' || !Number.isFinite(lev)) {
-          throw new CoreError(`leverage for ${contract} must be a number`, 'validation');
-        }
-        const leverageMax = await leverageMaxFor(deps, contract, false);
-        if (lev < 1 || (leverageMax > 0 && lev > leverageMax)) {
-          throw new CoreError(
-            `leverage ${lev}x must be between 1 and ${leverageMax}x for ${contract}`,
-            'leverage',
-          );
-        }
-      }
-
-      // Apply, remembering each leg's previous value so a partial application can
-      // be undone. Without this, leg A's leverage stayed changed after leg B's
-      // call failed and the request returned "nothing was created": a user with
-      // an existing position would have had its liquidation price moved without
-      // ever seeing it, on a deal that was never created.
+      // Apply leverage BEFORE the intent exists. Remember each leg's previous
+      // value so a partial application — including a venue clamp reported in a
+      // successful response — can be undone before aborting.
       const applied: Array<{ contract: string; prev: number }> = [];
       try {
         for (const { contract, lev } of levs) {
@@ -103,8 +105,10 @@ export function dealsRoutes(deps: AppDeps) {
           } catch {
             /* can't read it → can't restore it; recorded as 0 and skipped below */
           }
-          await setLeverage(clients.crossEx, contract, lev as number);
+          // Record before the write: setLeverage also rejects a clamped
+          // confirmation, but at that point the venue has already changed it.
           applied.push({ contract, prev });
+          await setLeverage(clients.crossEx, contract, lev as number);
         }
       } catch (err) {
         for (const { contract, prev } of applied.reverse()) {
@@ -117,6 +121,7 @@ export function dealsRoutes(deps: AppDeps) {
         }
         throw new CoreError(
           `aborted before creating the deal: leverage set failed — ${(err as Error).message}`,
+          'leverage',
         );
       }
 

--- a/src/server/routes/leverage.ts
+++ b/src/server/routes/leverage.ts
@@ -4,12 +4,20 @@ import { getLeverageMax, setLeverage } from '../../core/orders';
 import type { AppDeps } from '../app';
 import { TTL } from '../cache';
 
-/** Max settable leverage for one symbol, from the cached risk-limit tiers. */
+/** Max settable leverage for one symbol, from the cached risk-limit tiers.
+ * Unknown data is rejected rather than cached: a later read must be able to
+ * recover immediately, and write callers must never interpret unknown as 0. */
 export async function leverageMaxFor(deps: AppDeps, symbol: string, fresh: boolean): Promise<number> {
   const { value } = await deps.cache.get(
     `risk:${symbol}`,
     TTL.static,
-    async () => (await getLeverageMax(deps.getClients().crossEx, [symbol])).get(symbol) ?? 0,
+    async () => {
+      const max = (await getLeverageMax(deps.getClients().crossEx, [symbol])).get(symbol);
+      if (max === undefined) {
+        throw new CoreError(`could not verify maximum leverage for ${symbol}`, 'leverage');
+      }
+      return max;
+    },
     { fresh },
   );
   return value;
@@ -21,7 +29,9 @@ export function leverageRoutes(deps: AppDeps) {
       const symbol = (req.params as { symbol: string }).symbol.toUpperCase();
       const fresh = (req.query as { fresh?: string }).fresh === '1';
       const { body } = await deps.getClients().crossEx.getCrossexPositionsLeverage({ symbols: symbol });
-      const leverageMax = await leverageMaxFor(deps, symbol, fresh);
+      // Reads stay available when the public risk table is incomplete or down.
+      // 0 is the existing wire/UI representation of an unknown maximum.
+      const leverageMax = await leverageMaxFor(deps, symbol, fresh).catch(() => 0);
       return reply.ok({ symbol, leverage: Number(body?.[symbol] ?? 0), leverageMax });
     });
 
@@ -32,7 +42,7 @@ export function leverageRoutes(deps: AppDeps) {
         throw new CoreError('body must be { leverage: number }', 'validation');
       }
       const leverageMax = await leverageMaxFor(deps, symbol, false);
-      if (leverage < 1 || (leverageMax > 0 && leverage > leverageMax)) {
+      if (leverage < 1 || leverage > leverageMax) {
         throw new CoreError(
           `leverage ${leverage}x must be between 1 and ${leverageMax}x for ${symbol}`,
           'leverage',

--- a/src/server/routes/opportunities.ts
+++ b/src/server/routes/opportunities.ts
@@ -130,8 +130,9 @@ function ruleClient(deps: AppDeps): CrossExApi {
  * `/api/leverage` and `/api/symbols` read (so a scan warms the ticket flow), but
  * filled from ONE comma-joined `getLeverageMax` rather than a call per symbol.
  *
- * A failed read or a symbol with no row leaves that symbol absent, which nulls
- * only that pair's capital — the notional-basis numbers still price.
+ * A failed read or a symbol with no usable tier leaves that symbol absent, which
+ * nulls only that pair's capital. Unknown values are thrown out of the cache
+ * loader so an incomplete batch can never poison the shared key with 0.
  */
 async function loadLeverageMax(
   deps: AppDeps,
@@ -148,7 +149,9 @@ async function loadLeverageMax(
           TTL.static,
           async () => {
             batch ??= getLeverageMax(ruleClient(deps), symbols);
-            return (await batch).get(symbol) ?? 0;
+            const max = (await batch).get(symbol);
+            if (max === undefined) throw new Error(`no maximum leverage for ${symbol}`);
+            return max;
           },
           { fresh },
         );

--- a/src/server/routes/symbols.ts
+++ b/src/server/routes/symbols.ts
@@ -125,7 +125,7 @@ export function symbolsRoutes(deps: AppDeps) {
       const { list, stale } = await livePerps(deps, fresh);
       const info = list.find((s) => s.symbol === symbol);
       if (!info) throw new CoreError(`symbol ${symbol} not found on CrossEx`, 'symbol-invalid');
-      const leverageMax = await leverageMaxFor(deps, symbol, fresh);
+      const leverageMax = await leverageMaxFor(deps, symbol, fresh).catch(() => 0);
       return reply.ok({ ...info, leverageMax }, { stale });
     });
   };

--- a/tests/server/deals.test.ts
+++ b/tests/server/deals.test.ts
@@ -218,6 +218,50 @@ describe('POST /api/deals', () => {
     expect(w.store.listPairs()).toHaveLength(0);
   });
 
+  it('rejects unknown leverage before resolveDeal preflight and creates no pair', async () => {
+    const w = mkApp();
+    app = w.app;
+    // Deliberately no rule-symbol or account interceptors: consuming either
+    // would prove resolveDeal ran before the risk bound was verified.
+    mockGateGet('/rule/risk_limits', { body: [] });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/deals',
+      headers: HOST,
+      payload: makerPayload({ leverage: { a: 20 } }),
+    });
+
+    expect(res.statusCode, res.body).toBe(400);
+    expect(res.json().error).toMatchObject({ category: 'leverage' });
+    expect(res.json().error.message).toMatch(/could not verify maximum leverage/);
+    expect(w.store.listPairs()).toHaveLength(0);
+    expect(nock.pendingMocks()).toEqual([]);
+  });
+
+  it('validates a mixed two-leg risk batch completely before any leverage write', async () => {
+    const w = mkApp();
+    app = w.app;
+    mockGateGet('/rule/risk_limits', {
+      body: [{ symbol: A_CONTRACT, tiers: [{ leverage_max: '50' }] }],
+    });
+    mockGateGet('/rule/risk_limits', {
+      body: [{ symbol: B_CONTRACT, tiers: [] }],
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/deals',
+      headers: HOST,
+      payload: makerPayload({ leverage: { a: 20, b: 20 } }),
+    });
+
+    expect(res.statusCode, res.body).toBe(400);
+    expect(res.json().error.message).toMatch(/could not verify maximum leverage/);
+    expect(w.store.listPairs()).toHaveLength(0);
+    expect(nock.pendingMocks()).toEqual([]);
+  });
+
   // These arrive as raw JSON and were applied with no checks at all, unlike the
   // sibling PUT /leverage/:symbol which validates type, finiteness and bounds.
   it('rejects an out-of-range or non-numeric leverage before touching the venue', async () => {
@@ -266,7 +310,9 @@ describe('POST /api/deals', () => {
       .reply(function (_uri, reqBody) {
         sets.push(reqBody);
         // 1st = A→20 (ok), 2nd = B→20 (fails), 3rd = the A rollback (ok)
-        return sets.length === 2 ? [400, { label: 'RISK_LIMIT', message: 'too high' }] : [200, {}];
+        if (sets.length === 2) return [400, { label: 'RISK_LIMIT', message: 'too high' }];
+        const request = reqBody as { symbol: string; leverage: string };
+        return [200, { symbol: request.symbol, leverage: request.leverage }];
       });
 
     const res = await app.inject({
@@ -280,6 +326,43 @@ describe('POST /api/deals', () => {
     expect(w.store.listPairs()).toHaveLength(0);
     expect(sets).toHaveLength(3); // the third call is the rollback
     expect(sets[2]).toMatchObject({ symbol: A_CONTRACT, leverage: '5' }); // restored
+  });
+
+  it('detects a venue clamp, restores the prior leverage, and creates no deal', async () => {
+    const w = mkApp();
+    app = w.app;
+    mockGateGet('/rule/risk_limits', {
+      body: [{ symbol: A_CONTRACT, tiers: [{ leverage_max: '50' }] }],
+    });
+    mockGateGet('/rule/symbols', { body: simRules() });
+    mockGateGet('/accounts', { fixture: 'account.json' });
+    gate().get(/positions\/leverage/).reply(200, { [A_CONTRACT]: '5' });
+    const sets: unknown[] = [];
+    gate()
+      .post('/api/v4/crossex/positions/leverage')
+      .times(2)
+      .reply(function (_uri, reqBody) {
+        sets.push(reqBody);
+        if (sets.length === 1) {
+          return [200, { symbol: A_CONTRACT, leverage: '20' }]; // requested 50x was clamped
+        }
+        return [200, { symbol: A_CONTRACT, leverage: '5' }];
+      });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/deals',
+      headers: HOST,
+      payload: makerPayload({ leverage: { a: 50 } }),
+    });
+
+    expect(res.statusCode, res.body).toBe(400);
+    expect(res.json().error.message).toMatch(/confirmed 20x instead of requested 50x/);
+    expect(sets).toEqual([
+      expect.objectContaining({ symbol: A_CONTRACT, leverage: '50' }),
+      expect.objectContaining({ symbol: A_CONTRACT, leverage: '5' }),
+    ]);
+    expect(w.store.listPairs()).toHaveLength(0);
   });
 
   it('creates a reduce-only close deal validated against the live position', async () => {

--- a/tests/server/leverage.test.ts
+++ b/tests/server/leverage.test.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import nock from 'nock';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { HOST, makeTestApp, mockGateGet, mockGatePost } from './helpers/gate-nock';
 
 const SYMBOL = 'GATE_FUTURE_ETH_USDT';
@@ -8,6 +8,7 @@ const SYMBOL = 'GATE_FUTURE_ETH_USDT';
 describe('/api/leverage/:symbol', () => {
   let app: FastifyInstance;
   afterEach(async () => {
+    vi.useRealTimers();
     await app?.close();
   });
 
@@ -20,6 +21,37 @@ describe('/api/leverage/:symbol', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().data).toEqual({ symbol: SYMBOL, leverage: 5, leverageMax: 50 });
+  });
+
+  it('GET stays available and reports max 0 when the risk row is tierless', async () => {
+    app = makeTestApp();
+    mockGateGet('/positions/leverage', { body: { [SYMBOL]: '5' } });
+    mockGateGet('/rule/risk_limits', { body: [{ symbol: SYMBOL, tiers: [] }] });
+
+    const res = await app.inject({ method: 'GET', url: `/api/leverage/${SYMBOL}`, headers: HOST });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data).toEqual({ symbol: SYMBOL, leverage: 5, leverageMax: 0 });
+  });
+
+  it.each([
+    ['empty', []],
+    ['tierless', [{ symbol: SYMBOL, tiers: [] }]],
+  ])('PUT fails closed on an %s risk-limit reply and performs no Gate write', async (_name, limits) => {
+    app = makeTestApp();
+    mockGateGet('/rule/risk_limits', { body: limits });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: `/api/leverage/${SYMBOL}`,
+      headers: HOST,
+      payload: { leverage: 5 },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatchObject({ category: 'leverage' });
+    expect(res.json().error.message).toMatch(/could not verify maximum leverage/);
+    expect(nock.pendingMocks()).toEqual([]);
   });
 
   it('PUT over max → 400 category leverage, and no Gate write happens', async () => {
@@ -69,5 +101,37 @@ describe('/api/leverage/:symbol', () => {
     const after = await app.inject({ method: 'GET', url: '/api/positions', headers: HOST });
     expect(after.statusCode).toBe(200);
     expect(positionsScope.isDone()).toBe(true);
+  });
+
+  it('keeps a stale-good max on rate limit instead of replacing it with unknown', async () => {
+    const t0 = Date.now();
+    vi.useFakeTimers({ toFake: ['Date'], now: t0 });
+    app = makeTestApp();
+    mockGateGet('/positions/leverage', { body: { [SYMBOL]: '5' } });
+    mockGateGet('/rule/risk_limits', { fixture: 'risk-limits.json' });
+
+    const warm = await app.inject({ method: 'GET', url: `/api/leverage/${SYMBOL}`, headers: HOST });
+    expect(warm.statusCode).toBe(200);
+    expect(warm.json().data.leverageMax).toBe(50);
+
+    vi.setSystemTime(t0 + 600_001);
+    mockGateGet('/rule/risk_limits', {
+      status: 429,
+      body: { label: 'TOO_MANY_REQUESTS', message: 'slow down' },
+    });
+    const write = mockGatePost('/positions/leverage', {
+      requestBody: { symbol: SYMBOL, leverage: '50' },
+      body: { symbol: SYMBOL, leverage: '50' },
+    });
+
+    const put = await app.inject({
+      method: 'PUT',
+      url: `/api/leverage/${SYMBOL}`,
+      headers: HOST,
+      payload: { leverage: 50 },
+    });
+
+    expect(put.statusCode, put.body).toBe(200);
+    expect(write.isDone()).toBe(true);
   });
 });

--- a/tests/server/opportunities.test.ts
+++ b/tests/server/opportunities.test.ts
@@ -245,6 +245,28 @@ describe('GET /api/opportunities', () => {
     expect(group.bestPair).toBeNull();
   });
 
+  it('does not cache 0 for a tierless batch, so the next scan can recover', async () => {
+    app = makeTestApp({ borosFetch: borosStub(borosBodies()) });
+    mockGateGet('/rule/symbols', { body: ruleSymbols });
+    mockGateGet('/fee', { body: feeRows });
+    mockGateGet('/rule/risk_limits', {
+      body: riskLimits.map(({ symbol }) => ({ symbol, tiers: [] })),
+    });
+    mockVenueBooks();
+    // Rules, fees, Boros data and venue books remain warm. Only risk limits
+    // should be re-read because the first unknown values were not cached.
+    const recoveredRisk = mockGateGet('/rule/risk_limits', { body: riskLimits });
+
+    const unknown = await app.inject({ method: 'GET', url: '/api/opportunities', headers: HOST });
+    expect(unknown.statusCode).toBe(200);
+    expect(unknown.json().data.groups[0].pairs[0].capitalUsd).toBeNull();
+
+    const recovered = await app.inject({ method: 'GET', url: '/api/opportunities', headers: HOST });
+    expect(recovered.statusCode).toBe(200);
+    expect(recovered.json().data.groups[0].pairs[0].capitalUsd).toBeGreaterThan(0);
+    expect(recoveredRisk.isDone()).toBe(true);
+  });
+
   it('keeps the scan alive when the risk-limit read itself fails', async () => {
     app = makeTestApp({ borosFetch: borosStub(borosBodies()) });
     mockGateGet('/rule/symbols', { body: ruleSymbols });

--- a/tests/server/symbols.test.ts
+++ b/tests/server/symbols.test.ts
@@ -76,6 +76,23 @@ describe('GET /api/symbols', () => {
     expect(data.leverageMax).toBe(50); // max over the tiers' leverage_max (50, 20)
   });
 
+  it('GET /api/symbols/:symbol stays available with max 0 for tierless risk data', async () => {
+    app = makeTestApp();
+    mockGateGet('/rule/symbols', { fixture: 'rule-symbols.json' });
+    mockGateGet('/rule/risk_limits', {
+      body: [{ symbol: 'GATE_FUTURE_ETH_USDT', tiers: [] }],
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/symbols/GATE_FUTURE_ETH_USDT',
+      headers: HOST,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data.leverageMax).toBe(0);
+  });
+
   it('GET /api/symbols/:symbol unknown → 400 symbol-invalid envelope', async () => {
     app = makeTestApp();
     mockGateGet('/rule/symbols', { fixture: 'rule-symbols.json' });

--- a/tests/unit/orders.test.ts
+++ b/tests/unit/orders.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   direction,
+  getLeverageMax,
   resolveQty,
   isMultipleOf,
   marketableClosePrice,
@@ -70,6 +71,33 @@ describe('isMultipleOf', () => {
     [0.007, '0.0001', true],
   ])('(%d, %j) -> %s', (qty, step, want) => {
     expect(isMultipleOf(qty, step)).toBe(want);
+  });
+});
+
+describe('getLeverageMax', () => {
+  const read = async (body: unknown[]) => {
+    const crossEx = {
+      listCrossexRuleRiskLimits: async () => ({ body }),
+    } as unknown as Parameters<typeof getLeverageMax>[0];
+    return getLeverageMax(crossEx, ['A', 'B']);
+  };
+
+  it.each([
+    ['empty reply', []],
+    ['tierless row', [{ symbol: 'A', tiers: [] }]],
+    ['row with no tiers field', [{ symbol: 'A' }]],
+    ['row with no positive finite tier', [{ symbol: 'A', tiers: [{ leverageMax: '0' }, { leverageMax: 'bad' }] }]],
+  ])('keeps %s absent instead of manufacturing a 0x cap', async (_name, body) => {
+    const max = await read(body as unknown[]);
+    expect(max.has('A')).toBe(false);
+  });
+
+  it('keeps the valid symbol in a mixed batch and omits the tierless symbol', async () => {
+    const max = await read([
+      { symbol: 'A', tiers: [{ leverageMax: '10' }, { leverageMax: '25' }] },
+      { symbol: 'B', tiers: [] },
+    ]);
+    expect([...max.entries()]).toEqual([['A', 25]]);
   });
 });
 


### PR DESCRIPTION
## Problem

A successful but empty/tierless CrossEx risk-limit response becomes cap `0`, is cached for 10 minutes, and every write guard interprets `0` as `unknown, skip the upper bound`. The opportunities scanner writes the same sentinel into shared `risk:` cache keys. A leverage request can therefore pass without a verified maximum; if Gate clamps rather than rejects, deal preflight reserves margin from the requested leverage and may underfund the hedge leg.

## Change

- Keep absent/tierless limits unknown instead of converting them to a valid cached `0`.
- Fail closed for leverage writes and new leveraged deals before deal preflight or intent creation.
- Preserve honest read behavior: GET routes report unknown max as `0`/unknown rather than failing.
- Preserve stale-good cache serving across a 429.
- Prevent opportunity scans from poisoning shared risk cache keys.
- Compare `setLeverage`'s venue-confirmed value with the request; rollback prior changes and create no pair if Gate clamps.
- Move the tracked finding to the fixed section and add focused regression coverage.

Close/remediation behavior and response wire shapes are unchanged.

## Verification

- `yarn test`: 43 files, 543 tests passed
- `yarn typecheck`: passed
- Independent patch review: clean; unknown limits fail closed, stale-good values remain usable, clamp rollback creates no pair
- `git diff | gitleaks stdin --no-banner`: no secrets

This patch does not overlap the files changed by open PR #15.