### PR TITLE
Hand-grouped positions: forget closed legs, hold one maturity, and stop a close crossing past flat

### DIFF
--- a/src/core/boros/borosApi.ts
+++ b/src/core/boros/borosApi.ts
@@ -190,6 +190,25 @@ export function decimalString(n: number): string {
   return n.toFixed(DECIMALS).replace(/(\.\d*?)0+$/, '$1').replace(/\.$/, '');
 }
 
+/**
+ * The venue's own 18-decimal size as a magnitude, or null when it is not an
+ * integer this can trust.
+ *
+ * Deliberately strict, and matched by a REGEX rather than left to `BigInt`:
+ * `BigInt('')` is `0n`, not a throw, so an absent field would have become a
+ * cap of ZERO and truncated the close to nothing — the opposite failure, and a
+ * worse one. Anything that is not a plain integer literal (a decimal point,
+ * exponent notation, an empty string) means the field is not the shape this
+ * cap assumes, and inventing a ceiling out of it beats having none only if it
+ * is right.
+ */
+export function absWei(raw: string): bigint | null {
+  const t = raw.trim();
+  if (!/^-?\d+$/.test(t)) return null;
+  const n = BigInt(t);
+  return n < 0n ? -n : n;
+}
+
 // ---------------------------------------------------------------------------
 // Wire shapes (only the fields this module reads)
 // ---------------------------------------------------------------------------
@@ -479,7 +498,7 @@ export function makeBorosApiOrderClient(config: BorosApiConfig): BorosOrderClien
         marketAcc: await marketAccFor(req.marketId),
         marketId: req.marketId,
         side: req.direction === 'long' ? SIDE_LONG : SIDE_SHORT,
-        size: parseUnits(decimalString(req.size), DECIMALS).toString(),
+        size: (req.sizeWei ?? parseUnits(decimalString(req.size), DECIMALS)).toString(),
         tif: TIF_IOC,
         // The worst rate this leg accepts. `slippage` is deliberately NOT sent
         // alongside: the backend derives its guard from mid ± slippage, which
@@ -643,8 +662,26 @@ export function makeBorosApiOrderClient(config: BorosApiConfig): BorosOrderClien
      * A close is an ordinary opposing market order — Boros has no close
      * primitive and no reduce-only flag — so it goes out on exactly the same
      * path as any other leg and reports its fill and shortfall the same way.
