### PR TITLE
Send the tracked address with the share-link mint, raw and out of the link

### DIFF
--- a/src/core/boros/client.ts
+++ b/src/core/boros/client.ts
@@ -532,6 +532,9 @@ export function resolveCollateralPricesUsd(markets: BorosMarket[]): Map<number, 
 export async function createShareShortLink(
   fetchImpl: FetchLike,
   d: string,
+  /** The sharer's tracked address, lowercased — sent RAW alongside `d`, never
+   * folded into it, and never part of the resulting public link. */
+  address?: string,
 ): Promise<{ code: string; expiresAt: number }> {
   const clientTag =
     'pendle_client=boroscrossex' + clientTagState.version + (clientTagState.active ? '_active' : '');
@@ -541,7 +544,7 @@ export async function createShareShortLink(
     resp = await fetchImpl(url, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ d }),
+      body: JSON.stringify(address ? { d, address } : { d }),
       // Snappier than the read timeout: the modal already shows the long link,
       // a short link that takes this long isn't worth upgrading to.
       signal: AbortSignal.timeout(10_000),

--- a/src/server/routes/shareLink.ts
+++ b/src/server/routes/shareLink.ts
@@ -7,6 +7,8 @@ import { TTL } from '../cache';
 /** Same cheap gate the backend applies — reject junk locally instead of
  * spending a round-trip on it. Real payloads are ~600-900 chars. */
 const BASE64URL_RE = /^[A-Za-z0-9_-]{1,4096}$/;
+/** Mirrors the terminal's own address gate (web HomeControls, routes/strategy). */
+const EVM_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
 
 /**
  * POST /api/share-link — turn a long share payload into a short code.
@@ -18,17 +20,34 @@ const BASE64URL_RE = /^[A-Za-z0-9_-]{1,4096}$/;
  * within the window costs nothing. Any upstream failure surfaces as the usual
  * error envelope; the modal treats that as "no short link" and keeps the long
  * `?d=` URL, which always works.
+ *
+ * The optional `address` is the sharer's tracked wallet, forwarded RAW next to
+ * the payload (never encoded into it — the wire format has no address field and
+ * the resulting link is public). The backend stores it beside the code so a
+ * shared position can later be checked against what that wallet held. It also
+ * takes part in the code's content address, so it is part of the cache key.
  */
 export function shareLinkRoutes(deps: AppDeps) {
   const fetchImpl = resolveBorosFetch(deps.borosFetch);
   return async function plugin(app: FastifyInstance): Promise<void> {
     app.post('/share-link', async (req, reply) => {
-      const d = (req.body as Record<string, unknown> | null)?.d;
+      const body = req.body as Record<string, unknown> | null;
+      const d = body?.d;
       if (typeof d !== 'string' || !BASE64URL_RE.test(d)) {
         throw new CoreError('share-link needs a base64url `d` payload', 'validation');
       }
-      const { value } = await deps.cache.get(`share-link:${d}`, TTL.shareLink, () =>
-        createShareShortLink(fetchImpl, d),
+      // A malformed address DROPS rather than fails: the backend would 400 the
+      // whole request, the modal would silently fall back to the long link, and
+      // the user would lose the short link over a field they never see. Losing
+      // the attribution is the smaller harm — and the terminal only ever stores
+      // an address that already passed the same regex.
+      const rawAddress = body?.address;
+      const address =
+        typeof rawAddress === 'string' && EVM_ADDRESS_RE.test(rawAddress)
+          ? rawAddress.toLowerCase()
+          : undefined;
+      const { value } = await deps.cache.get(`share-link:${address ?? ''}:${d}`, TTL.shareLink, () =>
+        createShareShortLink(fetchImpl, d, address),
       );
       return reply.ok(value);
     });

--- a/tests/server/share-link.test.ts
+++ b/tests/server/share-link.test.ts
@@ -11,6 +11,7 @@ import type { FetchLike } from '../../src/core/boros/client';
 import { HOST, makeTestApp } from './helpers/gate-nock';
 
 const D = 'eyJ2IjoxfQ'; // base64url of {"v":1} — the route forwards, it doesn't decode
+const ADDR = '0xAbC0000000000000000000000000000000000123';
 
 type Call = { url: string; method?: string; body?: string };
 
@@ -46,6 +47,44 @@ describe('POST /api/share-link', () => {
       /^https:\/\/api-boros\.pendle\.finance\/apis\/v1\/crossex\/shared-positions\?pendle_client=boroscrossex/,
     );
     expect(calls[0].method).toBe('POST');
+    expect(JSON.parse(calls[0].body ?? '')).toEqual({ d: D });
+  });
+
+  it('forwards the tracked address raw, lowercased, beside the payload', async () => {
+    const calls: Call[] = [];
+    app = makeTestApp({ borosFetch: stub({ code: 'Abc123_-xyz', expiresAt: 42 }, { calls }) });
+    const res = await post({ d: D, address: ADDR });
+    expect(res.statusCode).toBe(200);
+    // Raw field, NOT folded into `d` — the payload the backend stores is
+    // byte-identical to the address-less one, so the public link is unchanged.
+    expect(JSON.parse(calls[0].body ?? '')).toEqual({ d: D, address: ADDR.toLowerCase() });
+  });
+
+  it('caches per (address, payload) — one sharer\'s code is never served to another', async () => {
+    const calls: Call[] = [];
+    const other = '0x1111111111111111111111111111111111111111';
+    app = makeTestApp({ borosFetch: stub({ code: 'Abc123_-xyz', expiresAt: 42 }, { calls }) });
+    await post({ d: D, address: ADDR });
+    await post({ d: D, address: ADDR });
+    expect(calls).toHaveLength(1); // same sharer, same payload → cache hit
+    await post({ d: D, address: other });
+    await post({ d: D }); // no address at all is its own key too
+    expect(calls).toHaveLength(3);
+    expect(JSON.parse(calls[1].body ?? '')).toEqual({ d: D, address: other });
+    expect(JSON.parse(calls[2].body ?? '')).toEqual({ d: D });
+  });
+
+  it('drops an unusable address instead of failing the mint', async () => {
+    const calls: Call[] = [];
+    app = makeTestApp({ borosFetch: stub({ code: 'Abc123_-xyz', expiresAt: 42 }, { calls }) });
+    for (const address of [42, '0xnope', `${ADDR}00`, '']) {
+      const res = await post({ d: D, address });
+      // The short link still mints — losing the attribution beats losing the
+      // link over a field the user never sees.
+      expect(res.statusCode).toBe(200);
+      expect(res.json().data.code).toBe('Abc123_-xyz');
+    }
+    expect(calls).toHaveLength(1); // all four collapse onto the address-less key
     expect(JSON.parse(calls[0].body ?? '')).toEqual({ d: D });
   });
 

--- a/web/src/panels/SharePositionModal.test.tsx
+++ b/web/src/panels/SharePositionModal.test.tsx
@@ -6,10 +6,15 @@ import { ToastProvider } from '../components/Toast';
 import { fmtDateUtc } from '../lib/fmt';
 import { buildShareUrl, buildShortShareUrl } from '../lib/share';
 import { renderShareCard } from '../lib/shareCard';
-import { decodeSharePayload } from '../lib/shareCodec';
+import { decodeSharePayload, encodeSharePayload } from '../lib/shareCodec';
+import { writeJson } from '../lib/storage';
 import { makeSharePayload } from '../test/fixtures';
 import { env, server } from '../test/server';
+import { loadStored, STRATEGY_STORAGE_KEY } from './HomeControls';
 import { SharePositionModal } from './SharePositionModal';
+import { TrackedAddressProvider } from './trackedAddress';
+
+const TRACKED = '0xAbC0000000000000000000000000000000000123';
 
 // jsdom has no 2D canvas — stub the renderer with a canvas-shaped object.
 vi.mock('../lib/shareCard', () => ({
@@ -27,6 +32,19 @@ const mount = () =>
       <SharePositionModal payload={payload} onClose={() => {}} />
     </ToastProvider>,
   );
+
+/** Same modal, but inside the provider and with an address already tracked —
+ * the only difference the mint call should see. */
+const mountTracked = () => {
+  writeJson(STRATEGY_STORAGE_KEY, { ...loadStored(), address: TRACKED });
+  return render(
+    <ToastProvider>
+      <TrackedAddressProvider>
+        <SharePositionModal payload={payload} onClose={() => {}} />
+      </TrackedAddressProvider>
+    </ToastProvider>,
+  );
+};
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -91,6 +109,41 @@ describe('SharePositionModal', () => {
     mount();
     expect(screen.getByText(/X can't attach an image from a link/)).toBeInTheDocument();
     expect(screen.getByText(/wallet address is not part of the link/)).toBeInTheDocument();
+    // The address is not in the link, but it IS recorded — say both.
+    expect(screen.getByText(/does store\s+your address with the short code/)).toBeInTheDocument();
+  });
+
+  it('sends the tracked address raw alongside the payload — never inside it', async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    server.use(
+      http.post('*/api/share-link', async ({ request }) => {
+        bodies.push((await request.json()) as Record<string, unknown>);
+        return HttpResponse.json(env({ code: 'Abc123_-xyz', expiresAt: 0 }));
+      }),
+    );
+    mountTracked();
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(bodies[0].address).toBe(TRACKED);
+    // The payload is byte-identical to the address-less one, so the public
+    // link never carries the wallet.
+    expect(bodies[0].d).toBe(encodeSharePayload(payload));
+    const input = screen.getByLabelText('Position share link') as HTMLInputElement;
+    await waitFor(() => expect(input.value).toBe(buildShortShareUrl('Abc123_-xyz')));
+    expect(input.value).not.toContain(TRACKED.toLowerCase());
+    expect(input.value).not.toContain(TRACKED);
+  });
+
+  it('omits the address entirely when none is tracked', async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    server.use(
+      http.post('*/api/share-link', async ({ request }) => {
+        bodies.push((await request.json()) as Record<string, unknown>);
+        return HttpResponse.json(env({ code: 'Abc123_-xyz', expiresAt: 0 }));
+      }),
+    );
+    mount(); // no provider at all — the modal must still mint
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(Object.keys(bodies[0])).toEqual(['d']);
   });
 
   it('upgrades the link (and the X intent) to the short URL once the backend mints a code', async () => {

--- a/web/src/panels/SharePositionModal.tsx
+++ b/web/src/panels/SharePositionModal.tsx
@@ -10,6 +10,7 @@ import { useToast } from '../components/Toast';
 import { buildShareUrl, buildShortShareUrl, buildXIntentUrl, shareFileName } from '../lib/share';
 import { renderShareCard } from '../lib/shareCard';
 import { encodeSharePayload, type SharePayloadV1 } from '../lib/shareCodec';
+import { useTrackedAddressOptional } from './trackedAddress';
 
 /** `ClipboardItem` accepts a Blob PROMISE — and Safari in fact requires the
  * promise form (constructing after an await loses the user gesture). */
@@ -18,6 +19,12 @@ const canCopyImage = () =>
 
 export function SharePositionModal({ payload, onClose }: { payload: SharePayloadV1; onClose: () => void }) {
   const toast = useToast();
+  // The tracked address rides ALONGSIDE the payload when the code is minted —
+  // never inside it. The wire format has no address field by construction and
+  // the link is posted in public; this travels raw in the POST body, is stored
+  // next to the code, and is never echoed by the resolve endpoint. It exists so
+  // a share code can be checked against what that wallet actually held.
+  const trackedAddress = useTrackedAddressOptional()?.address ?? null;
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [dataUrl, setDataUrl] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
@@ -44,7 +51,7 @@ export function SharePositionModal({ payload, onClose }: { payload: SharePayload
     } catch {
       return;
     }
-    postJson<{ code: string }>('/share-link', { d })
+    postJson<{ code: string }>('/share-link', trackedAddress ? { d, address: trackedAddress } : { d })
       .then((r) => {
         if (!cancelled && r?.code) setShortUrl(buildShortShareUrl(r.code));
       })
@@ -52,7 +59,7 @@ export function SharePositionModal({ payload, onClose }: { payload: SharePayload
     return () => {
       cancelled = true;
     };
-  }, [payload]);
+  }, [payload, trackedAddress]);
 
   const shareUrl = shortUrl ?? longUrl;
 
@@ -118,7 +125,9 @@ export function SharePositionModal({ payload, onClose }: { payload: SharePayload
         <p className="text-xs leading-relaxed text-ink-500">
           X can't attach an image from a link — the post opens pre-filled with your link; download
           or copy the image and add it in the compose window. Your wallet address is not part of
-          the link or the image, and leg details are rounded to display precision.
+          the link or the image, and leg details are rounded to display precision. Pendle does store
+          your address with the short code, so a shared position can be checked for incentive
+          campaigns.
         </p>
 
         {shareUrl && (


### PR DESCRIPTION
## Why

The short code is becoming the handle for an incentive campaign, so it needs to know whose position it was. The wire payload has no address field **by construction** — that's what keeps the public link and the share card wallet-free — so the address travels as a separate raw field in the mint request.

Pairs with pendle-finance/pendle-backend-v3#3223, which stores it beside the code. **Merge that one first.**

## What

```
modal  ──{ d, address }──>  POST /api/share-link  ──>  /apis/v1/crossex/shared-positions
```

- The modal reads the tracked Boros address via `useTrackedAddressOptional()` and adds it to the mint body.
- The local proxy validates it against the same `EVM_ADDRESS_RE` the rest of the terminal uses, lowercases it, and folds it into the TTL cache key — so one sharer's code is never handed to another.
- `createShareShortLink(fetch, d, address?)` forwards it.

The `?s=<code>` link is byte-for-byte what it was. The address is **optional** at every layer: no address tracked (perp-only boxes, a fresh install) still mints a code exactly as before.

### A bad address drops, it doesn't fail

The backend 400s a malformed address, the modal swallows mint failures silently, and the user would lose their short link over a field they never see. So the proxy drops an unusable address and mints anyway — losing the attribution is the smaller harm, and the terminal only ever stores an address that already passed this same regex.

### Privacy copy

The modal's note used to read "your wallet address is not part of the link or the image", full stop. That's still true but no longer the whole truth, so it now says both halves: not in the link or image, **and** Pendle does store it against the short code.

## Verification

`yarn verify` green — 814 server/unit + 568 web — plus `yarn --cwd web build` (the step CI runs beyond verify). 5 new tests:

- forwards the address raw and lowercased, beside the payload
- caches per (address, payload) — one sharer's code is never served to another
- drops an unusable address instead of failing the mint
- sends the tracked address raw alongside the payload, never inside it — asserts the resulting link contains the wallet in neither case
- omits the address entirely when none is tracked (modal mounted with no provider at all)

## Deploy order

Backend PR #3223 first. An old backend with this build is safe — `whitelist: true` strips the undeclared field — but silently drops the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015RM73sjLSN5PArJeCyvvX8