### PR TITLE
Opportunities: unpack the card, and flip the tenor filter to a floor

### DIFF
--- a/web/src/panels/OpportunitiesPanel.test.tsx
+++ b/web/src/panels/OpportunitiesPanel.test.tsx
@@ -464,7 +464,7 @@ describe('OpportunitiesPanel — collapse', () => {
     expect(
       screen.getByRole('button', { name: /^Hedge the perps for ETH short Hyperliquid/ }),
     ).toBeInTheDocument();
-    expect(toggles()[0]).toHaveTextContent('Details');
+    expect(toggles()[0]).toHaveTextContent('More details');
     expect(toggles()[0]).toHaveAttribute('aria-expanded', 'false');
     expect(container.querySelector('[data-waterfall]')).toBeNull();
     expect(screen.queryByText('Boros taker fee')).not.toBeInTheDocument();
@@ -1323,18 +1323,18 @@ describe('OpportunitiesPanel — filters', () => {
     expect(chip(/^BTC 1$/)).toHaveAttribute('aria-disabled', 'false');
   });
 
-  it('caps the tenor in days, keeping the card that prints exactly that number', async () => {
+  it('floors the tenor in days, cutting the card that prints exactly that number', async () => {
     server.use(opportunitiesHandler(multiPairResult()));
     renderWithClient(<OpportunitiesPanel />);
 
     // Two 30-day ETH cards and one 90-day BTC card.
     await waitFor(() => expect(toggles()).toHaveLength(3));
     await openMoreFilters();
-    await userEvent.type(screen.getByLabelText('Matures within'), '30');
+    await userEvent.type(screen.getByLabelText('Matures in more than'), '30');
 
-    // The 90-day cohort goes; "(30 days)" is inside a 30-day cap, not outside.
-    await waitFor(() => expect(toggles()).toHaveLength(2));
-    expect(screen.queryByText('8.0% APR')).not.toBeInTheDocument();
+    // Only the 90-day cohort survives: "(30 days)" is not MORE THAN 30.
+    await waitFor(() => expect(toggles()).toHaveLength(1));
+    expect(screen.getByText('8.0% APR')).toBeInTheDocument();
   });
 
   it('offers no filter row for a dimension that cannot exclude anything', async () => {
@@ -1364,7 +1364,7 @@ describe('OpportunitiesPanel — filters', () => {
     const popover = screen.getByRole('dialog', { name: /venue, maturity and APR/i });
     expect(trigger).toHaveAttribute('aria-controls', popover.id);
     expect(within(popover).getByText('Venue')).toBeInTheDocument();
-    expect(within(popover).getByLabelText('Matures within')).toBeInTheDocument();
+    expect(within(popover).getByLabelText('Matures in more than')).toBeInTheDocument();
     // The APR floor is gone — the hero APR is what the list is already sorted
     // by, so a second way to say "at least this much" earned nothing.
     expect(within(popover).queryByLabelText('Min APR')).not.toBeInTheDocument();
@@ -1387,7 +1387,7 @@ describe('OpportunitiesPanel — filters', () => {
   it('restores last session\u2019s selection, and keeps it visible while it narrows', async () => {
     localStorage.setItem(
       OPPORTUNITY_FILTERS_STORAGE_KEY,
-      JSON.stringify({ assets: ['BTC'], venues: ['GATE'], maxDaysText: '' }),
+      JSON.stringify({ assets: ['BTC'], venues: ['GATE'], minDaysText: '' }),
     );
     server.use(opportunitiesHandler(multiPairResult()));
     renderWithClient(<OpportunitiesPanel />);
@@ -1406,7 +1406,7 @@ describe('OpportunitiesPanel — filters', () => {
     // SOL priced yesterday; today it does not.
     localStorage.setItem(
       OPPORTUNITY_FILTERS_STORAGE_KEY,
-      JSON.stringify({ assets: ['SOL'], venues: [], maxDaysText: '' }),
+      JSON.stringify({ assets: ['SOL'], venues: [], minDaysText: '' }),
     );
     server.use(opportunitiesHandler(multiPairResult()));
     renderWithClient(<OpportunitiesPanel />);
@@ -1503,7 +1503,7 @@ describe('OpportunitiesPanel — filters', () => {
 
     await waitFor(() => expect(toggles()).toHaveLength(3));
     await openMoreFilters();
-    await userEvent.type(screen.getByLabelText('Matures within'), '1');
+    await userEvent.type(screen.getByLabelText('Matures in more than'), '999');
 
     await waitFor(() =>
       expect(screen.getByText('No opportunity matches these filters')).toBeInTheDocument(),

--- a/web/src/panels/OpportunitiesPanel.tsx
+++ b/web/src/panels/OpportunitiesPanel.tsx
@@ -501,24 +501,31 @@ const OpportunityCard = memo(function OpportunityCard({
       </div>
 
       <div className="p-4">
-        {/* Stacked on phones: the shrink-0 button group is 184px, which left
-            the APR hero and the stat row ~112px to fight over and spilling. */}
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between sm:gap-5">
+        {/* Stacked on phones: the shrink-0 action column is 184px, which left
+            the APR hero and the stat row ~112px to fight over and spilling.
+            items-CENTER, not items-end: the action column runs ~22px taller
+            than the figures (two buttons over their caption), and ending them
+            together dropped that whole gap above the APR, which read as a
+            bloated top margin on every card. */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-5">
           {/* Hero + stats share one baseline (items-end): the APR leads, the
               labelled figures columnize across cards. */}
           <div className="flex min-w-0 flex-wrap items-end gap-x-7 gap-y-3">
-            {/* basis-full below xl: the hero takes its own row and the stats a
-                second one, so every card keeps the same shape at the same
+            {/* basis-full below 2xl: the hero takes its own row and the stats
+                a second one, so every card keeps the same shape at the same
                 viewport. The switch must hang on the VIEWPORT, never on fit:
                 token-margined groups render "$10k (4.16 ETH)" where USDT ones
-                render "$10k", and a fit-driven wrap would break only those
-                cards, un-aligning the list. xl is where the content column
-                (viewport less ~400px of rail chrome) fits hero + stats + the
-                buttons on one line even with the token bracket — the same
-                geometry that gates the expanded section's two-column grid. The
-                xl min-width then starts every card's stat columns at the same
-                x, however wide its APR. */}
-            <span className="flex basis-full items-baseline gap-2 xl:basis-auto xl:min-w-[15rem]">
+                render "$10k", and a fit-driven wrap breaks only those cards,
+                stranding Notional on a ragged second line while the USDT card
+                above it stays whole. 2xl, not xl: the content column is the
+                viewport less ~400px of rail chrome, and at xl that leaves ~848
+                inside the card for a row that wants ~851 with the token
+                bracket — three pixels short, which is how the ragged wrap got
+                in. (The expanded section's two-column grid stays at xl; its
+                leg boxes fit where this row does not.) The min-width then
+                starts every card's stat columns at the same x, however wide
+                its APR. */}
+            <span className="flex basis-full items-baseline gap-2 2xl:basis-auto 2xl:min-w-[15rem]">
               {capitalApr === null || !Number.isFinite(capitalApr) ? (
                 <span
                   className="num text-3xl font-bold leading-none tracking-tight text-ink-400"
@@ -595,23 +602,17 @@ const OpportunityCard = memo(function OpportunityCard({
               </Stat>
             )}
           </div>
-
+          {/* Buttons only. The sequence caption used to stack under them here,
+              which made this column ~22px taller than the figures beside it
+              and left that much dead band inside the row; it rides the footer
+              line now, still right-aligned under "Hedge the perps". With it
+              gone the two sides are naturally the same height and the row is
+              exactly as tall as its content. */}
           <div className="flex shrink-0 items-center gap-2">
-            <button
-              type="button"
-              className="btn-ghost"
-              aria-expanded={open}
-              aria-label={`${open ? 'Hide' : 'Show'} details for ${base} short ${prettyVenue(pair.shortLeg.venue)} / long ${prettyVenue(pair.longLeg.venue)}, ${group.collateral}-margined ${fmtDateUtc(group.maturity)}`}
-              disabled={detailsDisabled}
-              title={detailsTitle}
-              onClick={() => setOpen((v) => !v)}
-            >
-              {open ? 'Hide details' : 'Details'}
-            </button>
-            {/* PRIMARY — locking the fixed spread IS the trade; the perps only
-                hedge what this leg buys, so it comes first and hedging second.
-                Both carry the same identity as Details: many cards per cohort
-                now differ only by their legs. */}
+            {/* PRIMARY — locking the fixed spread IS the trade; the perps
+                only hedge what this leg buys, so it comes first and hedging
+                second. Both carry the same identity as Details: many cards
+                per cohort now differ only by their legs. */}
             <button
               type="button"
               className="btn btn-primary px-4 font-semibold"
@@ -634,9 +635,9 @@ const OpportunityCard = memo(function OpportunityCard({
                 executeTitle ?? 'Prefills the pair ticket with the two perp legs that hedge the spread'
               }
               onClick={() =>
-                // Size the perps in the Boros collateral when that IS the base
-                // coin, so the two legs match without an eyeballed conversion;
-                // USDT-margined cohorts keep the dollar figure.
+                // Size the perps in the Boros collateral when that IS the
+                // base coin, so the two legs match without an eyeballed
+                // conversion; USDT-margined cohorts keep the dollar figure.
                 pair &&
                 onExecute?.(
                   pair,
@@ -649,10 +650,34 @@ const OpportunityCard = memo(function OpportunityCard({
               Hedge the perps
             </button>
           </div>
-          {/* The sequence, stated once under the pair rather than wedged
-              between the two buttons as a floating word. Hedging before the
-              spread is locked leaves you holding naked perp exposure. */}
-          <span className="mt-1 block text-right text-[10px] text-ink-500">
+        </div>
+
+        {/* Footer line — the two quiet notes the card still owes, on one row
+            so neither costs its own band: the expand toggle left, the sequence
+            caption right under the buttons it captions. */}
+        <div className="mt-2.5 flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
+          {/* Details as a dotted-underline text link rather than a third
+              button: expanding is the quiet, reversible move and should not
+              carry the weight of the two that open positions. Still a real
+              <button> — it owns aria-expanded and must stay keyboard- and
+              screen-reader-addressable; only its chrome is gone. */}
+          <button
+            type="button"
+            className="text-xs text-ink-300 underline decoration-ink-400 decoration-dotted decoration-2 underline-offset-4 transition-colors hover:text-ink-100 hover:decoration-ink-200 disabled:cursor-not-allowed disabled:no-underline disabled:opacity-50 disabled:hover:text-ink-300"
+            aria-expanded={open}
+            aria-label={`${open ? 'Hide' : 'Show'} details for ${base} short ${prettyVenue(pair.shortLeg.venue)} / long ${prettyVenue(pair.longLeg.venue)}, ${group.collateral}-margined ${fmtDateUtc(group.maturity)}`}
+            disabled={detailsDisabled}
+            title={detailsTitle}
+            onClick={() => setOpen((v) => !v)}
+          >
+            {open ? 'Hide details' : 'More details'}
+          </button>
+          {/* ml-auto so it stays pinned right when the row wraps on a phone and
+              Details is alone on the line above. nowrap keeps the phrase whole:
+              it is one instruction, and breaking after "then" reads as two.
+              Hedging before the spread is locked leaves you holding naked perp
+              exposure. */}
+          <span className="ml-auto whitespace-nowrap text-[10px] text-ink-500">
             lock the rate first, then hedge
           </span>
         </div>

--- a/web/src/panels/OpportunityFilterBar.tsx
+++ b/web/src/panels/OpportunityFilterBar.tsx
@@ -27,7 +27,7 @@ import { useDebounced } from '../lib/useDebounced';
 import {
   facets,
   hasActiveFilter,
-  maxDays,
+  minDays,
   NO_FILTERS,
   toggleValue,
   type FacetOption,
@@ -221,7 +221,7 @@ export function OpportunityFilterBar({
   /** How many cards survive `filters` — the "showing N of M" numerator. */
   shown: number;
 }) {
-  const maxDaysId = useId();
+  const minDaysId = useId();
   const moreId = useId();
   // Asset is the dimension a reader SCANS by; venue, maturity and the APR floor
   // are refinements they reach for. Only the first stays on the line.
@@ -237,36 +237,36 @@ export function OpportunityFilterBar({
   // The field types LOCALLY and lands debounced: every keystroke straight into
   // `filters` re-renders the whole card list synchronously, which at 100 cards
   // costs ~14ms a character (and mounts rows the next character removes).
-  const [maxDaysText, setMaxDaysText] = useState(filters.maxDaysText);
-  const debouncedMaxDays = useDebounced(maxDaysText, 250);
+  const [minDaysText, setMinDaysText] = useState(filters.minDaysText);
+  const debouncedMinDays = useDebounced(minDaysText, 250);
   // What we last pushed up, so an echo of our own value is not mistaken for the
   // parent resetting the field (Clear filters).
-  const pushed = useRef(filters.maxDaysText);
+  const pushed = useRef(filters.minDaysText);
 
   useEffect(() => {
-    if (debouncedMaxDays === pushed.current) return;
-    pushed.current = debouncedMaxDays;
-    onChange({ ...filters, maxDaysText: debouncedMaxDays });
+    if (debouncedMinDays === pushed.current) return;
+    pushed.current = debouncedMinDays;
+    onChange({ ...filters, minDaysText: debouncedMinDays });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedMaxDays]);
+  }, [debouncedMinDays]);
 
   // Clear filters (or any other outside write) wins over the local text.
   useEffect(() => {
-    if (filters.maxDaysText === pushed.current) return;
-    pushed.current = filters.maxDaysText;
-    setMaxDaysText(filters.maxDaysText);
-  }, [filters.maxDaysText]);
+    if (filters.minDaysText === pushed.current) return;
+    pushed.current = filters.minDaysText;
+    setMinDaysText(filters.minDaysText);
+  }, [filters.minDaysText]);
 
   const f = facets(rows, filters);
   const active = hasActiveFilter(filters);
   // A refinement that is ACTIVE while folded away has to announce itself, or
   // the list is narrowed for no reason the reader can see — the same trap a
   // vanishing chip sets. The badge is what stands in for the hidden chips.
-  const hiddenActive = filters.venues.length + (maxDays(filters) === null ? 0 : 1);
+  const hiddenActive = filters.venues.length + (minDays(filters) === null ? 0 : 1);
   // Judged on what the reader has TYPED, not on the debounced value the list is
   // filtered by — the red border must answer the keystroke, not trail it.
-  const maxDaysBad =
-    maxDaysText.trim() !== '' && maxDays({ ...filters, maxDaysText }) === null;
+  const minDaysBad =
+    minDaysText.trim() !== '' && minDays({ ...filters, minDaysText }) === null;
 
   return (
     <div
@@ -324,27 +324,27 @@ export function OpportunityFilterBar({
             onToggle={(v) => onChange({ ...filters, venues: toggleValue(filters.venues, v) })}
           />
           <span className="flex flex-wrap items-center gap-1.5">
-            <label htmlFor={maxDaysId} className={`${microLabelClass} mr-0.5`}>
-              Matures within
+            <label htmlFor={minDaysId} className={`${microLabelClass} mr-0.5`}>
+              Matures in more than
             </label>
             <input
-              id={maxDaysId}
+              id={minDaysId}
               type="text"
               inputMode="numeric"
               autoComplete="off"
               placeholder="any"
-              value={maxDaysText}
-              onChange={(e) => setMaxDaysText(e.target.value)}
-              title="Longest tenor to keep, in days — a plain number, e.g. 60"
-              aria-invalid={maxDaysBad}
-              aria-describedby={maxDaysBad ? `${maxDaysId}-err` : undefined}
+              value={minDaysText}
+              onChange={(e) => setMinDaysText(e.target.value)}
+              title="Shortest tenor to keep, in days — a plain number, e.g. 30. A card printing exactly that many days is not more than it, so it is cut too."
+              aria-invalid={minDaysBad}
+              aria-describedby={minDaysBad ? `${minDaysId}-err` : undefined}
               className={`input num h-[26px] w-16 !px-2 !py-0 text-[11px] ${
-                maxDaysBad ? 'border-rose-500/60' : ''
+                minDaysBad ? 'border-rose-500/60' : ''
               }`}
             />
             <span className="text-[11px] text-ink-400">days</span>
-            {maxDaysBad && (
-              <span id={`${maxDaysId}-err`} role="alert" className="text-[11px] text-rose-300">
+            {minDaysBad && (
+              <span id={`${minDaysId}-err`} role="alert" className="text-[11px] text-rose-300">
                 needs a plain number
               </span>
             )}

--- a/web/src/panels/opportunityFilters.test.ts
+++ b/web/src/panels/opportunityFilters.test.ts
@@ -15,7 +15,7 @@ import {
   facets,
   hasActiveFilter,
   loadFilters,
-  maxDays,
+  minDays,
   NO_FILTERS,
   OPPORTUNITY_FILTERS_STORAGE_KEY,
   saveFilters,
@@ -177,36 +177,38 @@ describe('applyFilters', () => {
     expect(applyFilters(rows, filters({ venues: ['HYPERLIQUID'] }))).toHaveLength(2);
   });
 
-  it('caps the tenor by DAYS, inclusive of the number the card prints', () => {
+  it('floors the tenor by DAYS, EXCLUDING the number the card prints', () => {
     const rows = toRows(book());
     // The book is two 30-day ETH rows and one 90-day BTC row.
     expect(rows.map((r) => r.days)).toEqual([30, 90, 30]);
 
-    expect(applyFilters(rows, filters({ maxDaysText: '30' })).map((r) => r.days)).toEqual([30, 30]);
-    expect(applyFilters(rows, filters({ maxDaysText: '90' }))).toHaveLength(3);
-    expect(applyFilters(rows, filters({ maxDaysText: '29' }))).toHaveLength(0);
+    // "more than 30" cuts the cards printing exactly 30, not just the shorter
+    // ones — the field says more THAN, and 30 is not more than 30.
+    expect(applyFilters(rows, filters({ minDaysText: '30' })).map((r) => r.days)).toEqual([90]);
+    expect(applyFilters(rows, filters({ minDaysText: '29' }))).toHaveLength(3);
+    expect(applyFilters(rows, filters({ minDaysText: '90' }))).toHaveLength(0);
   });
 
-  it('ignores a tenor cap it cannot parse', () => {
+  it('ignores a tenor floor it cannot parse', () => {
     const rows = toRows(book());
     // A half-typed entry must never blank the list.
-    expect(applyFilters(rows, filters({ maxDaysText: '3e' }))).toHaveLength(3);
-    expect(applyFilters(rows, filters({ maxDaysText: '  ' }))).toHaveLength(3);
+    expect(applyFilters(rows, filters({ minDaysText: '3e' }))).toHaveLength(3);
+    expect(applyFilters(rows, filters({ minDaysText: '  ' }))).toHaveLength(3);
   });
 
   it('rejects every numeric literal that is not a plain decimal', () => {
     const rows = toRows(book());
     // `Number()` alone happily reads all of these, each as a silently wrong
-    // cap that Number.isFinite would wave through.
+    // floor that Number.isFinite would wave through.
     for (const text of ['0x10', '0o17', '0b11', '+5', '-5', '1e3', 'Infinity']) {
-      expect(maxDays(filters({ maxDaysText: text }))).toBeNull();
-      expect(applyFilters(rows, filters({ maxDaysText: text }))).toHaveLength(3);
-      expect(hasActiveFilter(filters({ maxDaysText: text }))).toBe(false);
+      expect(minDays(filters({ minDaysText: text }))).toBeNull();
+      expect(applyFilters(rows, filters({ minDaysText: text }))).toHaveLength(3);
+      expect(hasActiveFilter(filters({ minDaysText: text }))).toBe(false);
     }
     // Plain numbers still read, in every shape a person types them.
-    expect(maxDays(filters({ maxDaysText: '60' }))).toBe(60);
-    expect(maxDays(filters({ maxDaysText: '.5' }))).toBeCloseTo(0.5, 12);
-    expect(maxDays(filters({ maxDaysText: '30.' }))).toBe(30);
+    expect(minDays(filters({ minDaysText: '60' }))).toBe(60);
+    expect(minDays(filters({ minDaysText: '.5' }))).toBeCloseTo(0.5, 12);
+    expect(minDays(filters({ minDaysText: '30.' }))).toBe(30);
   });
 });
 
@@ -297,7 +299,8 @@ describe('facets', () => {
 
   it('lists every option even when a filter excludes it, so it stays releasable', () => {
     const rows = toRows(book());
-    const f = facets(rows, filters({ maxDaysText: '0' }));
+    // Nothing matures in more than 90 days — the longest row prints exactly 90.
+    const f = facets(rows, filters({ minDaysText: '90' }));
 
     expect(f.assets.map((o) => o.value)).toEqual(['ETH', 'BTC']);
     expect(f.assets.every((o) => o.count === 0)).toBe(true);
@@ -315,7 +318,7 @@ describe('facets', () => {
 
 describe('persistence', () => {
   it('round-trips a selection', () => {
-    const chosen = filters({ assets: ['BTC'], venues: ['GATE'], maxDaysText: '60' });
+    const chosen = filters({ assets: ['BTC'], venues: ['GATE'], minDaysText: '60' });
     saveFilters(chosen);
 
     expect(loadFilters()).toEqual(chosen);
@@ -338,14 +341,14 @@ describe('persistence', () => {
     expect(loadFilters()).toEqual(filters({ assets: ['ETH'], venues: ['GATE'] }));
   });
 
-  it('re-normalizes venue keys and drops a tenor cap it could not parse', () => {
+  it('re-normalizes venue keys and drops a tenor floor it could not parse', () => {
     localStorage.setItem(
       OPPORTUNITY_FILTERS_STORAGE_KEY,
-      JSON.stringify({ assets: [], venues: ['Gate', 'hyperliquid'], maxDaysText: '0x10' }),
+      JSON.stringify({ assets: [], venues: ['Gate', 'hyperliquid'], minDaysText: '0x10' }),
     );
 
     // Restored as a red field the reader never typed into would be worse than
-    // restored as no cap at all.
+    // restored as no floor at all.
     expect(loadFilters()).toEqual(filters({ venues: ['GATE', 'HYPERLIQUID'] }));
   });
 });
@@ -356,16 +359,16 @@ describe('filter state helpers', () => {
     expect(toggleValue(['ETH', 'BTC'], 'ETH')).toEqual(['BTC']);
   });
 
-  it('maxDays reads the cap in the same unit the rows carry', () => {
-    expect(maxDays(filters({ maxDaysText: '60' }))).toBe(60);
-    expect(maxDays(NO_FILTERS)).toBeNull();
-    expect(maxDays(filters({ maxDaysText: 'abc' }))).toBeNull();
+  it('minDays reads the floor in the same unit the rows carry', () => {
+    expect(minDays(filters({ minDaysText: '60' }))).toBe(60);
+    expect(minDays(NO_FILTERS)).toBeNull();
+    expect(minDays(filters({ minDaysText: 'abc' }))).toBeNull();
   });
 
-  it('hasActiveFilter ignores an unparseable tenor cap', () => {
+  it('hasActiveFilter ignores an unparseable tenor floor', () => {
     expect(hasActiveFilter(NO_FILTERS)).toBe(false);
     expect(hasActiveFilter(filters({ venues: ['GATE'] }))).toBe(true);
-    expect(hasActiveFilter(filters({ maxDaysText: '0' }))).toBe(true);
-    expect(hasActiveFilter(filters({ maxDaysText: 'x' }))).toBe(false);
+    expect(hasActiveFilter(filters({ minDaysText: '0' }))).toBe(true);
+    expect(hasActiveFilter(filters({ minDaysText: 'x' }))).toBe(false);
   });
 });

--- a/web/src/panels/opportunityFilters.ts
+++ b/web/src/panels/opportunityFilters.ts
@@ -112,30 +112,32 @@ export interface OpportunityFilters {
   assets: string[];
   /** Venue KEYS (see `venueKey`) — a row matches on either of its two legs. */
   venues: string[];
-  /** Raw field text: the longest tenor to keep, in DAYS; '' = no cap. A tenor
-   * is a span, so it takes a number rather than picking exact maturities — the
-   * reader caps how long their capital is locked, and does not care that two
-   * cohorts happen to settle on different dates inside that span. */
-  maxDaysText: string;
+  /** Raw field text: the shortest tenor to keep, in DAYS; '' = no floor. A
+   * tenor is a span, so it takes a number rather than picking exact maturities
+   * — the reader sets how long their capital must stay locked to be worth the
+   * trade, and does not care that two cohorts happen to settle on different
+   * dates beyond that floor. */
+  minDaysText: string;
 }
 
 export const NO_FILTERS: OpportunityFilters = {
   assets: [],
   venues: [],
-  maxDaysText: '',
+  minDaysText: '',
 };
 
 /** A plain decimal, and nothing else. `Number()` alone also takes `0x10`,
  * `0o17`, `0b11`, `1e3` and a leading sign — each of which would land as a
- * silently wrong cap that `Number.isFinite` is perfectly happy with. Negatives
- * are rejected too: no row has a tenor below one day, so a negative could only
- * blank the list without saying why. */
+ * silently wrong floor that `Number.isFinite` is perfectly happy with.
+ * Negatives are rejected too: they could only ever be a no-op, since every row
+ * has a tenor above zero. */
 const DECIMAL_ONLY = /^(?:\d+(?:\.\d*)?|\.\d+)$/;
 
-/** The typed tenor cap in DAYS; null when the field is blank or holds something
- * that isn't a plain decimal (a half-typed "3e" must not blank the list). */
-export function maxDays(filters: OpportunityFilters): number | null {
-  const text = filters.maxDaysText.trim();
+/** The typed tenor floor in DAYS; null when the field is blank or holds
+ * something that isn't a plain decimal (a half-typed "3e" must not blank the
+ * list). */
+export function minDays(filters: OpportunityFilters): number | null {
+  const text = filters.minDaysText.trim();
   if (text === '' || !DECIMAL_ONLY.test(text)) return null;
   const n = Number(text);
   return Number.isFinite(n) ? n : null;
@@ -143,7 +145,7 @@ export function maxDays(filters: OpportunityFilters): number | null {
 
 /** True once anything is narrowing the list — drives the Clear affordance. */
 export const hasActiveFilter = (filters: OpportunityFilters): boolean =>
-  filters.assets.length > 0 || filters.venues.length > 0 || maxDays(filters) !== null;
+  filters.assets.length > 0 || filters.venues.length > 0 || minDays(filters) !== null;
 
 /** Add or remove one value from a dimension's selection. */
 export function toggleValue<T>(list: T[], value: T): T[] {
@@ -154,17 +156,19 @@ export function toggleValue<T>(list: T[], value: T): T[] {
 // Applying + facet counts
 // ---------------------------------------------------------------------------
 
-type Dimension = 'assets' | 'venues' | 'maxDays';
+type Dimension = 'assets' | 'venues' | 'minDays';
 
 const PREDICATES: Record<Dimension, (row: OpportunityRow, f: OpportunityFilters) => boolean> = {
   assets: (row, f) => f.assets.length === 0 || f.assets.includes(row.asset),
   venues: (row, f) => f.venues.length === 0 || row.venueKeys.some((v) => f.venues.includes(v)),
-  maxDays: (row, f) => {
-    const cap = maxDays(f);
+  minDays: (row, f) => {
+    const floor = minDays(f);
     // Against the tenor the CARD PRINTS — `row.days` is `maturityDays`, the
-    // same rounding behind "(35 days)" — so a card reading 35 survives a cap
-    // of 35 rather than being cut by hours the reader never sees.
-    return cap === null || row.days <= cap;
+    // same rounding behind "(35 days)" — so the reader never has to reconcile
+    // a cut against hours they cannot see. Strictly greater, because the field
+    // reads "matures in more than N days": a card printing exactly 35 is not
+    // more than 35.
+    return floor === null || row.days > floor;
   },
 };
 
@@ -261,17 +265,22 @@ export function loadFilters(): OpportunityFilters {
     OPPORTUNITY_FILTERS_STORAGE_KEY,
     NO_FILTERS,
     (parsed) => {
-      const p = parsed as { assets?: unknown; venues?: unknown; maxDaysText?: unknown } | null;
+      // Only `minDaysText` is read. A blob written while this field meant a
+      // CAP carries `maxDaysText`, and reinterpreting a saved "within 30" as
+      // "more than 30" would silently hide the very rows it used to keep — so
+      // the old key is ignored and that reader restores with no tenor filter.
+      const p = parsed as { assets?: unknown; venues?: unknown; minDaysText?: unknown } | null;
       return {
         assets: stringList(p?.assets),
         // Re-normalized on the way in: a blob written before `venueKey` existed
         // — or hand-edited — must not sit in the state space as "Gate".
         venues: stringList(p?.venues).map(venueKey),
-        // Anything unparseable restores as no cap rather than as a red field
+        // Anything unparseable restores as no floor rather than as a red field
         // the reader never typed into.
-        maxDaysText:
-          typeof p?.maxDaysText === 'string' && maxDays({ ...NO_FILTERS, maxDaysText: p.maxDaysText }) !== null
-            ? p.maxDaysText
+        minDaysText:
+          typeof p?.minDaysText === 'string' &&
+          minDays({ ...NO_FILTERS, minDaysText: p.minDaysText }) !== null
+            ? p.minDaysText
             : '',
       };
     },

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -97,11 +97,6 @@
     @apply sticky top-0 z-10 whitespace-nowrap border-b border-ink-700 bg-ink-900 px-2 py-2 text-[11px] font-semibold uppercase tracking-wider text-ink-400;
   }
 
-  /* Secondary action next to a .btn-primary (the cards' "Details" toggle). */
-  .btn-ghost {
-    @apply rounded-lg border border-ink-700 bg-transparent px-3.5 py-1.5 text-sm font-medium text-ink-300 transition-colors hover:border-ink-500 hover:text-ink-100 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-ink-700 disabled:hover:text-ink-300;
-  }
-
   /* Cyan-active segmented control — the opportunity assumptions knobs. */
   .seg-cyan .seg-btn[data-active='true'] {
     @apply bg-cyan-500/15 text-cyan-300;


### PR DESCRIPTION
## What changed

**Opportunity card layout.** The cards read as packed and oversized. Three things were doing it, and they compounded:

- The action column stacked `lock the rate first, then hedge` under its two buttons, making that side of the hero row ~22px taller than the figures beside it. With `items-end`, the whole difference landed as dead space **above** the APR — that was the "big margin".
- `Details` was a third bordered button competing on the hero's line with the two that actually open positions.
- The stats row switched to one line at `xl`, but the content column there (viewport less ~400px of rail chrome) leaves ~848px inside the card for a row that wants ~851px with a collateral bracket. Three pixels short — so token-margined cohorts stranded `Notional` on a ragged second line while the USDT card above stayed whole.

Now the caption rides a footer line beside the toggle, so the two sides of the hero row are 33px and 34px and the row is exactly as tall as its content; `More details` is a dotted-underline text link rather than a button; and the one-line switch moved to `2xl`, where the row genuinely fits.

**Card height: 177px → 132px**, and every card in the list keeps the same shape at the same viewport.

`.btn-ghost` existed solely for that Details button and now has no callers, so it goes with it.

**Maturity filter → floor.** `Matures in more than N days` keeps `row.days > N`, where `Matures within N` kept `row.days <= N`.

## Reviewer notes

Three judgment calls worth a look:

1. **The filter is strictly `>`, not `>=`.** Per the field's own wording, a card printing exactly N days is not *more than* N — so a 30-day card is cut by a floor of 30. That is the opposite inclusivity from the old cap, so the boundary tests changed direction rather than just being renamed. One character to change if `at least X days` is preferred.

2. **Saved filters from before this change are dropped, deliberately.** The stored blob carries the old `maxDaysText` key; the loader now reads only `minDaysText`. Reinterpreting a saved "within 30" as "more than 30" would silently hide exactly the rows that reader had been keeping, so an old blob restores with no tenor filter. No storage-key bump needed — the parser already ignores unknown keys.

3. **The caption sits a line lower than originally asked for.** It was requested directly under `Hedge the perps`; it is now on the footer line, still right-aligned under that button. Anything stacked *inside* the action column re-inflates it to 55px and brings the dead band back, so this is the trade that makes the two sides the same height. Reverting to the tighter position is a small change if the height cost is acceptable.

`maxDaysText`/`maxDays()` are renamed to `minDaysText`/`minDays()` throughout so the names do not lie about the semantics. `Details` is still a real `<button>` — it owns `aria-expanded` and has to stay keyboard- and screen-reader-addressable; only its chrome is gone.

## Testing

- `yarn --cwd web typecheck` — clean
- `yarn --cwd web test` — 566 passed (43 files)
- Rendered the real component against the built CSS and measured the boxes at 800px and 1560px viewports, collapsed and expanded, plus the filter popover (`MATURES IN MORE THAN [any] days` fits on one line).

One note: a `PairTicket` idempotency test failed once mid-run and passed on re-run both in isolation and in a full suite. It is a timing flake in that test, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)