+     *
+     * ⚠ WHICH IS WHY THE CAP HAS TO BE APPLIED HERE, IN WEI.
+     *
+     * With no reduce-only flag, nothing at the venue stops a close at flat:
+     * an order one unit larger than the position crosses it and opens a fresh
+     * one the other way. The route already clamps the size to what is open,
+     * but it clamps two DOUBLES — and the order is not built from a double.
+     * `parseUnits(decimalString(50000000000000000 / 1e18))` is
+     * 50000000000000003, so a clean 0.05 close asked for three units more
+     * than existed and left a 3-unit opposing position behind. Too small to
+     * see, too small to close again (the venue refuses orders under $10 of
+     * notional), and reported as "closed" because in float space the two
+     * numbers were equal.
+     *
+     * So the float is only ever allowed to make the order SMALLER here. The
+     * venue's own integer is the ceiling, and it is never re-derived.
      */
     async closePosition(req: BorosClosePositionRequest): Promise<BorosLegFill> {
+      const asked = parseUnits(decimalString(req.size), DECIMALS);
+      const open = absWei(req.openSizeWei);
       const [fill] = await placeMarketOrders([
         {
           marketId: req.marketId,
@@ -652,6 +689,11 @@ export function makeBorosApiOrderClient(config: BorosApiConfig): BorosOrderClien
           size: req.size,
           limitApr: req.limitApr,
           clientOrderId: req.clientOrderId,
+          // A cap we could not read is no cap: fall back to the float the
+          // route already clamped, which is exactly the old behaviour rather
+          // than a new failure. `openSizeWei` is the venue's own field, so
+          // this is a shape change on their side, not a routine case.
+          ...(open === null ? {} : { sizeWei: (asked < open ? asked : open).toString() }),
         },
       ]);
       return fill;

--- a/src/core/boros/orders.ts
+++ b/src/core/boros/orders.ts
@@ -52,6 +52,19 @@ export interface BorosMarketOrderRequest {
    * lost response resent by the same process and nothing wider.
    */
   clientOrderId: string;
+  /**
+   * The EXACT size to place, in the venue's own 18-decimal integer units.
+   * Overrides `size` when present.
+   *
+   * ⚠ `size` is a float and an order is placed in WEI, and that conversion is
+   * not order-preserving: `parseUnits(String(50000000000000000 / 1e18))` is
+   * 50000000000000003 — three units ABOVE the position it was read from. On a
+   * venue with no reduce-only flag that is not a rounding detail, it is a
+   * close that crosses past flat and opens a fresh opposing position. This is
+   * the channel that lets a close carry the venue's own integer instead of
+   * re-deriving it through a double.
+   */
+  sizeWei?: string;
 }
 
 export type BorosLegFailureCode =
@@ -94,6 +107,22 @@ export interface BorosClosePositionRequest {
   marketId: number;
   /** Positive size to close — the whole netted position, in collateral units. */
   size: number;
+  /**
+   * What the venue says is open, in ITS OWN 18-decimal integer units — the
+   * ceiling this close may never exceed.
+   *
+   * ⚠ REQUIRED, and required as a STRING, because the cap only works in the
+   * units the order is placed in. `size` above is a double: clamping there
+   * (`Math.min(asked, open)`) compares two numbers that both already lost the
+   * position's low-order digits, and the wei the order is finally built from
+   * can land above the position anyway. Boros has no reduce-only flag, so
+   * that overshoot does not stop at flat — it opens a fresh position the
+   * other way, too small to be closed again under the venue's minimum order
+   * value, and the leg never goes away.
+   *
+   * Pass the venue's `notionalSize` verbatim; the sign is ignored.
+   */
+  openSizeWei: string;
   /** The direction that REDUCES: opposite the position's own side. */
   direction: BorosLegDirection;
   /** Worst rate this close will accept, an APR fraction. */

--- a/src/core/boros/returns.ts
+++ b/src/core/boros/returns.ts
@@ -31,6 +31,8 @@ import {
   allocateBorosByEvidence,
   borosIncrements,
   solvePerpPartition,
+  TIME_SCALE_SEC,
+  type BorosIncrement,
   type DealFillRecord,
   type PerpFillRecord,
   type PerpLegSnapshot,
@@ -1431,11 +1433,27 @@ export function buildStrategies(input: BuildStrategiesInput): StrategyReturns {
    * it a card is what makes it answerable with the same control as everything
    * else, and shows its funding and fees, which the strip never did.
    *
-   * Every coin gets this treatment, in the shape its leftovers actually have:
-   *  - a BOROS coin's leftovers are per-leg cards — each remainder is what one
-   *    strategy released, and they have nothing to do with each other;
-   *  - a coin with NO Boros keeps its legs together on one card — a
-   *    delta-neutral pair waiting for its rate lock is one position, not two.
+   * ⚠ A POSITION IS AT MOST TWO PERP LEGS AND TWO BOROS LEGS — one of each per
+   * venue, opposite sides. A coin with no Boros used to have ALL its perp legs
+   * pooled onto one `BASE#perps` card, on the reasoning that a delta-neutral
+   * pair waiting for its rate lock is one position. That reasoning only holds
+   * while the coin has exactly one pair: a book with two longs against one
+   * short is TWO strategies sharing a venue leg, and pooling them produced a
+   * three-legged card whose header could only name two of its venues, whose
+   * hedge ratios compared sums rather than pairs, and whose missing-Boros rows
+   * sized themselves off one leg of a side they had summed.
+   *
+   * So the pairing comes from the same solver every Boros coin uses — the
+   * tranche cards `splitStrategies` already builds — and only what NO tranche
+   * could pair reaches here. What does is per-leg: a remainder is what one
+   * strategy released, and remainders have nothing to do with each other.
+   *
+   * The one exception is `mergedStrategies`, the branch taken when the split
+   * does NOT reconcile. There the solver has said it cannot explain the book,
+   * so its cards stay merged and may hold any number of legs — splitting a
+   * book you have just declared unsplittable would be a guess wearing the
+   * clothes of a measurement. This whole pass is gated on `reconciled` for the
+   * same reason.
    */
   if (partition.reconciled) {
     const shown = new Map<string, number>();
@@ -1485,20 +1503,13 @@ export function buildStrategies(input: BuildStrategiesInput): StrategyReturns {
         capitalBasis: input.capitalBasis ?? 'balance',
       });
 
-    const pairless = new Map<string, PerpLegBuild[]>();
+    // Whatever no card claimed: one leg, one position. Keyed by the leg,
+    // because that is all this position is. Stable across re-solves, and
+    // distinguishable from a minted position id.
     for (const b of perpBuildsAll) {
       const left = leftoverOf(b);
       if (!left) continue;
-      if (borosBases.has(b.leg.base)) {
-        // Keyed by the leg, because that is all this position is. Stable
-        // across re-solves, and distinguishable from a minted position id.
-        strategies.push(card(`${b.leg.base}#unhedged:${b.symbol}`, b.leg.base, [left]));
-      } else {
-        pairless.set(b.leg.base, [...(pairless.get(b.leg.base) ?? []), left]);
-      }
-    }
-    for (const [base, builds] of pairless) {
-      strategies.push(card(`${base}#perps`, base, builds));
+      strategies.push(card(`${b.leg.base}#unhedged:${b.symbol}`, b.leg.base, [left]));
     }
   }
 
@@ -1639,6 +1650,8 @@ function applyMembership(
   const borosLeft = new Map<number, number>();
   const cards: StrategyRollup[] = [];
   const orphanedBoros: BorosLegBuild[] = [];
+  /** marketId → detached token size, summed over every row that detached it. */
+  const detachedByMarket = new Map<number, number>();
   /** See the note on the return type. Filled while reconciling entries. */
   const impliedByLeg = new Map<string, number>();
   const rows = input.membership ?? [];
@@ -1718,10 +1731,12 @@ function applyMembership(
       // derived pass reports whatever the cards do not show, by subtraction,
       // and a second list of the same size here was never read. Keeping one
       // would put two sources of truth behind one number.
+      // Accumulated PER MARKET, not per row: two rows detaching two chunks of
+      // one leg detach one leg, and pushing a build each made two cards out of
+      // one unclaimed position — with the same id, since a card is named for
+      // the legs it holds.
       if (leg.kind === 'boros') {
-        const b = borosByMarket.get(leg.marketId) as BorosLegBuild;
-        const whole = b.leg.notionalToken ?? 0;
-        orphanedBoros.push(got >= whole * (1 - 1e-9) ? b : scaleBorosBuild(b, got / whole));
+        detachedByMarket.set(leg.marketId, (detachedByMarket.get(leg.marketId) ?? 0) + got);
       }
       return;
     }
@@ -1753,6 +1768,14 @@ function applyMembership(
     }
     const each = left / claimants.length;
     for (const r of claimants) take(r.positionId, r.leg, each, false);
+  }
+
+  // Every detachment of one leg, as the ONE leg it is. Done after the draw so
+  // rows that detached the same market in several bites are already summed.
+  for (const [marketId, got] of detachedByMarket) {
+    const b = borosByMarket.get(marketId) as BorosLegBuild;
+    const whole = b.leg.notionalToken ?? 0;
+    orphanedBoros.push(got >= whole * (1 - 1e-9) ? b : scaleBorosBuild(b, got / whole));
   }
 
   /**
@@ -2103,29 +2126,7 @@ function splitStrategies(
   const boundVenues = new Map<string, string[]>();
   {
     const cohortLegs = borosLegsOf(cohortList);
-    const atoms: GroupingAtom[] = [];
-    for (const b of cohortLegs) {
-      const whole = b.leg.notionalToken ?? 0;
-      const incs = incrementsFor(b.marketId, whole);
-      // A leg whose history cannot be replayed has no increments to pair; it
-      // still gets grouped, just with no co-execution evidence.
-      if (!incs) continue;
-      // Boros LONG receives floating (+), SHORT pays it (−) — the same sign
-      // convention the hedge check uses, so opposite signs really do cancel.
-      const sign = b.leg.side === 'LONG' ? 1 : -1;
-      incs.forEach((inc, i) => {
-        atoms.push({
-          id: `boros:${b.marketId}#${i}`,
-          legKey: `boros:${b.marketId}`,
-          venue: b.leg.venue,
-          base: b.leg.base,
-          floating: sign * inc.qty,
-          qty: inc.qty,
-          rate: inc.fixedApr,
-          at: { kind: 'at', sec: inc.timeSec },
-        });
-      });
-    }
+    const { atoms } = borosAtoms(cohortLegs, incrementsFor);
     const execs = bindExecutions(atoms, {
       historyComplete: input.borosHistoryComplete !== false,
     });
@@ -2242,19 +2243,24 @@ function splitStrategies(
    * card has a base and a maturity to render.
    *
    * When there is no cohort at all on its coin — every Boros leg spoken for by
-   * someone else — it becomes its own cohort with nothing in it, rather than
-   * falling off the page. A perp pair with no hedge is a position; it is just
-   * an unhedged one.
+   * someone else, or a coin that never touched Boros — it becomes its own
+   * cohort with nothing in it, rather than falling off the page. A perp pair
+   * with no hedge is a position; it is just an unhedged one.
+   *
+   * ⚠ A coin with no Boros ANYWHERE used to be excluded here and rebuilt by a
+   * second card builder in `buildStrategies`. Two builders meant two copies of
+   * the open-time re-stamp, the share timelines and the dust floor — and they
+   * had already drifted: the copy labelled every pairing `measured`, so a
+   * guessed grouping on a Boros-less coin claimed to be an execution record
+   * while the identical grouping on a Boros coin admitted it was a proposal.
+   * One tranche, one card, one place.
    */
   for (const t of tranches) {
     if ([...assigned.values()].some((ts) => ts.includes(t))) continue;
     const home =
       pickCohort(cohortList, t.base, [t.long.venue, t.short.venue]) ??
-      // …but only on a coin this view OWNS. A coin with no Boros at all is the
-      // Positions panel's business, and giving it a strategy card here would
-      // show the same perps twice.
-      (borosBases.has(t.base) ? ({ base: t.base, maturity: 0, builds: [] } satisfies Cohort) : null);
-    if (home) assigned.set(home, [...(assigned.get(home) ?? []), t]);
+      ({ base: t.base, maturity: 0, builds: [] } satisfies Cohort);
+    assigned.set(home, [...(assigned.get(home) ?? []), t]);
   }
 
   // share_i(t) for SHARED venue legs. The venue's cumulative funding counter
@@ -2599,7 +2605,17 @@ function splitStrategies(
       if (![...perpBuilds, ...borosScaled].some((b) => b.leg.notionalUsd > 0.005)) continue;
       const rollup = assembleStrategy({
         strategyId: cardId,
-        attribution: { source: t.source, confidence: t.confidence, pinned: t.pinned },
+        attribution: {
+          // A coin that never touched Boros is `unhedged` however well the
+          // pairing itself is evidenced: the chip answers "is a rate locked
+          // against this", and nothing is. It is also what keeps a pure
+          // funding arb out of the Boros-tracked totals, where it would
+          // dominate an APR it has no part in. How the pairing was ARRIVED at
+          // is a separate question, and `confidence` still answers it.
+          source: borosBases.has(t.base) ? t.source : 'unhedged',
+          confidence: t.confidence,
+          pinned: t.pinned,
+        },
         base: cohort.base,
         maturity: cohort.maturity,
         borosBuilds: borosScaled,
@@ -2673,32 +2689,89 @@ function splitStrategies(
       );
     }
   }
-  for (const { cohort, base, maturity, builds: leftovers } of unowned.values()) {
+  for (const { cohort, base, maturity, builds: unclaimed } of unowned.values()) {
     // `attached` = this coin already has a strategy — solved OR asserted — so
     // the leftover is a remainder beside it. Otherwise the coin is Boros-only
     // and keeps the legacy behaviour of pulling in any perp nobody spoke for.
     const attached =
       (cohort !== undefined && assigned.has(cohort)) ||
       asserted.cards.some((c) => c.base === base);
-    out.push(
-      assembleStrategy({
-        strategyId: attached ? `${base}@${maturity}#unmatched` : `${base}@${maturity}`,
+    const freePerps =
+      attached || cohort === undefined
+        ? []
+        : perpBuildsAll.filter(
+            (p) =>
+              !spokenFor.has(p.symbol) &&
+              pickCohort(cohortList, p.leg.base, [p.leg.venue]) === cohort,
+          );
+    /**
+     * The spreads inside this remainder, before it is called one position.
+     *
+     * A cohort's unclaimed legs arrive here as a SET, and a set of four legs
+     * is not a strategy just because no perp tranche wanted it — a book that
+     * pays fixed at two venues against one that receives is two spreads
+     * sharing a leg. `pairBorosLegs` states which, and only what it could not
+     * pair stays whole.
+     */
+    const { pairs, leftovers } = pairBorosLegs(
+      unclaimed,
+      incrementsFor,
+      input.borosHistoryComplete !== false,
+    );
+    /** Every card this remainder becomes: its spreads, then its odd legs. */
+    const groups: Array<{ id: string; builds: BorosLegBuild[]; unconfirmed: boolean }> = [
+      ...pairs.map((p) => ({
+        // Keyed by the two MARKETS, not their venues. Stable across re-solves
+        // and it survives the other spread on a shared leg being closed —
+        // while a venue pair does not name a spread uniquely: one venue lists
+        // the same coin in several collateral zones, so two spreads in one
+        // cohort can sit on the same two venues and collide.
+        id: `${base}@${maturity}#boros:${p.long.marketId}-${p.short.marketId}`,
+        builds: [p.long, p.short],
+        unconfirmed: p.unconfirmed,
+      })),
+      ...leftovers.map((b) => ({
+        id: `${base}@${maturity}#boros:${b.marketId}`,
+        builds: [b],
+        unconfirmed: false,
+      })),
+    ];
+    if (groups.length === 1) {
+      // Nothing was split out, so this IS the remainder — keep the id it has
+      // always had, and leave existing pins and share links pointing at it.
+      groups[0].id = attached ? `${base}@${maturity}#unmatched` : `${base}@${maturity}`;
+    } else {
+      /**
+       * A market can reach this pass TWICE — once as size the user detached
+       * and once as size the solver could not place — and those are two
+       * different statements about one leg, so they stay two positions. Their
+       * ids are named for the legs they hold, though, which makes them the
+       * same string; the ordinal keeps them apart. Deterministic, because the
+       * order above is.
+       */
+      const used = new Set<string>();
+      for (const g of groups) {
+        let id = g.id;
+        for (let n = 2; used.has(id); n += 1) id = `${g.id}~${n}`;
+        used.add(id);
+        g.id = id;
+      }
+    }
+    for (const g of groups) {
+      const venues = new Set(g.builds.map((b) => b.leg.venue));
+      const rollup = assembleStrategy({
+        strategyId: g.id,
         attribution: {
           source: attached ? 'boros-only' : 'merged',
-          confidence: 'measured',
+          confidence: g.unconfirmed ? 'unconfirmed' : 'measured',
           pinned: false,
         },
         base,
         maturity,
-        borosBuilds: leftovers,
-        perpBuilds:
-          attached || cohort === undefined
-            ? []
-            : perpBuildsAll.filter(
-                (p) =>
-                  !spokenFor.has(p.symbol) &&
-                  pickCohort(cohortList, p.leg.base, [p.leg.venue]) === cohort,
-              ),
+        borosBuilds: g.builds,
+        // A pulled-in perp goes to the spread it sits at the venue of — never
+        // to all of them, which would count one position several times.
+        perpBuilds: freePerps.filter((p) => venues.has(p.leg.venue)),
         perpAvailable: input.perpPositions !== null,
         nowSec: input.nowSec,
         clockStartOverrideSec: input.clockStartOverrideSec,
@@ -2706,8 +2779,14 @@ function splitStrategies(
         fundingLedger: input.perpFunding,
         dealFills: input.dealFills,
         capitalBasis: input.capitalBasis ?? 'balance',
-      }),
-    );
+      });
+      if (g.unconfirmed) {
+        rollup.warnings.push(
+          `This ${base} spread was paired by size and open-time proximity, not by an execution record — the split between strategies is a proposal you can edit, not a measurement.`,
+        );
+      }
+      out.push(rollup);
+    }
   }
   if (!out.length) return mergedStrategies(input, cohortList, perpBuildsAll);
   return out;
@@ -2730,6 +2809,201 @@ function pickCohort(cohorts: Cohort[], base: string, venues: string[]): Cohort |
     }))
     .sort((a, b) => b.venueNotional - a.venueNotional);
   return ranked[0].venueNotional > 0 ? ranked[0].cohort : sameBase[0];
+}
+
+/**
+ * Boros legs as the trades they were built from — the input `./grouping` needs
+ * to say which of them went out together.
+ *
+ * ONE encoding, because there are two callers: the co-execution constraint on
+ * the cohort's legs, and the spread pairing on the ones no tranche claimed.
+ * The atom id scheme, the leg-key format and the floating-sign convention have
+ * to agree between them or the two passes disagree about what a book is, and
+ * `Atom.identity` (which short-circuits the score and upgrades the band to
+ * `certain`) would otherwise have to be added to both.
+ */
+function borosAtoms(
+  builds: readonly BorosLegBuild[],
+  incrementsFor: (marketId: number, size: number) => BorosIncrement[] | null,
+): { atoms: GroupingAtom[]; byLegKey: Map<string, BorosLegBuild> } {
+  const atoms: GroupingAtom[] = [];
+  const byLegKey = new Map<string, BorosLegBuild>();
+  for (const b of builds) {
+    const incs = incrementsFor(b.marketId, Math.abs(b.leg.notionalToken ?? 0));
+    // A leg whose history cannot be replayed has no increments to pair; both
+    // callers still handle it, just with no co-execution evidence.
+    if (!incs) continue;
+    const legKey = `boros:${b.marketId}`;
+    byLegKey.set(legKey, b);
+    // Boros LONG receives floating (+), SHORT pays it (−) — the same sign
+    // convention the hedge check uses, so opposite signs really do cancel.
+    const sign = b.leg.side === 'LONG' ? 1 : -1;
+    incs.forEach((inc, i) => {
+      atoms.push({
+        id: `${legKey}#${i}`,
+        legKey,
+        venue: b.leg.venue,
+        base: b.leg.base,
+        floating: sign * inc.qty,
+        qty: inc.qty,
+        rate: inc.fixedApr,
+        at: { kind: 'at', sec: inc.timeSec },
+      });
+    });
+  }
+  return { atoms, byLegKey };
+}
+
+/** One spread the Boros remainder pass could form: a pay-fixed leg against a
+ * receive-fixed leg on the same coin and maturity, each already scaled to the
+ * size the pairing gave it. */
+interface BorosPair {
+  long: BorosLegBuild;
+  short: BorosLegBuild;
+  /** True when no execution record explained the pairing — the same claim the
+   * perp side makes with `confidence: 'unconfirmed'`. */
+  unconfirmed: boolean;
+}
+
+/**
+ * Pair the Boros legs NO PERP TRANCHE CLAIMED into spreads.
+ *
+ * ⚠ This does NOT contradict the "perps anchor" doctrine in ./partition. That
+ * rule is about what may anchor the matching of a HEDGE: a Boros leg can be a
+ * standalone directional trade, so it must never pull a perp onto a card. It
+ * says nothing about two Boros legs that are plainly the two sides of one
+ * spread — one paying fixed, one receiving it, same coin, same maturity — and
+ * leaving those merged produced a card with three, four or more legs whose
+ * header could name only two venues and whose spread averaged across trades
+ * that have nothing to do with each other.
+ *
+ * Evidence first, in the same order the perp side uses it:
+ *  1. co-execution — the increments each leg decomposes into, bound by
+ *     `bindExecutions`. This terminal places both Boros legs as ONE order, so
+ *     a book it built is measured here rather than guessed;
+ *  2. proximity — what is left, paired by size and open-time closeness, and
+ *     reported `unconfirmed`.
+ *
+ * Whatever no pairing could claim comes back as `leftovers`: a directional leg
+ * is a position of one leg, never a third leg on someone else's card.
+ */
+function pairBorosLegs(
+  builds: readonly BorosLegBuild[],
+  incrementsFor: (marketId: number, size: number) => BorosIncrement[] | null,
+  historyComplete: boolean,
+): { pairs: BorosPair[]; leftovers: BorosLegBuild[] } {
+  const whole = (b: BorosLegBuild): number => Math.abs(b.leg.notionalToken ?? 0);
+  const sized = builds.filter((b) => whole(b) > 0);
+  const longs = sized.filter((b) => b.leg.side === 'LONG');
+  const shorts = sized.filter((b) => b.leg.side === 'SHORT');
+  // Nothing to pair against: every leg is directional, and each is its own
+  // position. Returned unscaled so a book that never needed splitting is
+  // byte-for-byte what it was.
+  if (!longs.length || !shorts.length) {
+    return { pairs: [], leftovers: [...builds] };
+  }
+
+  const left = new Map<BorosLegBuild, number>(sized.map((b) => [b, whole(b)]));
+  const openedAt = (b: BorosLegBuild): number | null => b.leg.openedAt ?? null;
+  const pairings: Array<{ long: BorosLegBuild; short: BorosLegBuild; qty: number; measured: boolean }> = [];
+  const add = (long: BorosLegBuild, short: BorosLegBuild, want: number, measured: boolean) => {
+    const qty = Math.min(want, left.get(long) ?? 0, left.get(short) ?? 0);
+    if (!(qty > 0)) return;
+    left.set(long, (left.get(long) as number) - qty);
+    left.set(short, (left.get(short) as number) - qty);
+    // ONE pairing per pair of legs, whatever explained it. A book part-built
+    // on the execution record and part off it (a top-up placed by hand) is one
+    // spread, not two cards on the same two legs — and, like a perp tranche
+    // assembled from several sources, it reports the weakest one.
+    const at = pairings.find((p) => p.long === long && p.short === short);
+    if (at) {
+      at.qty += qty;
+      at.measured = at.measured && measured;
+      return;
+    }
+    pairings.push({ long, short, qty, measured });
+  };
+
+  // --- 1. Co-execution ------------------------------------------------------
+  // Skipped when there is only one leg per side: the proximity pass below
+  // pairs them `forced`, which is already the strongest claim available, so
+  // replaying every fill and binding all-pairs could not change the answer.
+  if (longs.length > 1 || shorts.length > 1) {
+    const { atoms, byLegKey } = borosAtoms(sized, incrementsFor);
+    const byId = new Map(atoms.map((a) => [a.id, a]));
+    for (const exec of bindExecutions(atoms, { historyComplete })) {
+      const members = exec.atomIds.map((id) => byId.get(id)).filter((a): a is GroupingAtom => !!a);
+      const qtyByLeg = new Map<string, number>();
+      for (const a of members) qtyByLeg.set(a.legKey, (qtyByLeg.get(a.legKey) ?? 0) + a.qty);
+      // Only a TWO-leg execution states a pair. A wider one is a real trade
+      // that spanned three legs, and forcing it into a pair would invent the
+      // very grouping this is trying to stop guessing at — it falls through
+      // to proximity, which always yields two.
+      if (qtyByLeg.size !== 2) continue;
+      const [a, b] = [...qtyByLeg.keys()].map((k) => byLegKey.get(k));
+      if (!a || !b || a.leg.side === b.leg.side) continue;
+      const long = a.leg.side === 'LONG' ? a : b;
+      const short = a.leg.side === 'LONG' ? b : a;
+      add(
+        long,
+        short,
+        Math.min(qtyByLeg.get(`boros:${long.marketId}`) ?? 0, qtyByLeg.get(`boros:${short.marketId}`) ?? 0),
+        true,
+      );
+    }
+  }
+
+  // --- 2. Proximity ---------------------------------------------------------
+  // Same objective as the perp residual solver: closest in size, then in open
+  // time. A single long against a single short is the whole book, so it is
+  // still reported measured — there was no other partition to choose.
+  const forced = longs.length === 1 && shorts.length === 1;
+  for (;;) {
+    let best: { long: BorosLegBuild; short: BorosLegBuild; qty: number; score: number } | null = null;
+    for (const lo of longs) {
+      const lq = left.get(lo) ?? 0;
+      if (!(lq > 0)) continue;
+      const lt = openedAt(lo);
+      for (const sh of shorts) {
+        const sq = left.get(sh) ?? 0;
+        if (!(sq > 0)) continue;
+        const st = openedAt(sh);
+        const size = Math.abs(lq - sq) / Math.max(lq, sq);
+        const time = lt === null || st === null ? 1 : Math.abs(lt - st) / TIME_SCALE_SEC;
+        const score = size + time;
+        if (!best || score < best.score - 1e-12) {
+          best = { long: lo, short: sh, qty: Math.min(lq, sq), score };
+        }
+      }
+    }
+    if (!best) break;
+    add(best.long, best.short, best.qty, forced);
+  }
+
+  // --- Emit -----------------------------------------------------------------
+  const dust = (b: BorosLegBuild, qty: number) => qty <= Math.max(1e-12, whole(b) * 1e-9);
+  const pairs: BorosPair[] = [];
+  for (const p of pairings) {
+    if (dust(p.long, p.qty) || dust(p.short, p.qty)) continue;
+    const slice = (b: BorosLegBuild) => {
+      const share = p.qty / whole(b);
+      return share >= 1 - 1e-9 ? b : scaleBorosBuild(b, share);
+    };
+    pairs.push({ long: slice(p.long), short: slice(p.short), unconfirmed: !p.measured });
+  }
+  const leftovers: BorosLegBuild[] = [];
+  for (const b of builds) {
+    const over = left.get(b);
+    // A leg the pass never sized (no token notional) is passed through whole
+    // rather than dropped — it still has to be reported somewhere.
+    if (over === undefined) {
+      leftovers.push(b);
+      continue;
+    }
+    if (dust(b, over)) continue;
+    leftovers.push(over >= whole(b) * (1 - 1e-9) ? b : scaleBorosBuild(b, over / whole(b)));
+  }
+  return { pairs, leftovers };
 }
 
 /** A perp position scaled down to one tranche: its own size, its own entry

--- a/src/core/boros/returns.ts
+++ b/src/core/boros/returns.ts
@@ -1963,6 +1963,31 @@ function applyMembership(
     card.warnings.push(
       `This ${card.base} position holds the legs you assigned to it — the rest of the book is matched around them, and it holds until you change it.`,
     );
+    /**
+     * ⚠ A POSITION RUNS TO ONE DATE, and this is the only path that can break
+     * that.
+     *
+     * A solved card is single-maturity structurally: cohorts are keyed
+     * `(base, maturity)` and `mergedStrategies` emits one card per cohort, so
+     * the shape cannot arise there and needs no check. A card built from ROWS
+     * has no such floor — the user can assign a leg from any market on the
+     * coin, and a share link or a pin written before the dialog started
+     * refusing it can carry the clash in.
+     *
+     * It is worth its own warning rather than being left to the hedge ratios,
+     * because it does not degrade the card, it MISPRICES it. `maturity` above
+     * is `Math.min` across the legs, and the countdown, `secondsToMaturity`,
+     * `spreadReturnUsd` and the PnL projection all run off it — so the later
+     * leg's fixed rate is accrued only to the earlier leg's date, and every
+     * number keeps its confident formatting while it does. A size mismatch at
+     * least announces itself.
+     */
+    const legMaturities = [...new Set(maturities.filter((m) => m > 0))].sort((a, b) => a - b);
+    if (legMaturities.length > 1) {
+      card.warnings.push(
+        `This ${card.base} position holds Boros legs that mature on ${legMaturities.length} different dates (${legMaturities.map((m) => new Date(m * 1000).toISOString().slice(0, 10)).join(', ')}). Its countdown and every projection on it run to the earliest of them, so the later leg's rate is credited only up to that date — split them into one position per maturity to price either correctly.`,
+      );
+    }
     cards.push(card);
   }
 

--- a/src/core/boros/returns.ts
+++ b/src/core/boros/returns.ts
@@ -1704,10 +1704,17 @@ function applyMembership(
    * the overwhelmingly common way a leg stops existing is that the user CLOSED
    * it — the normal end of a position's life — and warning about that greeted
    * anyone who flattened their book with a wall of amber naming every leg they
-   * had just deliberately closed. The rows are pruned by the client
-   * (partitionStore) once the server stops returning their legs; a genuinely
-   * stale assertion is indistinguishable from a closed one here, and the
-   * closed reading is right almost every time.
+   * had just deliberately closed. A genuinely stale assertion is
+   * indistinguishable from a closed one here, and the closed reading is right
+   * almost every time.
+   *
+   * ⚠ THIS FILTER IS NOT A DELETE, and for a long time nothing else was one:
+   * the comment here claimed the client pruned the rows and it did not. A row
+   * names a LEG, so ignoring it per response left it in the browser naming a
+   * symbol the user was likely to trade again — and re-opening that market
+   * handed the leg straight back to the closed position, id, grouping,
+   * asserted entries and all. The delete now lives where it can see the whole
+   * book at once: `partitionStore.ts:pruneRows`, driven by PositionsHome.
    */
   const live = (l: LegRef): boolean =>
     l.kind === 'perp' ? perpBySymbol.has(l.symbol) : borosByMarket.has(l.marketId);

--- a/src/core/boros/returns.ts
+++ b/src/core/boros/returns.ts
@@ -317,6 +317,20 @@ export interface StrategyAttribution {
   source: TrancheSource | 'merged' | 'boros-only' | 'unhedged';
   confidence: TrancheConfidence;
   pinned: boolean;
+  /**
+   * True when this card exists ONLY to report size no position claims —
+   * detached by the user, or left over by the solver.
+   *
+   * ⚠ A SEPARATE QUESTION FROM `source`, which answers how a grouping was
+   * arrived at. The two were conflated, and collided both ways: a solver
+   * tranche on a coin with no Boros reports `source: 'unhedged'` (the chip
+   * means "no rate is locked against this"), while the Boros remainder card
+   * reports `'boros-only'` or `'merged'`. So "is this the card holding the
+   * detached size" could not be read off `source` at all — the client's
+   * Automatic deleted a neighbour's detachment from the first, and did
+   * nothing on the second.
+   */
+  unclaimed?: boolean;
 }
 
 export interface StrategyRollup {
@@ -375,6 +389,18 @@ export interface StrategyReturns {
   /** null when Gate isn't configured — Boros-only view. */
   perpSource: 'connected-gate-account' | null;
   strategies: StrategyRollup[];
+  /**
+   * Every Boros market the venue reports a live position on — counted from the
+   * account's own zones, so no downstream filtering can shorten it.
+   *
+   * ⚠ NOT the same as the markets appearing on `strategies`. A collateral zone
+   * that cannot be priced in USD is excluded from every card (with a warning)
+   * while its positions stay open, so a market can be live here and absent
+   * there. The client prunes membership rows against THIS, never against the
+   * cards: reading "no card holds it" as "the position closed" deleted pins
+   * the user cannot get back.
+   */
+  liveBorosMarketIds: number[];
   totals: {
     capitalUsd: number;
     realizedPnlUsd: number;
@@ -1488,7 +1514,8 @@ export function buildStrategies(input: BuildStrategiesInput): StrategyReturns {
     const card = (strategyId: string, base: string, perpBuilds: PerpLegBuild[]) =>
       assembleStrategy({
         strategyId,
-        attribution: { source: 'unhedged', confidence: 'measured', pinned: false },
+        // Live perp size no position claimed: this card IS the remainder.
+        attribution: { source: 'unhedged', confidence: 'measured', pinned: false, unclaimed: true },
         base,
         // No Boros legs, so no maturity — see the sentinel on StrategyRollup.
         maturity: 0,
@@ -1560,10 +1587,37 @@ export function buildStrategies(input: BuildStrategiesInput): StrategyReturns {
     }
   }
 
+  /**
+   * Every Boros market the venue reports a live position on.
+   *
+   * ⚠ READ FROM THE ZONES, not from the cards, and that is the whole point.
+   * The client prunes a membership row once the server stops reporting its
+   * leg, so "which legs exist" has to be answered by something no downstream
+   * filtering can shorten — and `buildBorosLegs` drops an entire collateral
+   * zone when its USD price cannot be resolved (a warning, and a 200). Legs in
+   * that zone are open, invisible on every card, and were being read as
+   * closed: two settled polls later the user's pins and asserted entries for
+   * them were deleted, with no undo.
+   *
+   * So this counts positions, nothing else. A leg listed here may still be
+   * missing from every card; that means the card could not be built, never
+   * that the position is gone.
+   */
+  const liveBorosMarketIds = [
+    ...new Set(
+      input.zones.flatMap((z) =>
+        [...(z.cross ? [z.cross] : []), ...z.isolated].flatMap((g) =>
+          g.marketPositions.filter((p) => norm18(p.notionalSize) !== 0).map((p) => p.marketId),
+        ),
+      ),
+    ),
+  ];
+
   return {
     address: input.address,
     perpSource: perpAvailable ? 'connected-gate-account' : null,
     strategies,
+    liveBorosMarketIds,
     totals: {
       capitalUsd,
       realizedPnlUsd,
@@ -2797,6 +2851,9 @@ function splitStrategies(
           source: attached ? 'boros-only' : 'merged',
           confidence: g.unconfirmed ? 'unconfirmed' : 'measured',
           pinned: false,
+          // Boros notional NO POSITION CLAIMED — what the solver could not
+          // attach and what the user detached, which arrive here as one thing.
+          unclaimed: true,
         },
         base,
         maturity,

--- a/src/server/routes/borosPair.ts
+++ b/src/server/routes/borosPair.ts
@@ -217,6 +217,18 @@ function parseClientOrderId(raw: unknown, which: string): string {
 interface AccountView {
   /** marketId → signed netted size, collateral units (+ long fixed). */
   positionByMarket: Map<number, number>;
+  /**
+   * marketId → the SAME position as the venue's own 18-decimal integer,
+   * verbatim.
+   *
+   * ⚠ Kept beside the float rather than derived from it, because it cannot be
+   * derived from it. `norm18` divides an 18-decimal integer into a double and
+   * loses the low-order digits; converting back can land ABOVE where it
+   * started. Everything that only displays or compares is happy with the
+   * float — a close, which places an order in these units on a venue with no
+   * reduce-only flag, is not. See `BorosClosePositionRequest.openSizeWei`.
+   */
+  positionRawByMarket: Map<number, string>;
   /** marketId → initial margin that position already posts, collateral units. */
   committedMarginByMarket: Map<number, number>;
   /** marketId → true when that market currently sits in an ISOLATED bucket. */
@@ -254,6 +266,7 @@ function holdsPositionOrOrders(p: {
 function readAccount(zones: BorosCollateralZone[]): AccountView {
   const view: AccountView = {
     positionByMarket: new Map(),
+    positionRawByMarket: new Map(),
     committedMarginByMarket: new Map(),
     isolatedMarkets: new Set(),
     isolatedOccupied: new Set(),
@@ -272,6 +285,7 @@ function readAccount(zones: BorosCollateralZone[]): AccountView {
       });
       for (const p of zone.cross.marketPositions) {
         view.positionByMarket.set(p.marketId, norm18(p.notionalSize));
+        view.positionRawByMarket.set(p.marketId, String(p.notionalSize ?? '0'));
         view.committedMarginByMarket.set(
           p.marketId,
           norm18(p.positionInitialMargin ?? p.initialMargin),
@@ -287,6 +301,7 @@ function readAccount(zones: BorosCollateralZone[]): AccountView {
       for (const p of group.marketPositions) {
         const size = norm18(p.notionalSize);
         view.positionByMarket.set(p.marketId, size);
+        view.positionRawByMarket.set(p.marketId, String(p.notionalSize ?? '0'));
         view.committedMarginByMarket.set(
           p.marketId,
           norm18(p.positionInitialMargin ?? p.initialMargin),
@@ -811,16 +826,28 @@ export function borosPairRoutes(deps: AppDeps) {
       }
       // Reduce = trade the opposite way to the position's sign.
       const direction: BorosLegDirection = current > 0 ? 'short' : 'long';
-      // ⚠ CLAMPED to what is actually open. Boros has no reduce-only flag, so
-      // a size larger than the position does not stop at flat — it crosses it
-      // and opens a fresh one the other way. The cap is what makes accepting a
-      // caller size safe at all.
+      /**
+       * ⚠ CLAMPED to what is actually open. Boros has no reduce-only flag, so
+       * a size larger than the position does not stop at flat — it crosses it
+       * and opens a fresh one the other way. The cap is what makes accepting a
+       * caller size safe at all.
+       *
+       * ⚠ AND THIS CLAMP IS NOT THE ONE THAT ENFORCES IT. Both operands are
+       * doubles that already lost the position's low-order digits, so it can
+       * only narrow what the CALLER asked for — it cannot bound the wei the
+       * order is finally built from, and for a clean 0.05 that conversion
+       * landed three units above the position. The binding cap is
+       * `openSizeWei`, applied in the venue's own units in `closePosition`.
+       * This one stays because it is still what decides a deliberate PARTIAL.
+       */
       const openSize = Math.abs(current);
       const size = sizeOverride === null ? openSize : Math.min(sizeOverride, openSize);
       const slippageApr = slippageOverride ?? CLOSE_SLIPPAGE_APR;
       const fill = await orders.closePosition({
         marketId,
         size,
+        // The venue's own integer, never re-derived from `size`.
+        openSizeWei: account.positionRawByMarket.get(marketId) ?? '0',
         direction,
         limitApr: limitAprFor(direction, market.markApr, slippageApr),
         clientOrderId,

--- a/tests/unit/boros-api-order-client.test.ts
+++ b/tests/unit/boros-api-order-client.test.ts
@@ -8,6 +8,7 @@ import { keccak256, verifyTypedData, type Hex } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { describe, expect, it } from 'vitest';
 import {
+  absWei,
   BOROS_API_BASE,
   CROSS_MARKET_ID,
   decimalString,
@@ -436,5 +437,88 @@ describe('makeBorosApiOrderClient — a result that says nothing is not a result
     expect(fills[1].failure?.code).toBe('unknown');
     expect(fills[1].failure?.message).toMatch(/may or may not have filled/i);
     expect(fills[1].failure?.message).not.toMatch(/nothing matched/i);
+  });
+});
+
+/**
+ * A CLOSE MAY NEVER PLACE MORE THAN IS OPEN.
+ *
+ * Boros has no reduce-only flag, so nothing at the venue stops a close at
+ * flat: one unit too many crosses it and opens a fresh position the other way.
+ * The route clamps the size to what is open, but it clamps two DOUBLES, and
+ * the order is not built from a double — `parseUnits` of `50000000000000000 /
+ * 1e18` is 50000000000000003. Three units of an opposing position, invisible,
+ * unclosable under the venue's $10 minimum order value, and reported as
+ * "closed" because in float space the two numbers were equal.
+ */
+describe('closePosition — the cap that binds is in wei', () => {
+  /** The wei the venue was actually asked for. */
+  const placedWei = (api: ReturnType<typeof fakeApi>): bigint => {
+    const order = api.calls.find((c) => c.path.startsWith('/v1/calldata-builder/agent/place-order'));
+    return BigInt(String(order!.body.size));
+  };
+  const close = async (api: ReturnType<typeof fakeApi>, over: { size: number; openSizeWei: string }) =>
+    client(api).closePosition({
+      marketId: HL,
+      direction: 'short',
+      limitApr: 0.0875,
+      clientOrderId: 'c-0000001',
+      ...over,
+    });
+
+  it('never asks for more than the venue holds, where the float rounds UP', () => {
+    // 0.05 is the case that bit a real user: a clean open, and the size that
+    // cannot survive the round trip.
+    const api = fakeApi();
+    return close(api, { size: 50000000000000000 / 1e18, openSizeWei: '50000000000000000' }).then(() => {
+      expect(placedWei(api)).toBe(50000000000000000n);
+    });
+  });
+
+  it('holds the line on a size whose float lands 556 units high', async () => {
+    const api = fakeApi();
+    await close(api, { size: 123456789000000000000 / 1e18, openSizeWei: '123456789000000000000' });
+    expect(placedWei(api)).toBe(123456789000000000000n);
+  });
+
+  it('ignores the sign — a short is closed by its magnitude', async () => {
+    const api = fakeApi();
+    await close(api, { size: 50000000000000000 / 1e18, openSizeWei: '-50000000000000000' });
+    expect(placedWei(api)).toBe(50000000000000000n);
+  });
+
+  it('still honours a deliberate PARTIAL rather than widening it to the whole', async () => {
+    // The cap is a ceiling, not the size. Closing 0.02 of 0.05 must place
+    // 0.02 — a cap that overrode the request would close someone's position
+    // for them.
+    const api = fakeApi();
+    await close(api, { size: 0.02, openSizeWei: '50000000000000000' });
+    expect(placedWei(api)).toBe(20000000000000000n);
+  });
+
+  it('falls back to the float when the venue\'s own field is not an integer', async () => {
+    // A cap that cannot be read is no cap. That is the OLD behaviour, which is
+    // a shape change on the venue's side rather than a routine case — better
+    // than throwing on the close path.
+    const api = fakeApi();
+    await close(api, { size: 50000000000000000 / 1e18, openSizeWei: '5e16' });
+    expect(placedWei(api)).toBe(50000000000000003n);
+  });
+});
+
+describe('absWei', () => {
+  it('reads the venue\'s own integer as a magnitude', () => {
+    expect(absWei('50000000000000000')).toBe(50000000000000000n);
+    expect(absWei('-50000000000000000')).toBe(50000000000000000n);
+    expect(absWei(' 0 ')).toBe(0n);
+  });
+
+  it('refuses anything that is not a plain integer, rather than inventing a ceiling', () => {
+    // A wrong ceiling silently truncates a close; no ceiling merely restores
+    // the previous behaviour.
+    expect(absWei('5e16')).toBeNull();
+    expect(absWei('0.05')).toBeNull();
+    expect(absWei('')).toBeNull();
+    expect(absWei('nope')).toBeNull();
   });
 });

--- a/tests/unit/boros-membership.test.ts
+++ b/tests/unit/boros-membership.test.ts
@@ -136,6 +136,49 @@ const cardFor = (out: ReturnType<typeof buildStrategies>, perpVenue: string) =>
 const borosQty = (s: ReturnType<typeof buildStrategies>['strategies'][number], venue: string) =>
   s.legs.find((l) => l.kind === 'boros' && l.venue === venue)?.notionalToken ?? 0;
 
+/**
+ * ⚠ THE CARDS ARE NOT A CENSUS OF THE VENUE.
+ *
+ * The client prunes a membership row once the server stops reporting its leg,
+ * so "which legs exist" must be answered by something no downstream filtering
+ * can shorten. `buildBorosLegs` drops a whole collateral zone whose USD price
+ * cannot be resolved — a warning, and a 200 — so a position can be open and on
+ * no card. Read off the cards, that was indistinguishable from closed, and the
+ * user's pins for those legs were deleted with no undo.
+ */
+describe('liveBorosMarketIds — counted from the zones, not the cards', () => {
+  it('still lists a market whose collateral zone could not be priced', () => {
+    const out = buildStrategies(book({ pricesUsd: new Map([[2, null]]) }));
+    // Nothing could be built…
+    expect(out.strategies.flatMap((s) => s.legs).filter((l) => l.kind === 'boros')).toEqual([]);
+    expect(out.warnings.join(' ')).toMatch(/Can't price the .* collateral zone/);
+    // …and the positions are open all the same.
+    expect([...out.liveBorosMarketIds].sort((a, b) => a - b)).toEqual([128, 129]);
+  });
+
+  it('lists exactly the markets the account holds a position on', () => {
+    const out = buildStrategies(book());
+    expect([...out.liveBorosMarketIds].sort((a, b) => a - b)).toEqual([128, 129]);
+  });
+
+  it('leaves out a market whose position is flat', () => {
+    // A closed leg must NOT be reported live, or the prune could never run.
+    const flat = zones().map((z) => ({
+      ...z,
+      cross: z.cross
+        ? {
+            ...z.cross,
+            marketPositions: z.cross.marketPositions.map((p) =>
+              p.marketId === 128 ? { ...p, notionalSize: '0' } : p,
+            ),
+          }
+        : z.cross,
+    }));
+    const out = buildStrategies(book({ zones: flat }));
+    expect(out.liveBorosMarketIds).toEqual([129]);
+  });
+});
+
 describe('shared Boros leg — anchored on the Boros fills', () => {
   it('gives the whole leg to the strategy whose fills opened it', () => {
     // Boros anchors: the fill that built this leg landed with the Binance

--- a/tests/unit/boros-membership.test.ts
+++ b/tests/unit/boros-membership.test.ts
@@ -287,6 +287,48 @@ describe('one perp, two maturities', () => {
     expect(out.strategies.flatMap((s) => s.warnings).join(' ')).not.toMatch(/largest cohort/);
   });
 
+  /**
+   * ⚠ A POSITION RUNS TO ONE DATE, and only a PINNED card can break that.
+   *
+   * A solved card is single-maturity structurally (cohorts are keyed
+   * `(base, maturity)`), so this is the one path that needs saying out loud.
+   * The dialog refuses the assignment now, but a share link or a pin written
+   * before it did can still carry the clash in — and it does not degrade the
+   * card, it misprices it, silently, while every number keeps its confident
+   * formatting.
+   */
+  it('warns when a pinned position holds Boros legs of two maturities', () => {
+    const P = 'a1b2c3d4';
+    const out = buildStrategies({
+      ...twoMaturities(),
+      membership: [
+        { positionId: P, leg: { kind: 'boros', marketId: 129 } }, // Dec long
+        { positionId: P, leg: { kind: 'boros', marketId: 128 } }, // Dec short
+        { positionId: P, leg: { kind: 'boros', marketId: 102 } }, // SEP short — the intruder
+      ],
+    });
+    const card = out.strategies.find((s) => s.strategyId === P)!;
+    expect(card.legs.filter((l) => l.kind === 'boros')).toHaveLength(3);
+    expect(card.warnings.join(' ')).toMatch(/mature on 2 different dates/);
+    // …and the warning is worth having because THIS is what the card's own
+    // countdown and every projection on it are computed against.
+    expect(card.maturity).toBe(MAT_SEP);
+  });
+
+  it('says nothing when a pinned position keeps to one maturity', () => {
+    const P = 'a1b2c3d4';
+    const out = buildStrategies({
+      ...twoMaturities(),
+      membership: [
+        { positionId: P, leg: { kind: 'boros', marketId: 129 } },
+        { positionId: P, leg: { kind: 'boros', marketId: 128 } },
+      ],
+    });
+    const card = out.strategies.find((s) => s.strategyId === P)!;
+    expect(card.legs.filter((l) => l.kind === 'boros')).toHaveLength(2);
+    expect(card.warnings.join(' ')).not.toMatch(/different dates/);
+  });
+
   it('splits one Hyperliquid perp across the two maturities it hedges', () => {
     const out = buildStrategies(twoMaturities());
     const hlPerp = out.strategies

--- a/tests/unit/boros-returns.test.ts
+++ b/tests/unit/boros-returns.test.ts
@@ -324,9 +324,15 @@ describe('buildStrategies — scaling', () => {
     zones[0].tokenId = 4; // BNB — no BNB market in the fixture set
     const out = buildStrategies(input({ zones, pricesUsd: new Map([[4, null]]) }));
     // No priceable Boros legs anywhere — the perps still render, as the
-    // unhedged card every Boros-less coin gets, rather than vanishing.
+    // unhedged card every Boros-less coin gets, rather than vanishing. The
+    // pair is the solver's, so the card is the two-leg tranche, not a pool.
     expect(out.strategies.flatMap((s) => s.legs).filter((l) => l.kind === 'boros')).toEqual([]);
-    expect(out.strategies.map((s) => s.strategyId)).toEqual(['ETH#perps']);
+    expect(out.strategies).toHaveLength(1);
+    expect(out.strategies[0].attribution.source).toBe('unhedged');
+    expect(out.strategies[0].legs.map((l) => `${l.kind}:${l.venue}`)).toEqual([
+      'perp:HYPERLIQUID',
+      'perp:OKX',
+    ]);
     expect(out.warnings.join(' ')).toMatch(/BNB collateral zone/);
   });
 });
@@ -372,12 +378,164 @@ describe('buildStrategies — hedge states & degraded modes', () => {
     const out = buildStrategies(input({ perpPositions: [...ethPerps(), stray] }));
     expect(out.strategies).toHaveLength(2);
     const sol = out.strategies.find((s) => s.base === 'SOL');
-    expect(sol?.strategyId).toBe('SOL#perps');
+    expect(sol?.strategyId).toBe('SOL#unhedged:BINANCE_FUTURE_SOL_USDT');
     expect(sol?.attribution.source).toBe('unhedged');
     expect(sol?.hedge).toBe('unhedged');
     expect(sol?.legs.map((l) => `${l.kind}:${l.venue}`)).toEqual(['perp:BINANCE']);
     // The ETH strategy is untouched by the stray coin.
     expect(out.strategies.find((s) => s.base === 'ETH')?.legs.filter((l) => l.base === 'SOL')).toEqual([]);
+  });
+
+  it('splits a Boros remainder into spreads rather than one many-legged card', () => {
+    // Two pay-fixed legs against one receive-fixed leg of twice the size, and
+    // no perps at all. Merging them made a single three-legged card whose
+    // header could name only two of its three venues and whose spread
+    // averaged two trades that have nothing to do with each other.
+    const bybitMarket: BorosMarket = {
+      ...hlMarket,
+      marketId: 159,
+      name: 'Bybit ETHUSDT 31 Jul 2026',
+      venue: 'Bybit',
+      markApr: 0.062,
+      floatingApr: 0.061,
+      midApr: 0.062,
+    };
+    const LATER = OPENED + 3 * DAY;
+    const zones: BorosCollateralZone[] = [
+      {
+        tokenId: 3,
+        cross: {
+          isCross: true,
+          netBalance: raw(20_000),
+          marketPositions: [
+            {
+              marketId: 155, // Hyperliquid, receive-fixed, twice the size
+              side: 1,
+              notionalSize: raw(-2_000_000),
+              fixedApr: 0.08,
+              markApr: 0.076,
+              pnl: { rateSettlementPnl: raw(0), unrealisedPnl: raw(0) },
+              positionInitialMargin: raw(10_000),
+            },
+            {
+              marketId: 158, // OKX, pay-fixed, opened with the first half
+              side: 0,
+              notionalSize: raw(1_000_000),
+              fixedApr: 0.03,
+              markApr: 0.032,
+              pnl: { rateSettlementPnl: raw(0), unrealisedPnl: raw(0) },
+              positionInitialMargin: raw(5_000),
+            },
+            {
+              marketId: 159, // Bybit, pay-fixed, opened three days later
+              side: 0,
+              notionalSize: raw(1_000_000),
+              fixedApr: 0.05,
+              markApr: 0.062,
+              pnl: { rateSettlementPnl: raw(0), unrealisedPnl: raw(0) },
+              positionInitialMargin: raw(5_000),
+            },
+          ],
+        },
+        isolated: [],
+      },
+    ];
+    // Each half of the Hyperliquid leg was placed in the same second as the
+    // pay-fixed leg it hedges — the co-execution evidence the pairing reads.
+    const txns: BorosTxn[] = [
+      { marketId: 155, time: OPENED, fee: raw(390), pnl: raw(-390), prevPositionS: '0', postPositionS: raw(-1_000_000), fixedApr: 0.08 },
+      { marketId: 158, time: OPENED, fee: raw(300), pnl: raw(-300), prevPositionS: '0', postPositionS: raw(1_000_000), fixedApr: 0.03 },
+      { marketId: 155, time: LATER, fee: raw(390), pnl: raw(-390), prevPositionS: raw(-1_000_000), postPositionS: raw(-2_000_000), fixedApr: 0.08 },
+      { marketId: 159, time: LATER, fee: raw(300), pnl: raw(-300), prevPositionS: '0', postPositionS: raw(1_000_000), fixedApr: 0.05 },
+    ];
+    const out = buildStrategies(
+      input({
+        zones,
+        markets: [hlMarket, okxMarket, bybitMarket],
+        txnsByToken: new Map([[3, txns]]),
+        perpPositions: [],
+      }),
+    );
+    expect(out.strategies).toHaveLength(2);
+    for (const s of out.strategies) {
+      expect(s.legs.filter((l) => l.kind === 'boros')).toHaveLength(2);
+      expect(s.legs.filter((l) => l.side === 'LONG')).toHaveLength(1);
+      expect(s.legs.filter((l) => l.side === 'SHORT')).toHaveLength(1);
+      // Bound by the execution record, not guessed at.
+      expect(s.attribution.confidence).toBe('measured');
+    }
+    // One spread per pay-fixed venue, each against half of the Hyperliquid leg.
+    expect(out.strategies.map((s) => s.legs.map((l) => l.venue).sort().join('/')).sort()).toEqual([
+      'HYPERLIQUID/OKX',
+      'BYBIT/HYPERLIQUID',
+    ].sort());
+    // The shared leg is divided, not double-counted.
+    const hlToken = out.strategies
+      .flatMap((s) => s.legs)
+      .filter((l) => l.venue === 'HYPERLIQUID')
+      .reduce((sum, l) => sum + (l.notionalToken ?? 0), 0);
+    expect(hlToken).toBeCloseTo(2_000_000, 3);
+    // Each spread keeps the rate IT locked, not the book's blend.
+    const bybit = out.strategies.find((s) => s.legs.some((l) => l.venue === 'BYBIT'));
+    expect(bybit?.spread).toBeCloseTo(0.08 - 0.05, 10);
+    const okx = out.strategies.find((s) => s.legs.some((l) => l.venue === 'OKX'));
+    expect(okx?.spread).toBeCloseTo(0.08 - 0.03, 10);
+  });
+
+  it('splits a Boros-less coin into two-leg pairs rather than pooling its legs', () => {
+    // Two longs against one short, no Boros on the coin. Pooling them made a
+    // single three-legged card: its header could name only two of the three
+    // venues, and its perp match ratio compared $59+$57 against $116 and
+    // called a book that is really two strategies perfectly matched.
+    const spread = (over: Partial<PerpPositionLike>): PerpPositionLike => ({
+      symbol: 'BINANCE_FUTURE_SOL_USDT',
+      positionSide: 'LONG',
+      positionQty: '10',
+      positionValue: '2000',
+      entryPrice: '200',
+      upnl: '1',
+      fundingFee: '2',
+      fee: '-1',
+      initialMargin: '400',
+      ...over,
+    });
+    const out = buildStrategies(
+      input({
+        perpPositions: [
+          spread({}),
+          spread({ symbol: 'GATE_FUTURE_SOL_USDT', positionQty: '10', positionValue: '2000' }),
+          spread({
+            symbol: 'HYPERLIQUID_FUTURE_SOL_USDC',
+            positionSide: 'SHORT',
+            positionQty: '-20',
+            positionValue: '4000',
+            initialMargin: '800',
+          }),
+        ],
+      }),
+    );
+    const sol = out.strategies.filter((s) => s.base === 'SOL');
+    expect(sol).toHaveLength(2);
+    for (const s of sol) {
+      expect(s.legs.filter((l) => l.kind === 'perp')).toHaveLength(2);
+      expect(s.legs.filter((l) => l.side === 'LONG')).toHaveLength(1);
+      expect(s.legs.filter((l) => l.side === 'SHORT')).toHaveLength(1);
+      expect(s.hedge).toBe('unhedged'); // no rate is locked against either
+      // A coin that never touched Boros stays out of the Boros-tracked totals
+      // however well the pairing itself is evidenced.
+      expect(s.attribution.source).toBe('unhedged');
+    }
+    // One pair per long venue, each against the shared Hyperliquid short.
+    expect(sol.map((s) => s.legs.map((l) => l.venue).sort().join('/')).sort()).toEqual([
+      'BINANCE/HYPERLIQUID',
+      'GATE/HYPERLIQUID',
+    ]);
+    // The short is split, not double-counted: each card holds half of it.
+    const hlToken = sol
+      .flatMap((s) => s.legs)
+      .filter((l) => l.venue === 'HYPERLIQUID')
+      .reduce((sum, l) => sum + (l.notionalToken ?? 0), 0);
+    expect(hlToken).toBeCloseTo(20, 6);
   });
 
   it('flags a notional mismatch beyond the 2% band as a partial hedge', () => {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -330,6 +330,19 @@ export interface StrategyAttribution {
     | 'unhedged';
   confidence: 'measured' | 'unconfirmed';
   pinned: boolean;
+  /**
+   * True when this card exists ONLY to report size no position claims —
+   * detached by the user, or left over by the solver.
+   *
+   * ⚠ A SEPARATE QUESTION FROM `source`, which answers how a grouping was
+   * arrived at. The two were conflated, and collided both ways: a solver
+   * tranche on a coin with no Boros reports `source: 'unhedged'` (the chip
+   * means "no rate is locked against this"), while the Boros remainder card
+   * reports `'boros-only'` or `'merged'`. So "is this the card holding the
+   * detached size" could not be read off `source` at all — Automatic deleted
+   * a neighbour's detachment from the first, and did nothing on the second.
+   */
+  unclaimed?: boolean;
 }
 
 /** What anchors the realized-APR clock: earliest Boros leg (default), perp
@@ -396,6 +409,18 @@ export interface StrategyReturns {
   /** null when Gate isn't configured — Boros-only view. */
   perpSource: 'connected-gate-account' | null;
   strategies: StrategyRollup[];
+  /**
+   * Every Boros market the venue reports a live position on — counted from the
+   * account's own zones, so no downstream filtering can shorten it.
+   *
+   * ⚠ NOT the same as the markets appearing on `strategies`. A collateral zone
+   * that cannot be priced in USD is excluded from every card (with a warning)
+   * while its positions stay open, so a market can be live here and absent
+   * there. The client prunes membership rows against THIS, never against the
+   * cards: reading "no card holds it" as "the position closed" deleted pins
+   * the user cannot get back.
+   */
+  liveBorosMarketIds: number[];
   totals: {
     capitalUsd: number;
     realizedPnlUsd: number;

--- a/web/src/panels/PartitionEditor.test.tsx
+++ b/web/src/panels/PartitionEditor.test.tsx
@@ -144,7 +144,7 @@ describe('LegAssignment — behaviours the rewrite kept but stopped testing', ()
     const onAssert = vi.fn();
     mount('HYPERLIQUID', 'perp', {
       onAssert,
-      destinations: [{ id: 'ETH#OTHER#exec', label: 'ETH · OKX ⇄ Gate' }],
+      destinations: [{ id: 'ETH#OTHER#exec', label: 'ETH · OKX ⇄ Gate', borosMaturity: null }],
     });
     openDialog();
     fireEvent.click(screen.getByRole('button', { name: /ETH · OKX ⇄ Gate/ }));
@@ -308,7 +308,7 @@ describe('LegAssignment — correcting the entry', () => {
     mount('HYPERLIQUID', 'perp', {
       onAssert: vi.fn(),
       venueEntry: 2440,
-      destinations: [{ id: 'ETH#OTHER#exec', label: 'ETH · OKX ⇄ Gate' }],
+      destinations: [{ id: 'ETH#OTHER#exec', label: 'ETH · OKX ⇄ Gate', borosMaturity: null }],
     });
     openDialog();
     expect(screen.getByText('What did it cost?')).toBeInTheDocument();
@@ -405,5 +405,76 @@ describe('LegAssignment — entry editor: regressions from the re-audit', () => 
     mount('BINANCE', 'boros', { onAssert: vi.fn(), venueEntry: 0.0590778377 });
     fireEvent.click(screen.getByTitle(/of the .* open on/));
     expect(screen.getByText(/reports 5\.91% across the whole position/)).toBeInTheDocument();
+  });
+});
+
+/**
+ * ONE MATURITY PER POSITION.
+ *
+ * A solved card is single-maturity structurally — cohorts are keyed
+ * `(base, maturity)` and `mergedStrategies` emits one card per cohort, so the
+ * shape cannot arise there. The manual path had no such floor, and two
+ * maturities on one card do not degrade it, they misprice it: `maturity` is
+ * `Math.min` across the legs, and the countdown, `secondsToMaturity`,
+ * `spreadReturnUsd` and the PnL projection all run off it.
+ *
+ * Shape is still not policed. Six legs, a half-open hedge, a spread with no
+ * perps — all assertable. Only the date has to agree.
+ */
+describe('LegAssignment — one maturity per position', () => {
+  const MAT = 1_800_000_000; // 2027-01-15
+  const LATER = 1_820_000_000; // 2027-09-03
+  const boros = makeStrategyLeg({
+    kind: 'boros',
+    venue: 'BINANCE',
+    side: 'LONG',
+    notionalToken: 300,
+    marketId: 129,
+    maturity: MAT,
+  });
+  const mountBoros = (destinations: Parameters<typeof LegAssignment>[0]['destinations']) =>
+    render(
+      <LegAssignment leg={boros} strategyId="ETH#HERE" destinations={destinations} onAssert={vi.fn()} />,
+    );
+  const dest = (borosMaturity: number | null) => [
+    { id: 'ETH#OTHER#exec', label: 'ETH · OKX ⇄ Gate', borosMaturity },
+  ];
+
+  it('refuses a position running to a different date, and names the date', () => {
+    mountBoros(dest(LATER));
+    openDialog();
+    const btn = screen.getByRole('button', { name: /ETH · OKX ⇄ Gate/ });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveTextContent(/matures 2027-09-03, not this one/);
+  });
+
+  it('a refused destination cannot be selected by clicking it anyway', () => {
+    mountBoros(dest(LATER));
+    openDialog();
+    fireEvent.click(screen.getByRole('button', { name: /ETH · OKX ⇄ Gate/ }));
+    // Confirm only lights up once something changed; nothing did.
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+  });
+
+  it('offers a position running to the SAME date', () => {
+    mountBoros(dest(MAT));
+    openDialog();
+    expect(screen.getByRole('button', { name: /ETH · OKX ⇄ Gate/ })).toBeEnabled();
+  });
+
+  it('offers a position holding no Boros leg — it has no date to disagree with', () => {
+    // A perp-only card, or a spread whose Boros side is not open yet. Sending
+    // the first Boros leg there is how it stops being either.
+    mountBoros(dest(null));
+    openDialog();
+    expect(screen.getByRole('button', { name: /ETH · OKX ⇄ Gate/ })).toBeEnabled();
+  });
+
+  it('never blocks a PERP leg — a perp is perpetual and hedges every cohort', () => {
+    // The solver attaches one perp across maturities on purpose; refusing the
+    // same thing by hand would contradict it.
+    mount('HYPERLIQUID', 'perp', { onAssert: vi.fn(), destinations: dest(LATER) });
+    openDialog();
+    expect(screen.getByRole('button', { name: /ETH · OKX ⇄ Gate/ })).toBeEnabled();
   });
 });

--- a/web/src/panels/PartitionEditor.tsx
+++ b/web/src/panels/PartitionEditor.tsx
@@ -45,7 +45,19 @@ export type LegAssertion =
    * and an entry can be corrected without moving anything. The venue's own
    * average is never changed — see entryOverrideStore's conservation note.
    */
-  | { mode: 'entry'; leg: LegRef; value: number | null };
+  | { mode: 'entry'; leg: LegRef; value: number | null }
+  /**
+   * This position just CLOSED `qty` of the leg at the venue.
+   *
+   * Not a regrouping — a statement that the size this card claims is now
+   * smaller. It exists because a claim written as an explicit `qty` is an
+   * ABSOLUTE number while a venue position NETS: closing a card's own share of
+   * a shared leg shrank the venue leg and left the row claiming the same
+   * amount out of what remained, quietly taking it from the cards sharing it.
+   * The card looked untouched by its own close — the size never moved, only
+   * the denominator beside it.
+   */
+  | { mode: 'closed'; leg: LegRef; qty: number };
 
 /** Where a leg can be sent. */
 export interface LegDestination {

--- a/web/src/panels/PartitionEditor.tsx
+++ b/web/src/panels/PartitionEditor.tsx
@@ -20,7 +20,7 @@ import { useState } from 'react';
 import type { StrategyLeg, StrategyRollup } from '../api/types';
 import { Chip } from '../components/Chip';
 import { Modal } from '../components/Modal';
-import { fmtTokenQty } from '../lib/fmt';
+import { fmtDateUtc, fmtTokenQty } from '../lib/fmt';
 import { overrunsVenue, reconcileEntries } from './entryOverrideStore';
 import type { LegRef } from './partitionStore';
 
@@ -64,6 +64,25 @@ export interface LegDestination {
   /** The destination card's current strategyId. */
   id: string;
   label: string;
+  /**
+   * The Boros maturity this card already holds, or null when it holds no
+   * Boros leg and so has none to disagree with.
+   *
+   * ⚠ ONE MATURITY PER POSITION. Cohorts are keyed `(base, maturity)` and
+   * `mergedStrategies` emits one card per cohort, so a SOLVED card is
+   * single-maturity structurally — there is no check because the shape cannot
+   * arise. The manual path had no such floor, and two maturities on one card
+   * break more than the hedge ratios: `maturity` is `Math.min` across the
+   * legs, and the countdown, `secondsToMaturity`, `spreadReturnUsd` and the
+   * PnL projection are all computed against it, so the later leg's rate
+   * accrues to the earlier leg's date. Silently — unlike a size mismatch,
+   * which at least says so.
+   *
+   * A card holding several maturities already (a share link, a pin made
+   * before this rule) reports its EARLIEST here: it is the one the card's own
+   * numbers use, and any leg that disagrees with it is refused anyway.
+   */
+  borosMaturity: number | null;
 }
 
 /**
@@ -179,6 +198,27 @@ export function LegAssignment({
   const share = leg.share ?? 1;
   const venueTotal = share > 0 ? held / share : held;
   const shared = share < 0.999;
+
+  /**
+   * A destination this leg may not go to, and why — see `LegDestination`.
+   *
+   * Only ever a MATURITY clash. Shape is not policed here: a card holding six
+   * legs, or a hedge half-open, is a position the user is entitled to assert.
+   * Two maturities is different because it is not a shape the solver can even
+   * produce, and because the card's own countdown and every projection on it
+   * are computed against one date — so the disagreement does not show up as a
+   * warning, it shows up as numbers that are quietly wrong.
+   *
+   * ⚠ A PERP LEG IS NEVER BLOCKED. A perp is perpetual: one position hedges
+   * every maturity cohort at once, which is why the solver attaches perps
+   * across cohorts freely. It has no maturity to clash with.
+   */
+  const blockedReason = (d: LegDestination): string | null => {
+    if (leg.kind !== 'boros') return null;
+    const mine = leg.maturity;
+    if (!mine || d.borosMaturity === null || d.borosMaturity === mine) return null;
+    return `matures ${fmtDateUtc(d.borosMaturity)}`;
+  };
 
   /** Where the leg goes. HERE / a destination id / NOWHERE / AUTO. */
   const [where, setWhere] = useState<string>(HERE);
@@ -430,16 +470,30 @@ export function LegAssignment({
                 <button type="button" className={optionClass(where === HERE)} onClick={() => setWhere(HERE)}>
                   This position
                 </button>
-                {destinations.map((d) => (
-                  <button
-                    key={d.id}
-                    type="button"
-                    className={optionClass(where === d.id)}
-                    onClick={() => setWhere(d.id)}
-                  >
-                    {d.label}
-                  </button>
-                ))}
+                {destinations.map((d) => {
+                  const blocked = blockedReason(d);
+                  return (
+                    <button
+                      key={d.id}
+                      type="button"
+                      disabled={blocked !== null}
+                      title={
+                        blocked === null
+                          ? undefined
+                          : `That position ${blocked}; this leg matures ${fmtDateUtc(leg.maturity ?? 0)}. A position runs to ONE date — its countdown and every projection on it are computed against a single maturity.`
+                      }
+                      className={`${optionClass(where === d.id)} ${
+                        blocked === null ? '' : 'cursor-not-allowed opacity-40'
+                      }`}
+                      onClick={() => blocked === null && setWhere(d.id)}
+                    >
+                      {d.label}
+                      {blocked !== null && (
+                        <span className="ml-1 text-ink-500">— {blocked}, not this one</span>
+                      )}
+                    </button>
+                  );
+                })}
                 <button
                   type="button"
                   className={optionClass(isNowhere)}

--- a/web/src/panels/PerpLegExpanded.tsx
+++ b/web/src/panels/PerpLegExpanded.tsx
@@ -17,12 +17,16 @@ import { useTradeFlowOptional } from '../trade/TradeFlow';
 export function PositionRowActions({
   position,
   attributedQty,
+  onClosed,
   closeOnly = false,
   levOnly = false,
 }: {
   position: CrossexPosition;
   /** Size the strategy showing this row owns, when the venue leg is shared. */
   attributedQty?: number;
+  /** How much came off the venue, so the card can shrink a stated claim by it
+   * — see ClosePopover's note on what "closed" means here. */
+  onClosed?: (qty: number) => void;
   /** Drop [Lev] and keep [Close]. The collapsed leg row has six columns to fit
    * inside a fixed-width card, and leverage is not something you reach for at
    * a glance the way closing is — it stays in the expanded detail, where the
@@ -88,6 +92,7 @@ export function PositionRowActions({
         <ClosePopover
           position={position}
           attributedQty={attributedQty}
+          onClosed={onClosed}
           onDismiss={() => setOpen(null)}
         />
       )}

--- a/web/src/panels/PositionsHome.test.tsx
+++ b/web/src/panels/PositionsHome.test.tsx
@@ -840,7 +840,7 @@ describe('PositionsHome — a Boros-less pair rendered as a card', () => {
     makeStrategyReturns({
       strategies: [
         makeStrategyRollup({
-          strategyId: 'ETH#perps',
+          strategyId: 'ETH#BINANCE-HYPERLIQUID#0',
           attribution: { source: 'unhedged', confidence: 'measured', pinned: false },
           hedge: 'unhedged',
           maturity: 0,

--- a/web/src/panels/PositionsHome.test.tsx
+++ b/web/src/panels/PositionsHome.test.tsx
@@ -6,12 +6,14 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it, vi } from 'vitest';
-import type { PositionsResponse, StrategyReturns } from '../api/types';
+import type { ActionInput, PositionsResponse, StrategyReturns } from '../api/types';
 import {
+  makeCrossexPosition,
   makeExposureGroup,
   makeStrategyLeg,
   makeStrategyReturns,
   makeStrategyRollup,
+  previewFor,
   versionHandler,
 } from '../test/fixtures';
 import { env, server } from '../test/server';
@@ -944,5 +946,294 @@ describe('PositionsHome → Boros prefill', () => {
 
     await waitFor(() => expect(seen).toHaveLength(1));
     expect(seen[0].maturity).toBe(MATURITY);
+  });
+});
+
+/**
+ * A row names a LEG, so it does not go quiet when its position ends — it lies
+ * in wait for the next position to use that symbol. `applyMembership` ignores
+ * dangling rows per response and its comment says the client deletes them;
+ * the client never did, so closing a hand-grouped position and re-opening the
+ * same market reconstituted the dead one — its id, its grouping, its asserted
+ * entries — with the solver locked out of legs the user never spoke about.
+ */
+describe('PositionsHome — assertions are forgotten when their legs close', () => {
+  const track = () =>
+    localStorage.setItem(STRATEGY_STORAGE_KEY, JSON.stringify({ address: ADDR, since: null }));
+
+  const SAVED_AT = 1_700_000_000;
+
+  /** One card holding Boros market 190 and its Hyperliquid perp. Nothing else
+   * in this book is open — every other leg a row can name has closed. */
+  const liveBook = () =>
+    makeStrategyReturns({
+      strategies: [
+        makeStrategyRollup({
+          legs: [
+            makeStrategyLeg({ marketId: 190 }),
+            makeStrategyLeg({
+              kind: 'perp',
+              side: 'SHORT',
+              symbol: 'HYPERLIQUID_FUTURE_HYPE_USDC',
+              notionalToken: 900,
+              collateral: undefined,
+              entryApr: undefined,
+              markApr: undefined,
+              floatingApr: undefined,
+              maturity: undefined,
+            }),
+          ],
+        }),
+      ],
+    });
+
+  type StoredRow = { positionId?: string; leg: { kind: string; symbol?: string; marketId?: number } };
+  const seed = (rows: StoredRow[], overrides: unknown[] = []) => {
+    localStorage.setItem(
+      'crossex.partition.v1',
+      JSON.stringify({ [BOOK]: { rows, savedAtSec: SAVED_AT } }),
+    );
+    if (overrides.length) {
+      localStorage.setItem(
+        'crossex.entryOverride.v1',
+        JSON.stringify({ [BOOK]: { rows: overrides, savedAtSec: SAVED_AT } }),
+      );
+    }
+  };
+  const storedRows = (): StoredRow[] =>
+    JSON.parse(localStorage.getItem('crossex.partition.v1') ?? '{}')[BOOK]?.rows ?? [];
+  const storedOverrides = (): Array<{ positionId: string }> =>
+    JSON.parse(localStorage.getItem('crossex.entryOverride.v1') ?? '{}')[BOOK]?.rows ?? [];
+
+  /** The strategy feed's own refetch control — the only way to give that feed
+   * a second look inside a test without waiting out its 30s poll. */
+  const lookAgain = () => fireEvent.click(screen.getByTitle('Refetch strategy data'));
+
+  it('drops the rows of a closed Boros market, and keeps the open one', async () => {
+    track();
+    seed([
+      { positionId: 'dead1234', leg: { kind: 'boros', marketId: 777 } },
+      { positionId: 'a3f1c8d2', leg: { kind: 'boros', marketId: 190 } },
+    ]);
+    mockPositions();
+    mockStrategy(liveBook());
+    renderWithClient(<PositionsHome />);
+    await screen.findByText('hedged ✓');
+
+    // ⚠ ONE settled response is not evidence. Venues do answer 200 with an
+    // empty list during an incident, and a prune has no undo — so the first
+    // look only starts the count.
+    expect(storedRows().map((r) => r.leg.marketId)).toEqual([777, 190]);
+
+    lookAgain();
+    await waitFor(() => expect(storedRows().map((r) => r.leg.marketId)).toEqual([190]));
+  });
+
+  it('will not let one feed delete the other feed\'s rows', async () => {
+    // The perp feed polls at 4s and the strategy feed at 30s, so they
+    // practically never settle on the same tick. A strategy refetch says
+    // nothing about a perp symbol and must leave it alone — judging both
+    // against whichever response happened to arrive would delete assertions
+    // about legs nobody looked at.
+    track();
+    seed([
+      { positionId: 'dead1234', leg: { kind: 'perp', symbol: 'GATE_FUTURE_ETH_USDT' } },
+      { positionId: 'dead1234', leg: { kind: 'boros', marketId: 777 } },
+    ]);
+    mockPositions(); // the account holds no perps at all
+    mockStrategy(liveBook());
+    renderWithClient(<PositionsHome />);
+    await screen.findByText('hedged ✓');
+
+    lookAgain();
+    await waitFor(() => expect(storedRows()).toHaveLength(1));
+    expect(storedRows()[0].leg.symbol).toBe('GATE_FUTURE_ETH_USDT');
+  });
+
+  it('takes the asserted entry down with the claim that made it', async () => {
+    // The worse half of the bug: a stale grouping shows on the card, a stale
+    // entry is just a wrong number — re-armed the moment that position id and
+    // leg coexist again, and conserved onto every other claim on the leg.
+    track();
+    seed(
+      [{ positionId: 'dead1234', leg: { kind: 'boros', marketId: 777 } }],
+      [{ positionId: 'dead1234', leg: { kind: 'boros', marketId: 777 }, value: 0.081 }],
+    );
+    mockPositions();
+    mockStrategy(liveBook());
+    renderWithClient(<PositionsHome />);
+    await screen.findByText('hedged ✓');
+    expect(storedOverrides()).toHaveLength(1);
+
+    lookAgain();
+    await waitFor(() => expect(storedRows()).toEqual([]));
+    expect(storedOverrides()).toEqual([]);
+  });
+
+  it('stops sending a closed leg in ?partition=, so re-opening it starts clean', async () => {
+    // What the user actually feels: the pins the server is asked to honour no
+    // longer name the dead position, so the same market opening again is the
+    // solver's to group, not the ghost's to reclaim.
+    track();
+    seed([{ positionId: 'dead1234', leg: { kind: 'boros', marketId: 777 } }]);
+    mockPositions();
+    const urls: string[] = [];
+    server.use(
+      http.get('/api/strategy/:address', ({ request }) => {
+        urls.push(request.url);
+        return HttpResponse.json(env(liveBook()));
+      }),
+    );
+    renderWithClient(<PositionsHome />);
+    await screen.findByText('hedged ✓');
+    expect(urls.every((u) => u.includes('partition='))).toBe(true);
+
+    lookAgain();
+    await waitFor(() => expect(urls[urls.length - 1]).not.toContain('partition='));
+  });
+});
+
+/**
+ * A pinned claim is an ABSOLUTE number, and a venue position NETS.
+ *
+ * Closing a card's own share of a shared leg shrank the venue leg while the
+ * row went on claiming the same size out of what was left — silently taken
+ * from the cards sharing it. From the card it looked as though nothing had
+ * happened: the size held still and only the denominator beside it moved.
+ */
+describe('PositionsHome — a close shrinks the claim it came from', () => {
+  const SYMBOL = 'GATE_FUTURE_ETH_USDT';
+  const PINNED = 'dead1234';
+  /** The venue holds 0.058; this card states 0.01 of it. */
+  const VENUE_QTY = 0.058;
+  const MINE = 0.01;
+
+  const track = () =>
+    localStorage.setItem(STRATEGY_STORAGE_KEY, JSON.stringify({ address: ADDR, since: null }));
+
+  const seedClaim = (qty: number = MINE) =>
+    localStorage.setItem(
+      'crossex.partition.v1',
+      JSON.stringify({
+        [BOOK]: {
+          rows: [{ positionId: PINNED, leg: { kind: 'perp', symbol: SYMBOL }, qty }],
+          savedAtSec: 1_700_000_000,
+        },
+      }),
+    );
+
+  const pinnedBook = () =>
+    makeStrategyReturns({
+      strategies: [
+        makeStrategyRollup({
+          strategyId: PINNED,
+          attribution: { source: 'user', confidence: 'measured', pinned: true },
+          legs: [
+            makeStrategyLeg({ marketId: 190 }),
+            makeStrategyLeg({
+              kind: 'perp',
+              venue: 'GATE',
+              side: 'LONG',
+              symbol: SYMBOL,
+              notionalToken: MINE,
+              share: MINE / VENUE_QTY, // a SHARE of the venue leg, not all of it
+              collateral: undefined,
+              entryApr: undefined,
+              markApr: undefined,
+              floatingApr: undefined,
+              maturity: undefined,
+            }),
+          ],
+        }),
+      ],
+    });
+
+  const closeHandlers = () => [
+    http.post('/api/preview', async ({ request }) => {
+      const { actions } = (await request.json()) as { actions: ActionInput[] };
+      const a = actions[0];
+      return HttpResponse.json(
+        env({
+          previews: [
+            previewFor(a, {
+              side: 'SELL',
+              qty: a.kind === 'close-position' && a.qty ? a.qty : String(VENUE_QTY),
+              price: '2497.45',
+              closing: { positionQty: String(VENUE_QTY), upnl: '3', mark: 2510 },
+            }),
+          ],
+        }),
+      );
+    }),
+    http.post('/api/deals', async ({ request }) =>
+      HttpResponse.json(env({ id: ((await request.json()) as { id: string }).id }), { status: 202 }),
+    ),
+  ];
+
+  const claims = (): Array<{ qty?: number }> =>
+    JSON.parse(localStorage.getItem('crossex.partition.v1') ?? '{}')[BOOK]?.rows ?? [];
+
+  /** Open the leg's close dialog and hold the confirm through. */
+  const closeLeg = async () => {
+    fireEvent.click(await screen.findByTitle(`Close ${SYMBOL}`));
+    const confirm = await screen.findByRole('button', { name: 'Close now ▸' });
+    await waitFor(() => expect(confirm).toBeEnabled());
+    fireEvent.pointerDown(confirm);
+  };
+
+  const renderBook = async () => {
+    track();
+    mockPositions({
+      positions: [makeCrossexPosition({ symbol: SYMBOL, positionQty: String(VENUE_QTY) })],
+    });
+    server.use(
+      http.get('/api/strategy/:address', () => HttpResponse.json(env(pinnedBook()))),
+      ...closeHandlers(),
+    );
+    renderWithClient(<PositionsHome />);
+    await screen.findByTitle(`Close ${SYMBOL}`);
+  };
+
+  it('drops the claim when the card closes the whole of its own share', async () => {
+    // The dialog opens pre-filled with this card's 0.01 — the reported case.
+    // Afterwards the card holds none of that leg, and cannot drift back onto
+    // it: the solver proposes nothing into a card that has rows of its own.
+    seedClaim();
+    await renderBook();
+    await closeLeg();
+    await waitFor(() => expect(claims()).toEqual([]));
+  });
+
+  it('reduces it by the amount closed when only part of the share goes', async () => {
+    seedClaim();
+    await renderBook();
+    fireEvent.click(await screen.findByTitle(`Close ${SYMBOL}`));
+    fireEvent.change(await screen.findByLabelText('Close qty'), { target: { value: '0.004' } });
+    const confirm = await screen.findByRole('button', { name: 'Close now ▸' });
+    await waitFor(() => expect(confirm).toBeEnabled());
+    fireEvent.pointerDown(confirm);
+
+    // The row survives — this card still holds the rest — carrying what is
+    // left rather than the number it walked in with.
+    await waitFor(() => expect(claims()[0]?.qty).toBeCloseTo(MINE - 0.004, 9));
+    expect(claims()).toHaveLength(1);
+  });
+
+  it('leaves a blanket claim alone — "all of it" already follows the venue', async () => {
+    // There is no number to decrement. Writing one would turn a claim that
+    // re-derives itself into a constant that goes stale on the next close.
+    localStorage.setItem(
+      'crossex.partition.v1',
+      JSON.stringify({
+        [BOOK]: {
+          rows: [{ positionId: PINNED, leg: { kind: 'perp', symbol: SYMBOL } }],
+          savedAtSec: 1_700_000_000,
+        },
+      }),
+    );
+    await renderBook();
+    await closeLeg();
+    await waitFor(() => expect(claims()).toHaveLength(1));
+    expect(claims()[0].qty).toBeUndefined();
   });
 });

--- a/web/src/panels/PositionsHome.test.tsx
+++ b/web/src/panels/PositionsHome.test.tsx
@@ -398,7 +398,7 @@ describe('PositionsHome — a book split across strategies', () => {
         // leg, not a footnote beside them — same card, same controls.
         makeStrategyRollup({
           strategyId: 'HYPE#unhedged:HYPERLIQUID_FUTURE_HYPE_USDC',
-          attribution: { source: 'unhedged', confidence: 'measured', pinned: false },
+          attribution: { source: 'unhedged', confidence: 'measured', pinned: false, unclaimed: true },
           hedge: 'unhedged',
           maturity: 0,
           legs: sharedLegs()
@@ -628,7 +628,7 @@ describe('PositionsHome — membership journeys', () => {
           ...loose.map((l) =>
             makeStrategyRollup({
               strategyId: `${l.base}#unhedged:${l.symbol}`,
-              attribution: { source: 'unhedged', confidence: 'measured', pinned: false },
+              attribution: { source: 'unhedged', confidence: 'measured', pinned: false, unclaimed: true },
               hedge: 'unhedged',
               maturity: 0,
               legs: [l],
@@ -1009,6 +1009,29 @@ describe('PositionsHome — assertions are forgotten when their legs close', () 
    * a second look inside a test without waiting out its 30s poll. */
   const lookAgain = () => fireEvent.click(screen.getByTitle('Refetch strategy data'));
 
+  it('keeps a leg that is OPEN but on no card — an unpriced collateral zone', async () => {
+    // ⚠ THE CARDS ARE NOT A CENSUS. `buildBorosLegs` drops a whole collateral
+    // zone whose USD price cannot be resolved, warns, and still answers 200.
+    // Reading "no card holds it" as "the position closed" deleted pins the
+    // user cannot get back — so the prune counts positions, not cards.
+    track();
+    seed([
+      { positionId: 'a3f1c8d2', leg: { kind: 'boros', marketId: 190 } },
+      // Open, but on no card — its collateral zone could not be priced.
+      { positionId: 'a3f1c8d2', leg: { kind: 'boros', marketId: 777 } },
+      // Genuinely closed: on no card AND not a live position. Its disappearance
+      // is what proves the prune actually ran, so 777 surviving means something.
+      { positionId: 'a3f1c8d2', leg: { kind: 'boros', marketId: 999 } },
+    ]);
+    mockPositions();
+    mockStrategy({ ...liveBook(), liveBorosMarketIds: [190, 777] });
+    renderWithClient(<PositionsHome />);
+    await screen.findByText('hedged ✓');
+
+    lookAgain();
+    await waitFor(() => expect(storedRows().map((r) => r.leg.marketId)).toEqual([190, 777]));
+  });
+
   it('drops the rows of a closed Boros market, and keeps the open one', async () => {
     track();
     seed([
@@ -1291,7 +1314,7 @@ describe('PositionsHome — Automatic forgets only this card', () => {
         }),
         makeStrategyRollup({
           strategyId: 'HYPE#unhedged:190',
-          attribution: { source: 'unhedged', confidence: 'measured', pinned: false },
+          attribution: { source: 'unhedged', confidence: 'measured', pinned: false, unclaimed: true },
           hedge: 'unhedged',
           legs: [borosLeg(REST, REST / (MINE + REST))],
         }),
@@ -1335,6 +1358,76 @@ describe('PositionsHome — Automatic forgets only this card', () => {
     expect(rowsNow()).toEqual([
       { positionId: PINNED, leg: { kind: 'boros', marketId: MARKET }, qty: MINE },
     ]);
+  });
+
+  /**
+   * ⚠ `unclaimed`, NOT `source === 'unhedged'`.
+   *
+   * `source` answers how a grouping was arrived at, and reusing it here
+   * collided both ways: a solver tranche on a coin with no Boros ALSO reports
+   * 'unhedged' (the chip means "no rate is locked against this"), while the
+   * Boros remainder card reports 'boros-only'/'merged'.
+   */
+  it('leaves a neighbour\'s detachment alone when pressed on a solver tranche', async () => {
+    // `ETH#BINANCE-HYPERLIQUID#0` is what the solver emits for a coin with no
+    // Boros cohort — reported 'unhedged' because nothing locks a rate against
+    // it, but it asserted nothing and owns no rows. Automatic there is a
+    // statement about a card that never claimed the leg.
+    track();
+    seed([{ leg: { kind: 'boros', marketId: MARKET }, qty: REST }]);
+    mockPositions();
+    mockStrategy(
+      makeStrategyReturns({
+        strategies: [
+          makeStrategyRollup({
+            strategyId: 'HYPE#BINANCE-HYPERLIQUID#0',
+            attribution: { source: 'unhedged', confidence: 'measured', pinned: false },
+            hedge: 'unhedged',
+            legs: [borosLeg(MINE, MINE / (MINE + REST))],
+          }),
+        ],
+        liveBorosMarketIds: [MARKET],
+      }),
+    );
+    renderWithClient(<PositionsHome />);
+    await screen.findAllByTitle(/click to assign|click to change/);
+    await automaticOnRemainder();
+
+    // The orphan row is somebody else's detachment and must survive.
+    await waitFor(() => expect(rowsNow()).toHaveLength(1));
+    expect(rowsNow()[0].positionId).toBeUndefined();
+  });
+
+  it('un-detaches from a Boros remainder card, which reports neither pinned nor unhedged', async () => {
+    // The unowned Boros card carries source 'boros-only' / 'merged'. Keying
+    // off 'unhedged' made Automatic a silent no-op here — the one card family
+    // where it genuinely means "forget my detachment".
+    track();
+    seed([{ leg: { kind: 'boros', marketId: MARKET }, qty: REST }]);
+    mockPositions();
+    mockStrategy(
+      makeStrategyReturns({
+        strategies: [
+          makeStrategyRollup({
+            strategyId: 'HYPE@boros-remainder',
+            attribution: {
+              source: 'merged',
+              confidence: 'measured',
+              pinned: false,
+              unclaimed: true,
+            },
+            hedge: 'unhedged',
+            legs: [borosLeg(REST, 1)],
+          }),
+        ],
+        liveBorosMarketIds: [MARKET],
+      }),
+    );
+    renderWithClient(<PositionsHome />);
+    await screen.findAllByTitle(/click to assign|click to change/);
+    await automaticOnRemainder();
+
+    await waitFor(() => expect(rowsNow()).toEqual([]));
   });
 
   it('still sends the pin to the server, so the card does not lose the leg', async () => {

--- a/web/src/panels/PositionsHome.test.tsx
+++ b/web/src/panels/PositionsHome.test.tsx
@@ -525,6 +525,51 @@ describe('PositionsHome — a book split across strategies', () => {
     });
   });
 
+  /** Every positionId currently written for this book. */
+  const storedIds = (): string[] => [
+    ...new Set(
+      ((JSON.parse(localStorage.getItem('crossex.partition.v1') ?? '{}')[BOOK]?.rows ??
+        []) as Array<{ positionId?: string }>)
+        .map((r) => r.positionId)
+        .filter((x): x is string => typeof x === 'string'),
+    ),
+  ];
+
+  it('mints ONE id when a single Confirm carries both an entry and a size', async () => {
+    /**
+     * ⚠ ONE CONFIRM IS ONE CHANGE, however many facts it carries.
+     *
+     * `commit()` emits `entry` and then `assign` as two `applyAssertion`
+     * calls. Each one froze the card by re-reading `attribution.pinned` off
+     * the SAME rollup prop — still false, because no server response has
+     * landed in between — so the second minted a second id and wrote a second
+     * full row set. Every leg was then claimed by two ids at once, which the
+     * server duly split down the middle into two phantom positions, with the
+     * asserted entry hanging off whichever half went first.
+     */
+    track();
+    mockPositions();
+    mockStrategy(splitReturns());
+    renderWithClient(<PositionsHome />);
+    await screen.findByText('split unconfirmed');
+
+    // Stay on this card (so the entry question is asked) and change BOTH.
+    openAssign();
+    fireEvent.change(screen.getByLabelText(/size for this position/), { target: { value: '175' } });
+    fireEvent.change(screen.getByLabelText(/entry price for this position/), {
+      target: { value: '2461' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => expect(storedIds().length).toBeGreaterThan(0));
+    // One card, one id — not two halves of one card.
+    expect(new Set(storedIds()).size).toBe(1);
+    // …and the entry belongs to the id that actually holds the legs.
+    const overrides = JSON.parse(localStorage.getItem('crossex.entryOverride.v1') ?? '{}')[BOOK]
+      ?.rows as Array<{ positionId: string }> | undefined;
+    expect(overrides?.[0]?.positionId).toBe(storedIds()[0]);
+  });
+
   it('freezes what the solver proposed, then applies the correction', async () => {
     // The first assertion on a proposed card mints an id and writes a row for
     // every leg it already had — otherwise correcting one leg would hand the

--- a/web/src/panels/PositionsHome.test.tsx
+++ b/web/src/panels/PositionsHome.test.tsx
@@ -1237,3 +1237,128 @@ describe('PositionsHome — a close shrinks the claim it came from', () => {
     expect(claims()[0].qty).toBeUndefined();
   });
 });
+
+/**
+ * "Automatic" is scoped to the card it was pressed on.
+ *
+ * A shared venue leg is on more than one card. Choosing Automatic on the
+ * unclaimed remainder used to delete EVERY row naming that leg — including
+ * the pin a hand-grouped card held on it, a card the user never touched — and
+ * the solver, now seeing the whole venue leg free, swept all of it into one
+ * position. The pinned card silently lost its leg.
+ */
+describe('PositionsHome — Automatic forgets only this card', () => {
+  const PINNED = 'a1b2c3d4';
+  const MARKET = 190;
+  const MINE = 0.01;
+  const REST = 0.04;
+
+  const track = () =>
+    localStorage.setItem(STRATEGY_STORAGE_KEY, JSON.stringify({ address: ADDR, since: null }));
+
+  const borosLeg = (notionalToken: number, share: number) =>
+    makeStrategyLeg({
+      marketId: MARKET,
+      venue: 'HYPERLIQUID',
+      side: 'SHORT' as const,
+      notionalToken,
+      share,
+    });
+
+  /** One venue leg of 0.05, split: 0.01 pinned to a hand-grouped card, 0.04
+   * left over as its own unhedged card. */
+  const sharedBook = () =>
+    makeStrategyReturns({
+      strategies: [
+        makeStrategyRollup({
+          strategyId: PINNED,
+          attribution: { source: 'user', confidence: 'measured', pinned: true },
+          legs: [
+            makeStrategyLeg({
+              kind: 'perp',
+              venue: 'BINANCE',
+              side: 'LONG',
+              symbol: 'BINANCE_FUTURE_HYPE_USDT',
+              notionalToken: 0.05,
+              collateral: undefined,
+              entryApr: undefined,
+              markApr: undefined,
+              floatingApr: undefined,
+              maturity: undefined,
+            }),
+            borosLeg(MINE, MINE / (MINE + REST)),
+          ],
+        }),
+        makeStrategyRollup({
+          strategyId: 'HYPE#unhedged:190',
+          attribution: { source: 'unhedged', confidence: 'measured', pinned: false },
+          hedge: 'unhedged',
+          legs: [borosLeg(REST, REST / (MINE + REST))],
+        }),
+      ],
+    });
+
+  const seed = (rows: unknown[]) =>
+    localStorage.setItem(
+      'crossex.partition.v1',
+      JSON.stringify({ [BOOK]: { rows, savedAtSec: 1_700_000_000 } }),
+    );
+  const rowsNow = (): Array<{ positionId?: string; qty?: number }> =>
+    JSON.parse(localStorage.getItem('crossex.partition.v1') ?? '{}')[BOOK]?.rows ?? [];
+
+  /** Automatic on the LAST assign trigger — the unhedged card renders after
+   * the pinned one, and holds only the Boros leg. */
+  const automaticOnRemainder = async () => {
+    for (const t of screen.getAllByRole('button', { name: 'toggle details' })) fireEvent.click(t);
+    const triggers = screen.getAllByTitle(/click to assign|click to change/);
+    fireEvent.click(triggers[triggers.length - 1]);
+    fireEvent.click(screen.getByRole('button', { name: /Automatic/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+  };
+
+  it('hands the remainder back without stripping the pin on the same leg', async () => {
+    track();
+    seed([
+      { positionId: PINNED, leg: { kind: 'boros', marketId: MARKET }, qty: MINE },
+      { leg: { kind: 'boros', marketId: MARKET }, qty: REST },
+    ]);
+    mockPositions();
+    mockStrategy(sharedBook());
+    renderWithClient(<PositionsHome />);
+    await screen.findByText('grouped by you');
+
+    await automaticOnRemainder();
+
+    // The orphan row goes — that is what Automatic was asked for…
+    await waitFor(() => expect(rowsNow().filter((r) => r.positionId === undefined)).toEqual([]));
+    // …and the hand-grouped card keeps its 0.01. It was never in the question.
+    expect(rowsNow()).toEqual([
+      { positionId: PINNED, leg: { kind: 'boros', marketId: MARKET }, qty: MINE },
+    ]);
+  });
+
+  it('still sends the pin to the server, so the card does not lose the leg', async () => {
+    track();
+    seed([
+      { positionId: PINNED, leg: { kind: 'boros', marketId: MARKET }, qty: MINE },
+      { leg: { kind: 'boros', marketId: MARKET }, qty: REST },
+    ]);
+    mockPositions();
+    const urls: string[] = [];
+    server.use(
+      http.get('/api/strategy/:address', ({ request }) => {
+        urls.push(request.url);
+        return HttpResponse.json(env(sharedBook()));
+      }),
+    );
+    renderWithClient(<PositionsHome />);
+    await screen.findByText('grouped by you');
+
+    await automaticOnRemainder();
+
+    // Every request after the change still carries a partition — an empty one
+    // would mean the whole leg went back to the solver, which is the bug.
+    await waitFor(() => expect(urls.length).toBeGreaterThan(1));
+    expect(urls[urls.length - 1]).toContain('partition=');
+  });
+});

--- a/web/src/panels/PositionsHome.tsx
+++ b/web/src/panels/PositionsHome.tsx
@@ -212,6 +212,28 @@ export function PositionsHome() {
   const strategies = strategyQuery.data?.strategies ?? EMPTY_STRATEGIES;
 
   /**
+   * Ids minted for solver-proposed cards since the last server response.
+   *
+   * ⚠ ONE CONFIRM IS ONE CHANGE, however many facts it carries. `commit()`
+   * emits an entry correction and a membership change as two `applyAssertion`
+   * calls, and `freeze` decides whether a card already has an id by reading
+   * `attribution.pinned` off the rollup PROP — which is still false during the
+   * second call, because no response has landed in between. So the second call
+   * minted a second id and wrote a second full row set, every leg ended up
+   * claimed by two ids at once, and the server split the card down the middle
+   * into two phantom positions with the asserted entry on one of them.
+   *
+   * Memoizing by the card's current strategyId makes `freeze` idempotent for
+   * as long as the prop it cannot trust stays stale. Keyed on the `strategies`
+   * array identity so a fresh response starts over — by then the card carries
+   * its minted id as its own strategyId and takes the pinned branch anyway.
+   */
+  const mintedFor = useRef<{ solved: readonly StrategyRollup[]; ids: Map<string, string> }>({
+    solved: EMPTY_STRATEGIES,
+    ids: new Map(),
+  });
+
+  /**
    * Record where the user says one leg belongs.
    *
    * ⚠ Both ENDS of a move have to be frozen. A solver-proposed card has no
@@ -227,7 +249,15 @@ export function PositionsHome() {
         let next = prev;
         const freeze = (s: StrategyRollup): string => {
           if (s.attribution.pinned) return s.strategyId;
+          if (mintedFor.current.solved !== strategies) {
+            mintedFor.current = { solved: strategies, ids: new Map() };
+          }
+          // Same card, same tick, same id — see the note on `mintedFor`. Also
+          // what makes this updater safe to run twice under StrictMode.
+          const already = mintedFor.current.ids.get(s.strategyId);
+          if (already !== undefined) return already;
           const id = newPositionId();
+          mintedFor.current.ids.set(s.strategyId, id);
           for (const l of s.legs) {
             const ref = legRefOf(l);
             if (!ref) continue;

--- a/web/src/panels/PositionsHome.tsx
+++ b/web/src/panels/PositionsHome.tsx
@@ -42,7 +42,12 @@ import {
   type MembershipRow,
   type RowChange,
 } from './partitionStore';
-import { legRefOf, positionVenues, type LegAssertion } from './PartitionEditor';
+import {
+  legRefOf,
+  positionVenues,
+  type LegAssertion,
+  type LegDestination,
+} from './PartitionEditor';
 import { crossexVenueFor } from '../lib/boros';
 
 /** Stable empty list, so a callback's deps don't change every render. */
@@ -119,14 +124,32 @@ function distinctLabels(items: readonly StrategyRollup[]): string[] {
   return labels;
 }
 
-/** The other cards a leg on `s` can be sent to: same coin, any shape. */
+/**
+ * The other cards a leg on `s` can be sent to: same coin, any shape.
+ *
+ * Shape is still not a filter — a card may hold one leg or six, a hedge that
+ * is half-open, a spread with no perps yet. What each destination carries is
+ * the Boros maturity it already holds, so the dialog can refuse the one shape
+ * a solved card can never have: two maturities at once. See `LegDestination`.
+ */
 function destinationsFor(
   s: StrategyRollup,
   all: readonly StrategyRollup[],
-): Array<{ id: string; label: string }> {
+): LegDestination[] {
   const others = all.filter((o) => o.strategyId !== s.strategyId && o.base === s.base);
   const labels = distinctLabels(others);
-  return others.map((o, i) => ({ id: o.strategyId, label: labels[i] }));
+  return others.map((o, i) => {
+    // The EARLIEST, because that is the one every number on that card is
+    // computed against (`assembleStrategy` takes `Math.min`).
+    const maturities = o.legs
+      .filter((l) => l.kind === 'boros' && typeof l.maturity === 'number' && l.maturity > 0)
+      .map((l) => l.maturity as number);
+    return {
+      id: o.strategyId,
+      label: labels[i],
+      borosMaturity: maturities.length ? Math.min(...maturities) : null,
+    };
+  });
 }
 
 export function PositionsHome() {

--- a/web/src/panels/PositionsHome.tsx
+++ b/web/src/panels/PositionsHome.tsx
@@ -376,15 +376,23 @@ export function PositionsHome() {
            * same warning; this mode simply never got it.
            *
            * Which rows are "this card's" follows from how the card exists at
-           * all: a PINNED card owns rows under its own id, and an UNHEDGED
+           * all: a PINNED card owns rows under its own id, and an UNCLAIMED
            * card IS what an orphan row produces, so its rows carry no id. A
            * solver-proposed card asserted nothing, so it has nothing to
            * forget — Automatic is already true of it, and touching the orphan
            * rows from there would strip a neighbour's detachment instead.
+           *
+           * ⚠ `unclaimed`, NOT `source === 'unhedged'`. `source` answers how a
+           * grouping was arrived at, which is a different question, and using
+           * it here collided both ways: a solver tranche on a coin with no
+           * Boros also reports `'unhedged'` (so Automatic there deleted a
+           * neighbour's detachment — this exact bug, from the other side),
+           * while the Boros remainder card reports `'boros-only'`/`'merged'`
+           * (so Automatic there silently did nothing at all).
            */
           if (from.attribution.pinned) {
             next = withRow(next, { mode: 'auto', leg: a.leg, positionId: from.strategyId });
-          } else if (from.attribution.source === 'unhedged') {
+          } else if (from.attribution.unclaimed) {
             next = withRow(next, { mode: 'auto', leg: a.leg });
           }
         }
@@ -437,16 +445,29 @@ export function PositionsHome() {
   }, [positionsData?.positions, strategies]);
 
   /**
-   * Boros legs the book actually holds.
+   * Boros legs the book actually holds — from the payload's own count of live
+   * positions, NEVER from the cards.
    *
-   * Here the cards ARE the authority, and the payload offers nothing else —
-   * there is no flat list of Boros positions on the wire. It is sound because
-   * every live Boros leg reaches a card: what no position claimed and what the
-   * user detached both become their own unowned card (`returns.ts:addUnowned`),
-   * which is the asymmetry with perps above.
+   * ⚠ THE CARDS ARE NOT A CENSUS OF THE VENUE. This read them, on the
+   * reasoning that every live Boros leg reaches a card: what no position
+   * claimed and what the user detached both become their own unowned card.
+   * That holds for the grouping passes and fails before them —
+   * `buildBorosLegs` drops an entire collateral zone whose USD price cannot be
+   * resolved, warns, and still answers 200. Those positions are open and on no
+   * card, so the prune read them as closed and deleted the user's pins and
+   * asserted entries for them: the exact irreversible loss the two-look guard
+   * exists to prevent, reached by a route the guard cannot see.
+   *
+   * `liveBorosMarketIds` counts positions in the account's own zones and
+   * nothing else, so no downstream filtering can shorten it.
    */
   const liveBorosLegs = useMemo(() => {
     const live = new Set<string>();
+    for (const marketId of strategyData?.liveBorosMarketIds ?? []) {
+      live.add(legRefKey({ kind: 'boros', marketId }));
+    }
+    // A card holding a leg the census somehow missed is still evidence that
+    // leg is open. The union can only ever KEEP rows.
     for (const s of strategies) {
       for (const l of s.legs) {
         if (l.kind !== 'boros') continue;
@@ -455,7 +476,7 @@ export function PositionsHome() {
       }
     }
     return live;
-  }, [strategies]);
+  }, [strategyData?.liveBorosMarketIds, strategies]);
 
   /**
    * What each feed reported the LAST time it settled.

--- a/web/src/panels/PositionsHome.tsx
+++ b/web/src/panels/PositionsHome.tsx
@@ -40,7 +40,6 @@ import {
   saveRows,
   withRow,
   type MembershipRow,
-  type RowChange,
 } from './partitionStore';
 import {
   legRefOf,
@@ -365,9 +364,29 @@ export function PositionsHome() {
             saveOverrides(bookId, nextEntries, Math.floor(Date.now() / 1000));
             return nextEntries;
           });
-        } else {
-          const change: RowChange = { mode: a.mode, leg: a.leg };
-          next = withRow(next, change);
+        } else if (a.mode === 'auto') {
+          /**
+           * ⚠ FORGET ONLY WHAT THIS CARD SAID, never the whole leg.
+           *
+           * This dropped every row naming the leg. On a shared one that meant
+           * pressing Automatic on the unclaimed 0.04 remainder also deleted
+           * the 0.01 a pinned card held — a card the user never touched — and
+           * the solver, now seeing all 0.05 free, swept it into one position.
+           * The pinned card silently lost its leg. `orphan` above carries the
+           * same warning; this mode simply never got it.
+           *
+           * Which rows are "this card's" follows from how the card exists at
+           * all: a PINNED card owns rows under its own id, and an UNHEDGED
+           * card IS what an orphan row produces, so its rows carry no id. A
+           * solver-proposed card asserted nothing, so it has nothing to
+           * forget — Automatic is already true of it, and touching the orphan
+           * rows from there would strip a neighbour's detachment instead.
+           */
+          if (from.attribution.pinned) {
+            next = withRow(next, { mode: 'auto', leg: a.leg, positionId: from.strategyId });
+          } else if (from.attribution.source === 'unhedged') {
+            next = withRow(next, { mode: 'auto', leg: a.leg });
+          }
         }
         saveRows(bookId, next, Math.floor(Date.now() / 1000));
         return next;

--- a/web/src/panels/PositionsHome.tsx
+++ b/web/src/panels/PositionsHome.tsx
@@ -7,7 +7,7 @@
  * Owns the persisted {address, since, exit flags} state and both queries;
  * the boxes themselves are prop-driven.
  */
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { qk, usePositions, useStrategy } from '../api/queries';
 import type { CrossexPosition, StrategyRollup } from '../api/types';
@@ -21,6 +21,7 @@ import { useBookId } from './bookId';
 import {
   loadOverrides,
   overrideFor,
+  pruneOverrides,
   saveOverrides,
   withOverride,
   type EntryOverride,
@@ -35,6 +36,7 @@ import {
   legRefKey,
   loadRows,
   newPositionId,
+  pruneRows,
   saveRows,
   withRow,
   type MembershipRow,
@@ -45,6 +47,32 @@ import { crossexVenueFor } from '../lib/boros';
 
 /** Stable empty list, so a callback's deps don't change every render. */
 const EMPTY_STRATEGIES: StrategyRollup[] = [];
+
+/** One feed's last settled answer: which legs it reported, and which fetch
+ * said so. The stamp is what makes a second look a second FETCH. */
+interface Seen {
+  at: number;
+  legs: ReadonlySet<string>;
+}
+
+/**
+ * Fold a feed's newest answer into what it said last time.
+ *
+ * `legs` is the union of the two — every leg either look reported, which is
+ * what a prune is allowed to believe is gone — or null while this feed has
+ * only been looked at once, which is not enough to delete anything.
+ */
+function confirmedLegs(
+  prev: Seen | null,
+  at: number,
+  legs: ReadonlySet<string>,
+): { seen: Seen; legs: ReadonlySet<string> | null } {
+  if (prev === null) return { seen: { at, legs }, legs: null };
+  // The same fetch re-read: keep the earlier pair, and keep answering with it,
+  // so a re-render neither advances the count nor forgets a confirmed absence.
+  if (prev.at === at) return { seen: prev, legs: null };
+  return { seen: { at, legs }, legs: new Set([...prev.legs, ...legs]) };
+}
 
 /** A position, named the way its own card header names it. */
 const labelFor = (s: StrategyRollup): string => {
@@ -121,8 +149,15 @@ export function PositionsHome() {
   // Scoped to the book for the same reason the rows are.
   const [entryRows, setEntryRows] = useState<EntryOverride[]>(() => loadOverrides(bookId));
   const [rowsFor, setRowsFor] = useState<string>(bookId);
+  // WHEN this book came on screen. A credentials swap invalidates every query
+  // but does not blank what they already hold, so for a beat `bookId` names
+  // the new account while both feeds still answer for the old one — and
+  // pruning against that would delete the new book's assertions using the old
+  // book's legs. A response is only believed once it is stamped after this.
+  const [bookSince, setBookSince] = useState<number>(() => Date.now());
   if (rowsFor !== bookId) {
     setRowsFor(bookId);
+    setBookSince(Date.now());
     setRows(loadRows(bookId));
     setEntryRows(loadOverrides(bookId));
   }
@@ -259,6 +294,42 @@ export function PositionsHome() {
             // Whole leg → no size, so it stays orphaned if the venue grows it.
             ...(share < 0.999 ? { qty: mine?.notionalToken } : {}),
           });
+        } else if (a.mode === 'closed') {
+          /**
+           * ⚠ ONLY A STATED SIZE CAN GO STALE, and only on the card that
+           * stated it.
+           *
+           * A blanket claim ("all of it") is already relative — it re-derives
+           * from whatever the venue still holds — and a solver-proposed card
+           * is re-solved from the venue on every response. Both follow a close
+           * on their own. Writing a row for either would PIN a grouping the
+           * user never asserted, on their way out of the position, which is
+           * the last moment to start freezing things.
+           */
+          const key = legRefKey(a.leg);
+          const held = next.find(
+            (r) =>
+              r.positionId === from.strategyId && legRefKey(r.leg) === key && r.qty !== undefined,
+          )?.qty;
+          if (held !== undefined) {
+            const left = held - a.qty;
+            // Nothing left worth stating: drop the row, and this card simply
+            // does not hold that leg any more. It cannot drift back — the
+            // solver proposes nothing into a card that has rows of its own.
+            next =
+              left > Math.max(1e-9, held * 1e-6)
+                ? withRow(next, {
+                    mode: 'assign',
+                    positionId: from.strategyId,
+                    leg: a.leg,
+                    qty: left,
+                  })
+                : withRow(next, {
+                    mode: 'release',
+                    positionId: from.strategyId,
+                    leg: a.leg,
+                  });
+          }
         } else if (a.mode === 'entry') {
           // An entry says what THIS card paid, so it needs a stable id to hang
           // off — the same freeze the membership modes use. Nothing about the
@@ -296,6 +367,114 @@ export function PositionsHome() {
     for (const p of positionsData?.positions ?? []) map.set(p.symbol, p);
     return map;
   }, [positionsData?.positions]);
+
+  /**
+   * Perp legs the book actually holds, as `legRefKey` strings.
+   *
+   * The POSITIONS feed is the authority, not the cards: a perp the user
+   * detached never appears on one. `applyMembership` drops a detached perp
+   * straight out of the pool and the derived pass reports it by subtraction —
+   * so pruning perps against the cards would delete exactly the assertion that
+   * made the leg invisible, handing the leg back to the solver on the next
+   * poll. The cards are unioned in anyway: a leg on a card the 4s feed has not
+   * caught up with yet is still open, and the union can only keep rows.
+   */
+  const livePerpLegs = useMemo(() => {
+    const live = new Set<string>();
+    for (const p of positionsData?.positions ?? []) {
+      live.add(legRefKey({ kind: 'perp', symbol: p.symbol }));
+    }
+    for (const s of strategies) {
+      for (const l of s.legs) {
+        if (l.kind !== 'perp') continue;
+        const ref = legRefOf(l);
+        if (ref) live.add(legRefKey(ref));
+      }
+    }
+    return live;
+  }, [positionsData?.positions, strategies]);
+
+  /**
+   * Boros legs the book actually holds.
+   *
+   * Here the cards ARE the authority, and the payload offers nothing else —
+   * there is no flat list of Boros positions on the wire. It is sound because
+   * every live Boros leg reaches a card: what no position claimed and what the
+   * user detached both become their own unowned card (`returns.ts:addUnowned`),
+   * which is the asymmetry with perps above.
+   */
+  const liveBorosLegs = useMemo(() => {
+    const live = new Set<string>();
+    for (const s of strategies) {
+      for (const l of s.legs) {
+        if (l.kind !== 'boros') continue;
+        const ref = legRefOf(l);
+        if (ref) live.add(legRefKey(ref));
+      }
+    }
+    return live;
+  }, [strategies]);
+
+  /**
+   * What each feed reported the LAST time it settled.
+   *
+   * A leg has to be missing from two consecutive responses OF ITS OWN FEED
+   * before its rows are deleted. Venues do answer 200 with an empty list
+   * during an incident, and a single such poll would otherwise erase a whole
+   * book of assertions with no undo — the user would rebuild the grouping from
+   * memory, which is the failure `partitionStore` exists to prevent. Waiting
+   * one more poll costs a cleanup 4s (perps) or 30s (Boros) of lateness.
+   *
+   * Per feed, and keyed by `dataUpdatedAt`, so neither a re-render nor the
+   * perp feed's faster cadence can pass off one look as two.
+   */
+  const lastSeen = useRef<{ perp: Seen | null; boros: Seen | null }>({ perp: null, boros: null });
+
+  const perpAt = positionsQuery.dataUpdatedAt;
+  const borosAt = strategyQuery.dataUpdatedAt;
+  // Both halves of the book have to be settled, and settled for THIS book —
+  // see `bookSince`. Either one missing means we cannot tell a closed leg from
+  // an unloaded one, and a prune is forever.
+  const settledForBook =
+    positionsQuery.isSuccess && strategyQuery.isSuccess && perpAt > bookSince && borosAt > bookSince;
+
+  useEffect(() => {
+    if (!settledForBook) {
+      // A book change or a failed feed voids the first look; the next two
+      // start the count again.
+      lastSeen.current = { perp: null, boros: null };
+      return;
+    }
+    const perp = confirmedLegs(lastSeen.current.perp, perpAt, livePerpLegs);
+    const boros = confirmedLegs(lastSeen.current.boros, borosAt, liveBorosLegs);
+    lastSeen.current = { perp: perp.seen, boros: boros.seen };
+    if (perp.legs === null && boros.legs === null) return; // no feed looked again
+
+    /**
+     * ⚠ EACH KIND IS JUDGED BY ITS OWN FEED, and only while that feed has just
+     * confirmed an absence. The feeds run 4s and 30s apart, so they practically
+     * never advance on the same tick — requiring both would mean this never
+     * ran at all. `null` is "that feed has nothing new to say", which is not
+     * evidence of anything, so its rows are kept and it gets its own turn.
+     */
+    const nextRows = pruneRows(rows, (leg) =>
+      leg.kind === 'perp'
+        ? perp.legs === null || perp.legs.has(legRefKey(leg))
+        : boros.legs === null || boros.legs.has(legRefKey(leg)),
+    );
+    // Membership first: an override outlives its leg only through its claim.
+    const nextEntries = pruneOverrides(entryRows, nextRows);
+    if (nextRows === rows && nextEntries === entryRows) return;
+    const nowSec = Math.floor(Date.now() / 1000);
+    if (nextRows !== rows) {
+      saveRows(bookId, nextRows, nowSec);
+      setRows(nextRows);
+    }
+    if (nextEntries !== entryRows) {
+      saveOverrides(bookId, nextEntries, nowSec);
+      setEntryRows(nextEntries);
+    }
+  }, [settledForBook, perpAt, borosAt, livePerpLegs, liveBorosLegs, rows, entryRows, bookId]);
 
   // Perp-only cue: never claim "no Boros position" unless the strategy feed
   // has actually SETTLED successfully for the tracked address.

--- a/web/src/panels/StrategyCard.tsx
+++ b/web/src/panels/StrategyCard.tsx
@@ -1000,6 +1000,12 @@ export function StrategyCard({
             // acts on the whole position, so the popover has to open on THIS
             // position's size, not the venue's.
             attributedQty={(r.share ?? 1) < 0.999 ? r.notionalToken : undefined}
+            // …and the claim has to come down by what was closed, or the row
+            // goes on asserting a size this card no longer holds.
+            onClosed={(qty) => {
+              const ref = legRefOf(r);
+              if (ref) onAssert?.({ mode: 'closed', leg: ref, qty });
+            }}
             closeOnly
           />
         ) : null;
@@ -1672,7 +1678,14 @@ export function StrategyCard({
           widthClass="w-[460px]"
         >
           <div className="p-4">
-            <CloseBorosForm legs={closingBoros} onDone={() => setClosingBoros([])} />
+            <CloseBorosForm
+              legs={closingBoros}
+              onClosed={(leg, filled) => {
+                const ref = legRefOf(leg);
+                if (ref) onAssert?.({ mode: 'closed', leg: ref, qty: filled });
+              }}
+              onDone={() => setClosingBoros([])}
+            />
           </div>
         </Modal>
       )}

--- a/web/src/panels/entryOverrideStore.test.ts
+++ b/web/src/panels/entryOverrideStore.test.ts
@@ -3,12 +3,14 @@ import {
   loadOverrides,
   overrideFor,
   overrunsVenue,
+  pruneOverrides,
   reconcileEntries,
   saveOverrides,
   withOverride,
   type EntryClaim,
   type EntryOverride,
 } from './entryOverrideStore';
+import type { MembershipRow } from './partitionStore';
 
 const perp = (symbol: string) => ({ kind: 'perp' as const, symbol });
 const boros = (marketId: number) => ({ kind: 'boros' as const, marketId });
@@ -201,5 +203,49 @@ describe('overrunsVenue', () => {
 
   it('is true when the claims assert more size than the venue holds', () => {
     expect(overrunsVenue(claims(100, 100), 100, 0.005)).toBe(true);
+  });
+});
+
+/**
+ * An asserted entry dies with the CLAIM, not merely with the leg.
+ *
+ * Worse than a stale grouping, which at least shows on the card: a stale
+ * override re-arms silently the next time that position id and leg coexist,
+ * pricing a re-opened leg at what a long-closed position paid — and, because
+ * the venue blend is conserved across claims, pushing the invented difference
+ * onto whatever else claims that leg.
+ */
+describe('pruneOverrides', () => {
+  const OV: EntryOverride[] = [
+    { positionId: 'a1', leg: perp('BINANCE_ETH'), value: 2457.77 },
+    { positionId: 'a1', leg: boros(190), value: 0.081 },
+  ];
+
+  it('drops an assertion whose leg closed', () => {
+    const membership: MembershipRow[] = [{ positionId: 'a1', leg: boros(190) }];
+    expect(pruneOverrides(OV, membership)).toEqual([OV[1]]);
+  });
+
+  it('drops an assertion whose position let go of a still-open leg', () => {
+    // The leg lives on — another card claims it now — but a1 no longer paid
+    // anything for it, so a1's number must not be waiting for a1 to come back.
+    const membership: MembershipRow[] = [
+      { positionId: 'b2', leg: perp('BINANCE_ETH') },
+      { positionId: 'a1', leg: boros(190) },
+    ];
+    expect(pruneOverrides(OV, membership)).toEqual([OV[1]]);
+  });
+
+  it('ignores orphan rows — nobody claims a detached leg, so nobody paid for it', () => {
+    const membership: MembershipRow[] = [{ leg: perp('BINANCE_ETH') }];
+    expect(pruneOverrides(OV, membership)).toEqual([]);
+  });
+
+  it('returns the same array when every assertion still has its claim', () => {
+    const membership: MembershipRow[] = [
+      { positionId: 'a1', leg: perp('BINANCE_ETH') },
+      { positionId: 'a1', leg: boros(190), qty: 0.4 },
+    ];
+    expect(pruneOverrides(OV, membership)).toBe(OV);
   });
 });

--- a/web/src/panels/entryOverrideStore.ts
+++ b/web/src/panels/entryOverrideStore.ts
@@ -22,7 +22,7 @@
  * Anything else would let a user quietly restate their cost basis.
  */
 import { readJson, writeJson } from '../lib/storage';
-import { legRefKey, type LegRef } from './partitionStore';
+import { legRefKey, type LegRef, type MembershipRow } from './partitionStore';
 
 const KEY = 'crossex.entryOverride.v1';
 
@@ -235,4 +235,44 @@ export function overrunsVenue(
   if (restQty < 0) return true; // asserted more size than the venue holds
   const implied = (venueEntry * venueQty - assertedNotional) / restQty;
   return !(Number.isFinite(implied) && implied > 0);
+}
+
+/**
+ * Drop every asserted entry that no surviving CLAIM stands behind.
+ *
+ * An override is a statement about one claim — "my half of that leg entered at
+ * 3 412" — so it dies with the claim, not just with the leg. Both ways of
+ * dying are covered by taking the pruned membership rows as the authority:
+ *
+ *  - the leg closed, so `pruneRows` already deleted every row naming it;
+ *  - the leg is still open but this position let go of it (moved it to another
+ *    card, detached it, handed it back to the solver), so the row is gone
+ *    while the leg is not.
+ *
+ * Left behind, either one is live ammunition rather than dead weight. The
+ * value is merged into `?partition=` by position id and leg (`encodedPins`),
+ * so it re-arms the moment that pair exists again — pricing a leg the user
+ * re-opened at what a position they closed last month paid for it, and, since
+ * the venue's blend is conserved across claims, pushing the invented
+ * difference onto whatever else is claiming that leg. A stale grouping is
+ * visible on the card; a stale entry is just a wrong number.
+ *
+ * ⚠ Prune membership FIRST and pass the result — passing the un-pruned rows
+ * keeps exactly the overrides that most need to go.
+ *
+ * Returns `rows` itself when nothing is stale, so a caller can skip the write.
+ */
+export function pruneOverrides(
+  rows: readonly EntryOverride[],
+  membership: readonly MembershipRow[],
+): EntryOverride[] {
+  // Same key shape as `encodedPins` builds to merge the two back together —
+  // if that ever stops matching, an override silently stops being sent.
+  const claims = new Set(
+    membership.flatMap((r) =>
+      r.positionId === undefined ? [] : [`${r.positionId}|${legRefKey(r.leg)}`],
+    ),
+  );
+  const kept = rows.filter((r) => claims.has(`${r.positionId}|${legRefKey(r.leg)}`));
+  return kept.length === rows.length ? (rows as EntryOverride[]) : kept;
 }

--- a/web/src/panels/homeBoxes.ts
+++ b/web/src/panels/homeBoxes.ts
@@ -1,9 +1,12 @@
 /** Pure taxonomy for the home view: every position lands in exactly one box.
  *
  * - 'strategy'  — a server StrategyRollup. With the strategy feed live this is
- *                 EVERY position: the solver emits a card per coin, including
- *                 Boros-less pairs (`BASE#perps`) and unclaimed size
+ *                 EVERY position: the solver emits a card per PAIR, including
+ *                 Boros-less pairs and every leg no pair claimed
  *                 (`BASE#unhedged:SYMBOL`), so the leftover set is empty.
+ *                 (Cards stay merged, and may hold more than one pair, when
+ *                 the server could not reconcile the split — it says so in
+ *                 the card's own warnings rather than guessing a grouping.)
  * - 'perp-only' / 'stray' — the DEGRADED path only: exposure groups whose base
  *                 has no rollup. That happens when no address is tracked (the
  *                 strategy feed never runs) or the feed failed — the positions

--- a/web/src/panels/partitionStore.test.ts
+++ b/web/src/panels/partitionStore.test.ts
@@ -150,9 +150,31 @@ describe('withRow', () => {
     expect(withRow(partial, { mode: 'orphan', leg })).toEqual([{ leg }]);
   });
 
-  it('auto forgets everything said about the leg', () => {
+  /**
+   * ⚠ Automatic is SCOPED, like orphan and for the same reason.
+   *
+   * It used to drop every row naming the leg, so choosing it on the unclaimed
+   * remainder of a shared leg also deleted the pin another card held — a card
+   * the user never touched — and the solver then swept the whole venue leg
+   * into one position.
+   */
+  it('auto forgets one position\'s claim and leaves the rest of the leg alone', () => {
+    const out = withRow([{ positionId: 'aa', leg }, { positionId: 'bb', leg }, { leg }, BOROS], {
+      mode: 'auto',
+      leg,
+      positionId: 'aa',
+    });
+    expect(out).toEqual([{ positionId: 'bb', leg }, { leg }, BOROS]);
+  });
+
+  it('auto with no position forgets the ORPHAN rows — what it means on an unhedged card', () => {
     const out = withRow([{ positionId: 'aa', leg }, { leg }, BOROS], { mode: 'auto', leg });
-    expect(out).toEqual([BOROS]);
+    expect(out).toEqual([{ positionId: 'aa', leg }, BOROS]);
+  });
+
+  it('auto on a leg this position never claimed changes nothing', () => {
+    const rows = [{ positionId: 'aa', leg }, BOROS];
+    expect(withRow(rows, { mode: 'auto', leg, positionId: 'zz' })).toEqual(rows);
   });
 
   it('keys a leg by the venue\'s own identifier', () => {

--- a/web/src/panels/partitionStore.test.ts
+++ b/web/src/panels/partitionStore.test.ts
@@ -6,6 +6,7 @@ import {
   legRefKey,
   loadRows,
   newPositionId,
+  pruneRows,
   saveRows,
   withRow,
   type MembershipRow,
@@ -171,5 +172,51 @@ describe('encodeRows', () => {
   it('encodes to base64url, and to nothing when empty', () => {
     expect(encodeRows([PERP])).not.toMatch(/[+/=]/);
     expect(encodeRows([])).toBe('');
+  });
+});
+
+/**
+ * The delete `returns.ts:applyMembership` documents but never performed.
+ *
+ * A row names a LEG, so a row outliving its leg does not go quiet — it lies in
+ * wait for the next position to use that symbol. Closing a hand-grouped
+ * position and re-opening the same market used to reconstitute the dead one.
+ */
+describe('pruneRows', () => {
+  const liveSet = (...keys: string[]) => {
+    const live = new Set(keys);
+    return (leg: MembershipRow['leg']) => live.has(legRefKey(leg));
+  };
+
+  it('drops rows naming a leg no feed reports any more', () => {
+    expect(pruneRows([PERP, BOROS, ORPHAN], liveSet('boros:129'))).toEqual([BOROS]);
+  });
+
+  it('drops an ORPHAN row too — a leg that closed is not unhedged exposure', () => {
+    expect(pruneRows([ORPHAN], liveSet())).toEqual([]);
+  });
+
+  it('returns the same array when nothing is stale, so no write happens', () => {
+    const rows = [PERP, BOROS];
+    expect(
+      pruneRows(rows, liveSet('perp:BINANCE_FUTURE_ETH_USDT', 'boros:129')),
+    ).toBe(rows);
+  });
+
+  it('keeps every row of a kind whose feed answers "nothing new to say"', () => {
+    // What a perp poll does to Boros rows: says true, changes nothing. The two
+    // feeds are 26s apart and neither may speak for the other.
+    const rows = [PERP, BOROS];
+    const perpFeedSaysLive = (leg: MembershipRow['leg']) =>
+      leg.kind === 'boros' || legRefKey(leg) === 'perp:BINANCE_FUTURE_ETH_USDT';
+    expect(pruneRows(rows, perpFeedSaysLive)).toBe(rows);
+  });
+
+  it('re-opening the same market does not resurrect the closed position', () => {
+    // The bug, end to end at this layer: BINANCE_FUTURE_ETH_USDT closes, the
+    // rows are pruned, and the symbol coming back finds nothing claiming it.
+    const pruned = pruneRows([PERP, BOROS], liveSet('boros:129'));
+    const reopened = liveSet('perp:BINANCE_FUTURE_ETH_USDT', 'boros:129');
+    expect(pruneRows(pruned, reopened).some((r) => r.leg.kind === 'perp')).toBe(false);
   });
 });

--- a/web/src/panels/partitionStore.ts
+++ b/web/src/panels/partitionStore.ts
@@ -135,15 +135,25 @@ export type RowChange =
    * detaches only that much of a SHARED leg, leaving other positions' claims
    * alone; without it the whole venue leg is orphaned. */
   | { mode: 'orphan'; leg: LegRef; qty?: number }
-  /** Forget everything said about it; the solver decides again. */
-  | { mode: 'auto'; leg: LegRef };
+  /**
+   * Forget what THIS position said about it; the solver decides its share
+   * again.
+   *
+   * ⚠ SCOPED, like `orphan` above and for the same reason. It used to drop
+   * EVERY row on the leg, so pressing Automatic on the unclaimed remainder of
+   * a shared leg also deleted the pin another card held on it — a card the
+   * user never touched — and the solver then swept the whole venue leg into
+   * one position. `positionId` names the claim to forget; ABSENT means the
+   * orphan rows, which is what Automatic means on an unhedged card.
+   */
+  | { mode: 'auto'; leg: LegRef; positionId?: string };
 
 export function withRow(rows: readonly MembershipRow[], change: RowChange): MembershipRow[] {
   const key = legRefKey(change.leg);
   const onLeg = (r: MembershipRow) => legRefKey(r.leg) === key;
   switch (change.mode) {
     case 'auto':
-      return rows.filter((r) => !onLeg(r));
+      return rows.filter((r) => !(onLeg(r) && r.positionId === change.positionId));
     case 'orphan': {
       const orphans = rows.filter((r) => onLeg(r) && r.positionId === undefined);
       // The WHOLE leg: exclusive, so no position may keep a claim on any of it.

--- a/web/src/panels/partitionStore.ts
+++ b/web/src/panels/partitionStore.ts
@@ -197,3 +197,40 @@ export function encodeRows(rows: readonly MembershipRow[]): string {
   // are alphanumeric), so no escape dance is required.
   return btoa(JSON.stringify(body)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
+
+/**
+ * Drop every assertion about a leg the venues no longer report.
+ *
+ * ⚠ THIS IS THE DELETE `returns.ts:applyMembership` HAS ALWAYS DOCUMENTED.
+ * That function already ignores dangling rows, silently and on purpose — it
+ * cannot tell a leg the user closed from one that went stale, and warning
+ * about either greeted anyone who flattened their book with a wall of amber.
+ * But ignoring is per-RESPONSE. The rows stayed here, and a row names a LEG
+ * (`perp:GATE_FUTURE_ETH_USDT`, `boros:12`), never the position it was written
+ * for — so the server binds it to whatever leg carries that name TODAY.
+ * Closing a hand-grouped position and re-opening the same market therefore
+ * reconstituted the dead one: its id, its grouping, its asserted entries and
+ * (keyed off that id) its un-ticked entry-cost parts, with the solver locked
+ * out of legs the user never spoke about in this life.
+ *
+ * ⚠ `isLive` MUST BE ANSWERING FOR THE WHOLE BOOK, and must be believed. A
+ * `false` drawn from a partial view — one feed settled and the other still
+ * loading, a response fetched for the previous book, or a venue answering 200
+ * with an empty list during an incident — deletes facts the user would have to
+ * re-establish from memory, which is the one thing this store exists to
+ * prevent. There is no undo. PositionsHome earns every `false` it returns.
+ *
+ * A PREDICATE, not a set, because the two halves of a book are two feeds on
+ * two cadences and each can only speak for its own legs: it lets the caller
+ * keep a perp poll from deciding anything about a Boros market it never looked
+ * at. `true` is always the safe answer, and means "not known to be gone".
+ *
+ * Returns `rows` itself when nothing is stale, so a caller can skip the write.
+ */
+export function pruneRows(
+  rows: readonly MembershipRow[],
+  isLive: (leg: LegRef) => boolean,
+): MembershipRow[] {
+  const kept = rows.filter((r) => isLive(r.leg));
+  return kept.length === rows.length ? (rows as MembershipRow[]) : kept;
+}

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -427,6 +427,16 @@ export function makeStrategyReturns(overrides: Partial<StrategyReturns> = {}): S
     address: STRATEGY_ADDRESS,
     perpSource: 'connected-gate-account',
     strategies,
+    // Venue truth, so it defaults to every Boros market the cards hold —
+    // overridable to model a leg that is open but has no card (an unpriced
+    // collateral zone), which is what the prune must not read as closed.
+    liveBorosMarketIds: [
+      ...new Set(
+        strategies.flatMap((s) =>
+          s.legs.flatMap((l) => (l.kind === 'boros' && l.marketId !== undefined ? [l.marketId] : [])),
+        ),
+      ),
+    ],
     totals: {
       capitalUsd: strategies.reduce((s, x) => s + x.capitalUsd, 0),
       realizedPnlUsd: strategies.reduce((s, x) => s + x.realizedPnlUsd, 0),

--- a/web/src/trade/CloseBorosForm.test.tsx
+++ b/web/src/trade/CloseBorosForm.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * What a Boros close tells the card it took off the venue.
+ *
+ * A card that states an absolute share of a leg has to hear its own close, or
+ * the row goes on claiming the same size out of a smaller leg — taken from
+ * whoever shares it. Unlike a perp close (which only knows the deal was
+ * ACCEPTED), this route answers with the fill, so the number reported here is
+ * what actually closed.
+ */
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import type { BorosCancelAndCloseResult, StrategyLeg } from '../api/types';
+import { makeStrategyLeg, versionHandler } from '../test/fixtures';
+import { env, server } from '../test/server';
+import { renderWithClient } from '../test/utils';
+import { CloseBorosForm } from './CloseBorosForm';
+
+const MARKET = 190;
+/** The card's own share of the market — the number a row would state. */
+const MINE = 0.01;
+
+const leg = (): StrategyLeg =>
+  makeStrategyLeg({ marketId: MARKET, notionalToken: MINE, collateral: 'ETH' });
+
+/** An approved agent and nothing else: the confirm gate gets its clearance,
+ * the quote panel gets no context and simply shows no rate. */
+const ready = () => [
+  versionHandler(),
+  http.get('/api/boros/agent', () =>
+    HttpResponse.json(env({ configured: true, expired: false, address: '0xagent' })),
+  ),
+];
+
+const closeReturns = (r: Partial<BorosCancelAndCloseResult>, seen?: unknown[]) =>
+  http.post('/api/boros/pair/market/:id/cancel-and-close', async ({ request, params }) => {
+    seen?.push(await request.json());
+    return HttpResponse.json(
+      env<BorosCancelAndCloseResult>({
+        marketId: Number(params.id),
+        cancelled: true,
+        closed: true,
+        fill: null,
+        ...r,
+      }),
+    );
+  });
+
+const fill = (filledSize: number, shortfallSize = 0) => ({
+  marketId: MARKET,
+  direction: 'long' as const,
+  filledSize,
+  shortfallSize,
+  execApr: 0.09,
+  feeSize: 0,
+  failure: null,
+});
+
+/** Hold the confirm through its 800ms gate. */
+const confirmClose = async () => {
+  const btn = await screen.findByRole('button', { name: /Close leg/ });
+  await waitFor(() => expect(btn).toBeEnabled());
+  fireEvent.pointerDown(btn);
+};
+
+describe('CloseBorosForm — reporting what it closed', () => {
+  it('reports the filled size when the leg closes out', async () => {
+    const closed: Array<[number, number]> = [];
+    server.use(...ready(), closeReturns({ closed: true, fill: fill(MINE) }));
+    renderWithClient(
+      <CloseBorosForm legs={[leg()]} onClosed={(l, q) => closed.push([l.marketId!, q])} />,
+    );
+    await confirmClose();
+    await waitFor(() => expect(closed).toEqual([[MARKET, MINE]]), { timeout: 3_000 });
+  });
+
+  it('reports what REALLY filled when the book ran short, not what was asked', async () => {
+    // The whole point of reading the fill: shrinking the claim by the
+    // requested size would hand away 0.004 that is still open.
+    const closed: Array<[number, number]> = [];
+    server.use(...ready(), closeReturns({ closed: false, fill: fill(0.006, 0.004) }));
+    renderWithClient(
+      <CloseBorosForm legs={[leg()]} onClosed={(l, q) => closed.push([l.marketId!, q])} />,
+    );
+    await confirmClose();
+    await waitFor(() => expect(closed).toEqual([[MARKET, 0.006]]), { timeout: 3_000 });
+    expect(await screen.findByText(/left\s+open/)).toBeInTheDocument();
+  });
+
+  it('says nothing when the venue rejected the close', async () => {
+    // ⚠ A 200 is not a close. Reporting one here would shrink a claim on a
+    // position that never moved.
+    const closed: unknown[] = [];
+    server.use(
+      ...ready(),
+      closeReturns({
+        closed: false,
+        fill: { ...fill(0), failure: { code: 'rate-deviation', message: 'rate moved too far' } },
+      }),
+    );
+    renderWithClient(<CloseBorosForm legs={[leg()]} onClosed={() => closed.push(1)} />);
+    await confirmClose();
+    expect(await screen.findByText(/rate moved too far/)).toBeInTheDocument();
+    expect(closed).toEqual([]);
+  });
+
+  it('says nothing when there was nothing open to close', async () => {
+    const closed: unknown[] = [];
+    server.use(...ready(), closeReturns({ cancelled: true, closed: false, fill: null }));
+    renderWithClient(<CloseBorosForm legs={[leg()]} onClosed={() => closed.push(1)} />);
+    await confirmClose();
+    expect(await screen.findByText(/no open position to close/)).toBeInTheDocument();
+    expect(closed).toEqual([]);
+  });
+});

--- a/web/src/trade/CloseBorosForm.test.tsx
+++ b/web/src/trade/CloseBorosForm.test.tsx
@@ -84,7 +84,10 @@ describe('CloseBorosForm — reporting what it closed', () => {
     );
     await confirmClose();
     await waitFor(() => expect(closed).toEqual([[MARKET, 0.006]]), { timeout: 3_000 });
-    expect(await screen.findByText(/left\s+open/)).toBeInTheDocument();
+    expect(await screen.findByText(/of what you asked for is still open/)).toBeInTheDocument();
+    // …and the size is re-armed at the REMAINDER, so a second press cannot
+    // re-send the amount that just half-filled.
+    expect(screen.getByLabelText(/Close size for the .* Boros leg/)).toHaveValue('0.004');
   });
 
   it('says nothing when the venue rejected the close', async () => {
@@ -111,5 +114,60 @@ describe('CloseBorosForm — reporting what it closed', () => {
     await confirmClose();
     expect(await screen.findByText(/no open position to close/)).toBeInTheDocument();
     expect(closed).toEqual([]);
+  });
+});
+
+/**
+ * What the dialog SAYS once the close lands.
+ *
+ * `closed` is the venue going flat — `shortfall === 0 && size >= openSize`, an
+ * exact comparison. Keying the done panel off it meant a close that did
+ * exactly what was asked could still report itself unfinished: one small amber
+ * line, the confirm button still armed at the same size, and "close again to
+ * finish it" for a leg with nothing of the user's left in it. On a real-money
+ * surface that is an invitation to send the order twice.
+ */
+describe('CloseBorosForm — saying that it landed', () => {
+  const panel = () => screen.queryByText(/Leg closed\./);
+  const armed = () => screen.queryByRole('button', { name: /Close leg/ });
+
+  it('reports DONE when the request filled, even though the venue is not flat', async () => {
+    // The reported case: 39 asked, 39 filled, 0 short — and `closed: false`,
+    // because the live position carried a dust residual over the 39.
+    server.use(
+      ...ready(),
+      closeReturns({ closed: false, fill: fill(MINE), openSize: MINE + 1e-12 }),
+    );
+    renderWithClient(<CloseBorosForm legs={[leg()]} />);
+    await confirmClose();
+
+    expect(await screen.findByText(/Leg closed\./)).toBeInTheDocument();
+    // The confirm is GONE, replaced by Done — the whole point.
+    expect(armed()).toBeNull();
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+    expect(screen.queryByText(/close again to finish it/i)).toBeNull();
+  });
+
+  it('names the share another position holds instead of calling it unfinished', async () => {
+    // A card closing its own 0.01 of a 0.03 leg satisfies its request and
+    // leaves 0.02 open. That is somebody else's, and saying "close again to
+    // finish it" would be telling this user to close it.
+    server.use(...ready(), closeReturns({ closed: false, fill: fill(MINE), openSize: 0.03 }));
+    renderWithClient(<CloseBorosForm legs={[leg()]} />);
+    await confirmClose();
+
+    expect(await screen.findByText(/Leg closed\./)).toBeInTheDocument();
+    expect(screen.getByText(/another position's share of the same leg, not yours/)).toBeInTheDocument();
+    expect(armed()).toBeNull();
+  });
+
+  it('keeps the confirm armed only when something of the user\'s is genuinely left', async () => {
+    server.use(...ready(), closeReturns({ closed: false, fill: fill(0.006, 0.004) }));
+    renderWithClient(<CloseBorosForm legs={[leg()]} />);
+    await confirmClose();
+
+    expect(await screen.findByText(/of what you asked for is still open/)).toBeInTheDocument();
+    expect(panel()).toBeNull();
+    expect(armed()).toBeInTheDocument();
   });
 });

--- a/web/src/trade/CloseBorosForm.test.tsx
+++ b/web/src/trade/CloseBorosForm.test.tsx
@@ -148,6 +148,23 @@ describe('CloseBorosForm — saying that it landed', () => {
     expect(screen.queryByText(/close again to finish it/i)).toBeNull();
   });
 
+  it('does not call the user\'s OWN un-closed remainder somebody else\'s', async () => {
+    // A deliberate partial of a sole-owned leg: close 0.004 of 0.01 and the
+    // 0.006 left is entirely the user's. Reporting it as another position's
+    // share is a falsehood about their own money, and the panel replaces the
+    // form — so it also takes away the affordance to close it.
+    server.use(...ready(), closeReturns({ closed: false, fill: fill(0.004), openSize: MINE }));
+    renderWithClient(<CloseBorosForm legs={[{ ...leg(), notionalToken: MINE }]} />);
+    // Ask for less than the whole share.
+    fireEvent.change(screen.getByLabelText(/Close size for the .* Boros leg/), {
+      target: { value: '0.004' },
+    });
+    await confirmClose();
+
+    expect(await screen.findByText(/of this position is still open/)).toBeInTheDocument();
+    expect(screen.queryByText(/not yours/)).toBeNull();
+  });
+
   it('names the share another position holds instead of calling it unfinished', async () => {
     // A card closing its own 0.01 of a 0.03 leg satisfies its request and
     // leaves 0.02 open. That is somebody else's, and saying "close again to

--- a/web/src/trade/CloseBorosForm.tsx
+++ b/web/src/trade/CloseBorosForm.tsx
@@ -48,9 +48,20 @@ function floorTo1Sf(x: number): number {
 
 export function CloseBorosForm({
   legs,
+  onClosed,
   onDone,
 }: {
   legs: StrategyLeg[];
+  /**
+   * What actually came off each market, so the caller can shrink a claim that
+   * states an absolute size.
+   *
+   * The EXACT filled size, not the requested one — unlike a perp close, this
+   * route answers with the fill, so a leg that came back short shrinks the
+   * claim by what it really closed. Fires for a partial too: those are the
+   * ones where the number matters.
+   */
+  onClosed?: (leg: StrategyLeg, filled: number) => void;
   onDone?: () => void;
 }) {
   const close = useBorosCancelAndClose();
@@ -241,8 +252,10 @@ export function CloseBorosForm({
               shortfall: r.fill!.shortfallSize,
             },
           ]);
+          onClosed?.(l, r.fill!.filledSize);
         } else {
           setDone((prev) => [...prev, id]);
+          onClosed?.(l, r.fill!.filledSize);
         }
       } catch (err) {
         setFailed((prev) => [

--- a/web/src/trade/CloseBorosForm.tsx
+++ b/web/src/trade/CloseBorosForm.tsx
@@ -67,12 +67,27 @@ export function CloseBorosForm({
   const close = useBorosCancelAndClose();
   const agent = useBorosAgent();
   const { address } = useTrackedAddress();
-  const [done, setDone] = useState<number[]>([]);
+  /**
+   * Legs whose close filled everything it ASKED for, with whatever the venue
+   * still holds afterwards.
+   *
+   * ⚠ NOT the same as the venue going flat, which is what `closed` reports.
+   * A card closing its own share of a shared leg satisfies its request while
+   * the leg stays open, and so does a dust residual — `closed` is
+   * `shortfall === 0 && size >= openSize`, an exact comparison a size like
+   * 419.49999999 fails. Keying the done panel off `closed` meant a close that
+   * did exactly what was asked reported itself as unfinished: one small amber
+   * line, the confirm button still armed at the same size, and "close again to
+   * finish it" for a leg with nothing left to finish. The dialog answers the
+   * question the user asked it, and mentions the venue residual separately.
+   */
+  const [done, setDone] = useState<{ marketId: number; leftOpen: number }[]>([]);
   const [failed, setFailed] = useState<{ marketId: number; message: string }[]>([]);
-  /** Filled, but the leg is still open — a partial by request or by depth. */
-  const [partial, setPartial] = useState<
-    { marketId: number; filled: number; shortfall: number }[]
-  >([]);
+  /** Filled SHORT of what was asked — the book ran out inside the rate bound.
+   * `left` is what of this request is still open, never `shortfallSize`
+   * dressed up: that is requested − filled, which is the same number only when
+   * the request covered the whole venue position. */
+  const [partial, setPartial] = useState<{ marketId: number; filled: number; left: number }[]>([]);
 
   const closable = useMemo(() => legs.filter((l) => l.marketId !== undefined), [legs]);
 
@@ -207,17 +222,25 @@ export function CloseBorosForm({
     : 'The Boros agent approval has expired — approve a new agent key before closing Boros legs.';
 
   const allDone = closable.length > 0 && done.length === closable.length;
+  /** Size the venue still holds on legs that DID satisfy their request — a
+   * share another position owns, or dust. Reported, never acted on. */
+  const residual = done.reduce((sum, d) => sum + d.leftOpen, 0);
 
   const run = async () => {
     setFailed([]);
     setPartial([]);
     for (const l of closable) {
       const id = l.marketId as number;
-      if (done.includes(id)) continue;
+      if (done.some((d) => d.marketId === id)) continue;
+      const requested = sizeOf(l).value;
+      // The same tolerance the depth warning uses: a book that fully covers
+      // 419.5 answers 419.49999999, and calling that a shortfall reads as "no
+      // depth" on a market with plenty.
+      const dust = Math.max(1e-6, requested * 1e-6);
       try {
         const r = await close.mutateAsync({
           marketId: id,
-          size: sizeOf(l).value,
+          size: requested,
           slippageApr: slipPct / 100,
         });
         /**
@@ -241,21 +264,24 @@ export function CloseBorosForm({
                 : 'Nothing was closed.',
             },
           ]);
-        } else if (!r.closed) {
-          // Filled, but not to flat: a deliberate partial, or the book ran out
-          // inside the rate bound. Either way the leg is still open.
-          setPartial((prev) => [
-            ...prev,
-            {
-              marketId: id,
-              filled: r.fill!.filledSize,
-              shortfall: r.fill!.shortfallSize,
-            },
-          ]);
-          onClosed?.(l, r.fill!.filledSize);
+        } else if (r.fill!.filledSize < requested - dust) {
+          // SHORT of what was asked: the book ran out inside the rate bound.
+          // The only outcome that leaves something for a second press — so it
+          // is also the only one that re-seeds the size, below, rather than
+          // leaving the original amount armed under a line saying it is done.
+          const filled = r.fill!.filledSize;
+          const left = requested - filled;
+          setPartial((prev) => [...prev, { marketId: id, filled, left }]);
+          setSizes((prev) => ({ ...prev, [id]: String(Number(left.toPrecision(8))) }));
+          onClosed?.(l, filled);
         } else {
-          setDone((prev) => [...prev, id]);
-          onClosed?.(l, r.fill!.filledSize);
+          // Everything asked for came off. Whatever the venue still holds is
+          // somebody else's share or dust — worth SAYING, never worth arming
+          // a second close over.
+          const filled = r.fill!.filledSize;
+          const over = (r.openSize ?? filled) - filled;
+          setDone((prev) => [...prev, { marketId: id, leftOpen: over > dust ? over : 0 }]);
+          onClosed?.(l, filled);
         }
       } catch (err) {
         setFailed((prev) => [
@@ -273,12 +299,22 @@ export function CloseBorosForm({
   // A close that landed says so, and stays said until dismissed — the dialog
   // closing on its own gave no confirmation that anything had happened.
   if (allDone) {
+    const unit = closable[0]?.collateral ?? '';
     return (
       <div className="flex flex-col gap-3">
         <p className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2.5 text-[12px] leading-relaxed text-emerald-300">
           {closable.length === 1 ? 'Leg closed.' : `${closable.length} legs closed.`} The position is
           re-reading from the venue now — the card updates on its own.
         </p>
+        {/* The venue leg outliving the close is normal — a second position
+            holds the rest. Said plainly, and NOT as an amber warning: nothing
+            went wrong and there is nothing here for this user to finish. */}
+        {residual > 0 && (
+          <p className="text-[11px] leading-relaxed text-ink-400">
+            {fmtTokenQty(residual, unit)} is still open on the venue — that is another position's
+            share of the same leg, not yours.
+          </p>
+        )}
         <button type="button" className="btn-primary w-full" onClick={onDone}>
           Done
         </button>
@@ -376,8 +412,9 @@ export function CloseBorosForm({
               )}
               {part && (
                 <span className="text-amber-400/90">
-                  filled {fmtTokenQty(part.filled, unit)} — {fmtTokenQty(part.shortfall, unit)} left
-                  open. Close again to finish it.
+                  filled {fmtTokenQty(part.filled, unit)} — {fmtTokenQty(part.left, unit)} of what
+                  you asked for is still open. The size above is set to what is left; close again
+                  to finish it.
                 </span>
               )}
               {err && <span className="text-rose-400">{err.message}</span>}

--- a/web/src/trade/CloseBorosForm.tsx
+++ b/web/src/trade/CloseBorosForm.tsx
@@ -81,7 +81,7 @@ export function CloseBorosForm({
    * finish it" for a leg with nothing left to finish. The dialog answers the
    * question the user asked it, and mentions the venue residual separately.
    */
-  const [done, setDone] = useState<{ marketId: number; leftOpen: number }[]>([]);
+  const [done, setDone] = useState<{ marketId: number; yours: number; others: number }[]>([]);
   const [failed, setFailed] = useState<{ marketId: number; message: string }[]>([]);
   /** Filled SHORT of what was asked — the book ran out inside the rate bound.
    * `left` is what of this request is still open, never `shortfallSize`
@@ -222,9 +222,19 @@ export function CloseBorosForm({
     : 'The Boros agent approval has expired — approve a new agent key before closing Boros legs.';
 
   const allDone = closable.length > 0 && done.length === closable.length;
-  /** Size the venue still holds on legs that DID satisfy their request — a
-   * share another position owns, or dust. Reported, never acted on. */
-  const residual = done.reduce((sum, d) => sum + d.leftOpen, 0);
+  /**
+   * What the venue still holds on legs that DID satisfy their request, split
+   * by WHOSE it is.
+   *
+   * ⚠ Two different remainders, and reporting them as one told the user a
+   * falsehood about their own money: `openSize − filled` is `(openSize −
+   * myShare)`, which belongs to whoever else holds the leg, PLUS `(myShare −
+   * filled)`, which is theirs and was left open on purpose. Closing 0.004 of a
+   * sole-owned 0.01 announced that the remaining 0.006 was "another position's
+   * share, not yours".
+   */
+  const residualYours = done.reduce((sum, d) => sum + d.yours, 0);
+  const residualOthers = done.reduce((sum, d) => sum + d.others, 0);
 
   const run = async () => {
     setFailed([]);
@@ -275,12 +285,19 @@ export function CloseBorosForm({
           setSizes((prev) => ({ ...prev, [id]: String(Number(left.toPrecision(8))) }));
           onClosed?.(l, filled);
         } else {
-          // Everything asked for came off. Whatever the venue still holds is
-          // somebody else's share or dust — worth SAYING, never worth arming
-          // a second close over.
+          // Everything asked for came off. What the venue still holds splits
+          // in two, and only one half is somebody else's — worth SAYING,
+          // neither worth arming a second close over.
           const filled = r.fill!.filledSize;
-          const over = (r.openSize ?? filled) - filled;
-          setDone((prev) => [...prev, { marketId: id, leftOpen: over > dust ? over : 0 }]);
+          const mine = l.notionalToken ?? filled;
+          // This card's own share that the user chose not to close.
+          const yours = Math.max(0, mine - filled);
+          // The rest of the venue leg, which other positions hold.
+          const others = Math.max(0, (r.openSize ?? mine) - mine);
+          setDone((prev) => [
+            ...prev,
+            { marketId: id, yours: yours > dust ? yours : 0, others: others > dust ? others : 0 },
+          ]);
           onClosed?.(l, filled);
         }
       } catch (err) {
@@ -306,13 +323,20 @@ export function CloseBorosForm({
           {closable.length === 1 ? 'Leg closed.' : `${closable.length} legs closed.`} The position is
           re-reading from the venue now — the card updates on its own.
         </p>
-        {/* The venue leg outliving the close is normal — a second position
-            holds the rest. Said plainly, and NOT as an amber warning: nothing
-            went wrong and there is nothing here for this user to finish. */}
-        {residual > 0 && (
+        {/* The venue leg outliving the close is normal. Said plainly and NOT
+            as an amber warning: nothing went wrong. But the two halves are
+            not interchangeable — one is the user's to close whenever they
+            like, the other is not theirs at all. */}
+        {residualYours > 0 && (
           <p className="text-[11px] leading-relaxed text-ink-400">
-            {fmtTokenQty(residual, unit)} is still open on the venue — that is another position's
-            share of the same leg, not yours.
+            {fmtTokenQty(residualYours, unit)} of this position is still open — you closed part of
+            it. Close the rest whenever you like.
+          </p>
+        )}
+        {residualOthers > 0 && (
+          <p className="text-[11px] leading-relaxed text-ink-400">
+            {fmtTokenQty(residualOthers, unit)} more is open on the venue — that is another
+            position's share of the same leg, not yours.
           </p>
         )}
         <button type="button" className="btn-primary w-full" onClick={onDone}>

--- a/web/src/trade/ClosePopover.test.tsx
+++ b/web/src/trade/ClosePopover.test.tsx
@@ -127,6 +127,93 @@ describe('ClosePopover', () => {
     expect(dealCalls[0].b ?? null).toBeNull();
   });
 
+  /**
+   * A venue position NETS, so a card that states an absolute share of a shared
+   * leg has to hear about its own close — otherwise the row goes on claiming
+   * the same size out of a smaller leg, taking it from whoever shares it. The
+   * card looked untouched by its own close: only the denominator moved.
+   */
+  describe('reporting what it closed', () => {
+    const executed = async () => {
+      const btn = await screen.findByRole('button', { name: 'Close now ▸' });
+      await waitFor(() => expect(btn).toBeEnabled());
+      fireEvent.pointerDown(btn);
+    };
+    const dealsOk = () =>
+      http.post('/api/deals', async ({ request }) =>
+        HttpResponse.json(env({ id: ((await request.json()) as DealRequest).id }), { status: 202 }),
+      );
+
+    it('reports this position\'s own size on a partial close', async () => {
+      const closed: number[] = [];
+      server.use(...baseHandlers(), closePreviewHandler(), dealsOk());
+      // The venue holds 0.3, this card owns 0.1 — so partial is pre-selected
+      // at 0.1 and that is what leaves this card.
+      renderWithClient(
+        <ClosePopover
+          position={ethPosition}
+          attributedQty={0.1}
+          onClosed={(q) => closed.push(q)}
+          onDismiss={() => {}}
+        />,
+      );
+      await executed();
+      await waitFor(() => expect(closed).toEqual([0.1]));
+    });
+
+    it('reports the WHOLE venue size on a full close, however little the card owns', async () => {
+      // Full takes the other position's 0.2 with it. This card's claim cannot
+      // survive that, whatever number it stated.
+      const closed: number[] = [];
+      server.use(...baseHandlers(), closePreviewHandler(), dealsOk());
+      renderWithClient(
+        <ClosePopover
+          position={ethPosition}
+          attributedQty={0.1}
+          onClosed={(q) => closed.push(q)}
+          onDismiss={() => {}}
+        />,
+      );
+      fireEvent.click(await screen.findByRole('radio', { name: /full/ }));
+      await executed();
+      await waitFor(() => expect(closed).toEqual([0.3]));
+    });
+
+    it('says nothing until the deal is accepted', async () => {
+      // A 500 is not a close. Shrinking the claim on the attempt would hand
+      // size away that is still very much open.
+      const closed: number[] = [];
+      server.use(
+        ...baseHandlers(),
+        closePreviewHandler(),
+        http.post('/api/deals', () =>
+          HttpResponse.json(
+            {
+              ok: false,
+              error: { category: 'exchange', message: 'venue rejected the close', retryable: true },
+            },
+            { status: 500 },
+          ),
+        ),
+      );
+      renderWithClient(
+        <ClosePopover
+          position={ethPosition}
+          attributedQty={0.1}
+          onClosed={(q) => closed.push(q)}
+          onDismiss={() => {}}
+        />,
+      );
+      await executed();
+      // The rejection surfaces…
+      expect(await screen.findByRole('alert', {}, { timeout: 3_000 })).toHaveTextContent(
+        /venue rejected the close/,
+      );
+      // …and the claim is untouched: that size is still very much open.
+      expect(closed).toEqual([]);
+    });
+  });
+
   it('hovering "Close now" opens no review card — the preview box above already reviews it', async () => {
     server.use(...baseHandlers(), closePreviewHandler());
     renderWithClient(<ClosePopover position={ethPosition} onDismiss={() => {}} />);

--- a/web/src/trade/ClosePopover.tsx
+++ b/web/src/trade/ClosePopover.tsx
@@ -30,10 +30,22 @@ interface Props {
    * one. The close acts on the whole venue position, so the popover opens on
    * partial, pre-filled with this size, and says what Full would really do. */
   attributedQty?: number;
+  /**
+   * How much this close took off the venue, fired once the deal is accepted.
+   *
+   * ⚠ ACCEPTED, NOT FILLED. `onExecuted` runs on the 202, and this is a
+   * reduce-only IOC that can come back short. The caller uses it to shrink a
+   * claim, so the error is one-directional: a short fill leaves the card
+   * claiming LESS than it holds, and the difference surfaces as size no
+   * position claims — visible, and re-assignable in one click. The reverse
+   * (which is what happens with no callback at all) is a card silently
+   * claiming size it already sold, taken out of whoever shares the leg.
+   */
+  onClosed?: (qty: number) => void;
   onDismiss: () => void;
 }
 
-export function ClosePopover({ position, attributedQty, onDismiss }: Props) {
+export function ClosePopover({ position, attributedQty, onClosed, onDismiss }: Props) {
   const wholeQty = Math.abs(Number(position.positionQty));
   // A shared leg: this card owns less than the venue holds.
   const shared =
@@ -189,7 +201,12 @@ export function ClosePopover({ position, attributedQty, onDismiss }: Props) {
             // card would just repeat it on top of the popover. Errors still open it.
             hoverCard={false}
             previewOpts={{ debounceMs: 300, refetchInterval: 3_000 }}
-            onExecuted={onDismiss}
+            onExecuted={() => {
+              // Full acts on the WHOLE venue position, so it takes this card's
+              // claim with it whatever the card owns.
+              onClosed?.(mode === 'full' ? wholeQty : qtyNum);
+              onDismiss();
+            }}
           />
         </div>
       </div>


### PR DESCRIPTION
Every bug here is one thing wearing different clothes: **what the user said about their book drifting away from what the venue actually holds** — and the drift never announcing itself.

A membership row names a **leg** (`perp:GATE_FUTURE_ETH_USDT`, `boros:190`), never the position it was written for. That is what makes a row checkable, and also what lets one outlive its position, get re-adopted by a leg that merely reuses the name, or be deleted by a card that never claimed it. The Boros close path had the mirror problem: sizes crossing a float/integer boundary, so a close could ask for more than was open.

Reported one at a time by users; each was reproduced before being fixed.

## Manual grouping

**Rows outlived their legs.** `applyMembership` ignores a row whose leg the venue no longer reports, and its comment said the client deleted them. The client never did. Closing a hand-grouped position and re-opening the same market reconstituted the dead one — its id, its grouping, its asserted entries, and (keyed off that id) its un-ticked entry-cost parts — with the solver locked out of legs the user never spoke about in this life. `pruneRows` / `pruneOverrides` are the delete that comment always described.

Deleting an assertion has no undo, so each `false` is earned: perps judged by the positions feed and Boros by a **census of live positions** (not by the cards — see below), each kind judged only by its own feed since the two poll 4s and 30s apart, and a leg missing from two consecutive responses of its own feed before anything goes.

**A close didn't shrink the claim it came from.** A `qty` row is an absolute number while a venue position nets, so closing a card's own share of a shared leg took the venue leg from 0.058 to 0.048 and left the row claiming the same 0.01 out of what remained — drawn, silently, from whoever shares it. From the card it looked as though nothing had happened: the size held still and only the denominator moved. Both close surfaces now report what came off.

**"Automatic" deleted other cards' rows.** It dropped *every* row naming the leg, so choosing it on an unclaimed 0.04 remainder also deleted the 0.01 a pinned card held — and the solver, seeing all 0.05 free, swept it into one position. `orphan` carries this exact warning already; `auto` never got it.

**A position could span two maturities.** Solver-built cards are single-maturity structurally (cohorts keyed `(base, maturity)`), so the shape cannot arise there and needs no check. The manual path had no floor. It doesn't degrade the card, it **misprices** it: `maturity` is `Math.min` across the legs, and the countdown, `secondsToMaturity`, `spreadReturnUsd` and the PnL projection all run off it, so the later leg's rate is credited only to the earlier leg's date. The picker now refuses the assignment and names the clashing date; the server warns for share links and older pins.

*Not a leg-count rule* — capping legs at two would not have caught the reported card, which held exactly two, and would refuse single-maturity shapes the solver itself emits.

## The Boros close

**Dust: the close crossed past flat.** Boros has no reduce-only flag, so nothing at the venue stops a close at flat. The route knows this and clamps to what is open — but it clamps two **doubles**, and the order is not built from a double. Measured on the real functions:

| position | order placed |
|---|---|
| `50000000000000000` (0.05 ETH) | `50000000000000003` |
| `123456789000000000000` | `123456789000000000556` |

Three units of an *opposing* position for a clean 0.05 open. Invisible ($1e-16), reported as "Leg closed" because the two floats compared equal, kept by `/strategy` because its filter is `norm18(notionalSize) === 0`, and **unclosable** — three units is far under the venue's $10 minimum order value, so the phantom leg is permanent.

The binding cap now lives in wei: `AccountView` keeps the venue's own integer beside the float, and `closePosition` places `min(parseUnits(asked), openSizeWei)`. The float still decides a deliberate partial; it is simply no longer what the order is built from.

**A successful close looked unfinished.** `closed` means the *venue* went flat — an exact `size >= openSize` — so a close that did exactly what was asked could report itself unfinished: a small amber line, the confirm still armed at the same size, and "close again to finish it" for a leg with nothing left. Two ordinary things reach that state: a card closing its share of a shared leg, and a dust residual failing the exact comparison. The dialog now answers the question it was asked and mentions the venue separately. The amber line was also printing `shortfallSize` as "left open", which is *requested − filled* — the same number only when the request covered the whole venue position.

## Review pass

A separate model reviewed the branch and found five real defects, all in the new code. Every one was verified against the source before being accepted, and each fix has a test confirmed failing without it.

1. **Data loss.** `buildBorosLegs` drops an entire collateral zone whose USD price can't be resolved, warns, and still answers 200 — so a leg can be open and on no card, and the prune deleted its rows. My reasoning that "every live Boros leg reaches a card" held for the grouping passes and failed *before* them. Fixed by `liveBorosMarketIds`, counted from the account's own zones so no downstream filtering can shorten it. Worth noting the blast radius: `resolveCollateralPricesUsd` returns null for a whole zone whenever no market of that base has `assetMarkPriceUsd > 0`, so one upstream field going to zero prices every non-USDT zone null at once.
2. **`attribution.source` was answering the wrong question.** "Automatic" scoped itself by `source === 'unhedged'`, which says how a grouping was *arrived at*. It collided both ways — a solver tranche on a Boros-less coin also reports `'unhedged'` (so Automatic there deleted a neighbour's detachment, the same bug from the other side), and the Boros remainder card reports `'boros-only'`/`'merged'` (so Automatic there silently did nothing). Replaced with an explicit `attribution.unclaimed`.
3. **A partial close called the user's own remainder somebody else's.** `openSize − filled` is two remainders added together. Split, and each half named.
4. **One Confirm minted two position ids.** `commit()` emits `entry` and `assign` as two `applyAssertion` calls, and `freeze` re-read `attribution.pinned` off the same stale prop — so the second minted a second id and wrote a second full row set. Every leg claimed by two ids, which the server duly split into two phantom positions with the asserted entry on one half. `freeze` now memoizes per card per response, which also makes it idempotent under StrictMode.

## Tests

**825 server + 606 web**, both suites green. ~45 new tests. Each fix was re-run with itself stubbed out to confirm the test actually fails — that check caught two of my own tests asserting a condition that was already true before the fix ran.

## Reviewer notes

- **Cleanup is later, deliberately.** A closed Boros market takes up to ~30s to be forgotten (its feed's poll × 2). That is the price of the two-look rule, and the right direction to fail in.
- **A maturity roll is now two positions**, not one. Given every projection assumes a single date I think that is the correct reading, but it is a real workflow change. A first-class roll would be its own design.
- **Existing on-chain dust is not cleaned up** by the wei cap. Any phantom leg already out there stays, and is still unclosable under the $10 minimum.
- **Not fixed, pre-existing in `5fc04ae`:** a free perp can be double-counted across two spread groups that share a venue.
- **Unverified from here:** whether Boros itself clamps an oversized close. If it does, the overshoot was already harmless — the reported dust says otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
