### PR TITLE
added wizard flow + streamlined ui + version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,20 @@ Not available to, or intended for, any person where such use is unlawful (includ
 
 ---
 
-# CrossEx-Boros Terminal
+# Arbitrage with CrossEx
 
 **Open source tool** · **Experimental, use at your own risks**
 
-A trading terminal for delta-neutral funding-rate arbitrage on Gate's
-[CrossEx](https://www.gate.com/docs/developers/crossex/en/) platform: one collateral
-pool backing perp positions on multiple venues (BINANCE, BYBIT, GATE, OKX, KRAKEN,
-HYPERLIQUID). Go long a perp on one venue and short the same perp on another; the legs
-are delta-neutral and you collect the funding spread.
+A trading terminal for delta-neutral funding-rate arbitrage across Pendle's
+[Boros](https://boros.pendle.finance) and Gate's
+[CrossEx](https://www.gate.com/docs/developers/crossex/en/): one collateral pool backing
+perp positions on multiple venues (BINANCE, BYBIT, GATE, OKX, KRAKEN, HYPERLIQUID).
+
+The trade is four legs. Two **Boros** legs lock a fixed funding rate until a maturity
+date; two **CrossEx** perp legs — long one venue, short another — cancel the floating
+funding between them. What is left is the locked spread, which is the return. The
+terminal finds those pairs, prices them net of every cost, opens all four legs in the
+right order, and then tracks the position as one thing.
 
 You run it on your own machine — **macOS or Windows**. Your exchange API keys stay on
 that machine and are only ever sent, signed, to Gate.io's official API; the app itself
@@ -38,8 +43,8 @@ press Return:
 
 When it finishes (a few minutes the first time), the terminal opens in your browser at
 **http://localhost:6688** — bookmark it. From then on the app is always running in the
-background, even after you restart your Mac. You'll also find a **"CrossEx-Boros
-Terminal"** launcher in your `~/Applications` folder.
+background, even after you restart your Mac. You'll also find an **"Arbitrage with
+CrossEx"** launcher in your `~/Applications` folder.
 
 Everything lands in one folder: `~/.boros-crossex`.
 
@@ -58,7 +63,7 @@ irm https://raw.githubusercontent.com/pendle-finance/arbitrage-with-crossex/main
 
 When it finishes, the terminal opens in your browser at **http://localhost:6688** —
 bookmark it. The app then starts on its own every time you sign in, and you'll find a
-**"CrossEx-Boros Terminal"** shortcut in your Start Menu.
+**"Arbitrage with CrossEx"** shortcut in your Start Menu.
 
 Everything lands in one folder: `%LOCALAPPDATA%\CrossEx-Boros`.
 
@@ -318,7 +323,7 @@ notionals and check your positions on the exchange directly.
 
 Everything below is for people working on the code. The app is a TypeScript monorepo:
 a framework-free core library, a Fastify server, and a React SPA — built on
-the **official `gate-api` Node SDK** (v7.2+, which ships a native `CrossExApi`).
+the **official `gate-api` Node SDK** (`^7.1.8`, which ships a native `CrossExApi`).
 
 ## Setup
 
@@ -352,7 +357,7 @@ user data lives outside the auto-updated app directory.
 
 ## Web terminal — `yarn dev` / `yarn start`
 
-A local web app ("CrossEx-Boros Terminal") wraps the same core with a monitoring dashboard and a
+A local web app ("Arbitrage with CrossEx") wraps the same core with a monitoring dashboard and a
 safety-gated trading UI:
 
 ```bash
@@ -360,15 +365,23 @@ yarn dev      # Fastify API (127.0.0.1:6688) + Vite dev server with /api proxy (
 yarn start    # build the SPA once, serve everything from http://localhost:6688
 ```
 
-- **Monitoring**: account margin strip, per-coin balances, positions with an **arb-exposure
-  view grouped by coin** (neutral ✓ / imbalanced / single leg), recent trades with the **fee
-  paid per fill** (maker/taker, bps), open orders with cancel, per-venue fee rates.
-- **Trading**: order ticket (market with **tentative average fill price** walked from
-  per-venue public orderbooks + estimated fees; limit with tick snapping and post-only),
-  **pair ticket** (one notional → one shared qty across both legs), a **basket** of mixed
-  actions executed concurrently, and a review modal (previews auto-refresh; confirm is
-  hold-to-press and disabled when previews go stale). Executions run server-side, survive a
-  closed tab, and re-check closes for remnants.
+- **Opportunities**: every viable Boros↔CrossEx pair, ranked by fixed APR net of costs,
+  with the cost assumptions (fee tier, entry mode, perp exit) stated on screen and
+  adjustable. Sizing follows the market's collateral — ETH/BTC markets quote in the coin,
+  USDT/USDC markets in dollars — so both halves of a strategy share one unit.
+- **Monitoring**: account margin strip, per-coin balances, **positions as 4-leg strategy
+  cards** (one card per paired position, with its locked spread, capital, projection and
+  per-leg breakdown; legs shared across maturities show their share), recent trades with
+  the **fee paid per fill** (maker/taker, bps), open orders with cancel, per-venue fee rates.
+- **Trading**: a guided two-step flow — lock the rate on Boros, then hedge the perps —
+  which sizes the hedge from what step 1 actually *filled*, and warns before you leave with
+  a rate locked but unhedged. Underneath it, the same manual tickets: order ticket (market
+  with **tentative average fill price** walked from per-venue public orderbooks + estimated
+  fees; limit with tick snapping and post-only), **pair ticket** (one notional → one shared
+  qty across both legs), a **basket** of mixed actions executed concurrently, and a review
+  modal (previews auto-refresh; confirm is hold-to-press and disabled when previews go
+  stale). Executions run server-side, survive a closed tab, and re-check closes for
+  remnants.
 - **Safety**: pair legs are linked, and if exactly one leg fills you get a red **UNHEDGED**
   banner with one-click remediation (complete the missing leg / unwind the filled one) —
   the web version of `pair.ts`'s guard. Order state strings from Gate are undocumented, so
@@ -431,6 +444,10 @@ curl -s "https://api.gateio.ws/api/v4/crossex/rule/symbols" | jq '.[] | select(.
     never-over-hedge / never-over-acquire against venue truth).
   - `estimate/` — per-venue public orderbook fetchers, VWAP fill estimator (labeled
     source/confidence fallback chain), fee estimation with special-fee overrides.
+  - `boros/` — the fixed-rate side: `opportunities.ts` (prices every viable Boros↔CrossEx
+    pair net of costs), `pair.ts` + `orders.ts` (two-leg quoting and atomic execution),
+    `returns.ts` (the position solver behind the strategy cards — pairing, cost model,
+    projections), `partition.ts` (which venue leg belongs to which strategy).
   - `preview.ts` — `resolveActions` + estimates = `POST /api/preview`.
 - `src/server/` — Fastify app: TTL cache with request coalescing + 429 stale-serve, localhost
   Host/Origin guard, `/api/deals` routes (thin intent writers — the loop owns every venue
@@ -442,14 +459,20 @@ curl -s "https://api.gateio.ws/api/v4/crossex/rule/symbols" | jq '.[] | select(.
 
 ## Caveats & next steps
 
-- **No funding-rate endpoint in CrossEx.** The arb *signal* (which pair to open) must come
-  from each venue's funding data — e.g. Gate futures `GET /futures/usdt/tickers` exposes
-  `funding_rate`. A `funding.ts` scanner is the natural next script (not built yet).
+- **No funding-rate endpoint in CrossEx.** The arb *signal* comes from Boros' own market
+  data rather than CrossEx: `src/core/boros/opportunities.ts` prices every viable pair and
+  serves the Opportunities tab. What CrossEx still does not expose is a per-venue funding
+  feed, so the floating side of a hedge is measured from positions and the funding ledger,
+  not quoted ahead of time.
 - **Reference price for sizing** uses Gate's public spot/futures price, not the exact
-  remote-venue fill price. Cross-venue prices differ only a few bps; for tight sizing pass
-  `--price`. Qty is always floored to lot size, so the real notional is ≤ your target.
-- **Real funds.** Start with `--dry-run` and a tiny `--notional`; the confirmation prompt is
-  on by default. Margin rates show `n/a` when there are no open positions.
+  remote-venue fill price. Cross-venue prices differ only a few bps. Qty is always floored
+  to lot size, so the real notional is ≤ your target.
+- **Real funds.** Start small. Every execution is preceded by a preview you can read, and
+  confirm is hold-to-press and blocked while a quote is stale — but the orders are real.
+  Margin rates show `n/a` when there are no open positions.
+- **Maturity is a deadline.** The Boros legs stop at maturity; the perps do not. A card
+  whose legs have matured says so and asks you to close the perps — leaving them open is
+  naked funding exposure, not an arb.
 
 ## The public site
 

--- a/src/core/boros/returns.ts
+++ b/src/core/boros/returns.ts
@@ -826,7 +826,20 @@ function assembleStrategy(args: AssembleInput): StrategyRollup {
     ...perpLegs.slice().sort((a, b) => a.venue.localeCompare(b.venue)),
     ...borosLegs.slice().sort((a, b) => a.venue.localeCompare(b.venue)),
   ];
-  for (const leg of legs) warnings.push(...leg.warnings);
+  /**
+   * Leg warnings surface on the card — EXCEPT the split-share note.
+   *
+   * That note is per-leg by construction (each leg has its own percentage), so
+   * hoisting it printed the same sentence once per leg at the top of the card.
+   * Summarising it into one card line was still prose restating the table: the
+   * leg's own Manual Adjustment cell already reads `1.26 HYPE / 1.89 HYPE`,
+   * which says "shared, and by how much" in the place the number lives. The
+   * note stays on the leg row; the card says nothing.
+   */
+  const SPLIT_NOTE = /% of this .* perp is counted here\.$/;
+  for (const leg of legs) {
+    for (const w of leg.warnings) if (!SPLIT_NOTE.test(w)) warnings.push(w);
+  }
 
   // --- Hedge health: per-venue floating cancellation ------------------------
   const venues = [...new Set(legs.map((l) => l.venue))];
@@ -2680,10 +2693,18 @@ function splitStrategies(
             : cohortPerpShare > 0.99
               ? '>99'
               : String(Math.round(cohortPerpShare * 100));
+        /**
+         * ONE line per card, not one per leg.
+         *
+         * This was pushed onto every perp leg, and `assembleStrategy` hoists
+         * leg warnings to the card — so a two-leg position printed the same
+         * sentence twice at the top, in full, above the numbers it qualifies.
+         * The fact is about the CARD ("some of these perps also hedge other
+         * maturities"), so it is stated once and briefly; the exact share per
+         * leg is on the leg's own row, beside the numbers it describes.
+         */
         for (const b of perpBuilds) {
-          b.leg.warnings.push(
-            `${pct}% of this ${b.leg.venue} perp is counted here — the rest hedges ${cohort.base}'s other Boros maturities.`,
-          );
+          b.leg.warnings.push(`${pct}% of this ${b.leg.venue} perp is counted here.`);
         }
       }
       // Float dust from the perp pairing can leave a tranche with essentially

--- a/version.json
+++ b/version.json
@@ -1,11 +1,12 @@
 {
-  "version": "1.3.0",
+  "version": "1.4.0",
   "highlights": [
-    "Share a position: a PNG card, a public crossexboros.com link, and a pre-filled X post, straight from a hedged 4-leg box",
-    "The link opens a page that explains the trade — the four legs as a hedging diagram, the PnL waterfall, the capital split",
-    "The whole snapshot rides in the URL: the public page stores nothing, and your wallet address never travels with a link",
-    "A deal that stops because your limit price kept crossing the market now says so, and points you back to the order form",
-    "The deal graph draws what the hedge leg would pay at market, sized to what is still unhedged, refreshed as the deal runs",
-    "On Windows the background service no longer opens a terminal window at logon — re-run the install command to pick it up"
+    "Share links are far shorter — the same snapshot, in a URL that survives a paste into X or Telegram",
+    "Open and close Boros legs directly in the app, without a detour to the Boros front end",
+    "A four-leg arb now goes up in two steps: pick the pair, confirm the size — the legs are placed for you",
+    "When automatic grouping cannot tell shared legs apart, adjust a composite position by hand and the app keeps your split",
+    "Composite positions track more faithfully as legs fill, close, and settle",
+    "Position tracking and cost settings are streamlined into one place, so what you paid and what you hold read together",
+    "App renamed to Arbitrage with CrossEx"
   ]
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -134,7 +134,7 @@ describe('App tab shell', () => {
     // /api/opportunities fixture resolves).
     expect(
       await within(panel('opportunities')).findByRole('button', {
-        name: /^Hedge the perps for ETH short/,
+        name: /^Open this strategy — ETH short/,
       }),
     ).toBeInTheDocument();
     expect(panel('opportunities')).toBeVisible();
@@ -268,13 +268,17 @@ describe('App tab shell', () => {
     await userEvent.click(screen.getByRole('button', { name: /with these assumptions/ }));
     expect(screen.getByLabelText('Gate VIP tier')).toBeInTheDocument();
 
-    // Symbols are expectedly absent — the button stays enabled as the guide's nudge.
-    const execute = screen.getByRole('button', { name: /^Hedge the perps for ETH short/ });
+    // Symbols are expectedly absent — the button stays enabled as the guide's
+    // nudge. It does NOT open the wizard here: with no keys there is nothing to
+    // execute, so the click asks for setup instead.
+    const execute = screen.getByRole('button', { name: /^Open this strategy — ETH short/ });
     expect(execute).toBeEnabled();
     await userEvent.click(execute);
     await waitFor(() => expect(screen.getByLabelText('API key')).toHaveFocus());
     // The guide flashes the key form's ring on the same nonce bump.
     expect(document.querySelector('.flash-ring')).not.toBeNull();
+    // And the execution wizard stays shut — it could not trade without keys.
+    expect(screen.queryByRole('heading', { name: /Open this strategy/ })).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -237,12 +237,17 @@ function OrderTicketButton() {
 }
 
 /** The manual ticket, mounted ONLY while its drawer is open — a closed drawer
- * cannot sit armed with a stale order. Closing also clears any prefills. */
+ * cannot sit armed with a stale order. Closing also clears any prefills.
+ * `locked` while a Boros execution is in flight: closing would unmount the
+ * ticket, and its fill report — a partial fill's remediation included — and
+ * replay-protection order ids are component state that die with it while the
+ * order executes at the venue regardless. */
 function OrderTicketDrawer() {
   const flow = useTradeFlow();
+  const [busy, setBusy] = useState(false);
   return (
-    <Drawer open={flow.railOpen} title="Order ticket" onClose={flow.closeRail}>
-      <TradeRail />
+    <Drawer open={flow.railOpen} title="Order ticket" locked={busy} onClose={flow.closeRail}>
+      <TradeRail onBusyChange={setBusy} />
     </Drawer>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,8 +19,10 @@ import { PositionsHome } from './panels/PositionsHome';
 import { SettingsDrawer } from './panels/SettingsDrawer';
 import { TrackedAddressProvider } from './panels/trackedAddress';
 import { TradesPanel } from './panels/TradesPanel';
+import { Drawer } from './components/Drawer';
 import { RecoveryBanner } from './trade/RecoveryBanner';
-import { TradeFlowProvider } from './trade/TradeFlow';
+import { StrategyWizard } from './trade/StrategyWizard';
+import { TradeFlowProvider, useTradeFlow } from './trade/TradeFlow';
 import { TradeRail } from './trade/TradeRail';
 
 // The markdown renderer is ~160kB and only the guide needs it — split it out so
@@ -73,6 +75,10 @@ export default function App() {
   const headerControls = (
     <>
       <UpdateIndicator />
+      {/* The manual free-form ticket, behind a button now: the guided wizard
+          is the primary path, and an always-on armed order form beside
+          unrelated content was the old layout's mis-execution hazard. */}
+      {configured && <OrderTicketButton />}
       {/* Deliberately the loudest thing in the header after the tabs: new users
           who miss it place real orders without knowing what the scan's
           assumptions mean. */}
@@ -153,6 +159,8 @@ export default function App() {
 
           {credentials.data?.configured && <RecoveryBanner />}
 
+          {/* Full-width content: the order ticket is no longer a permanent
+              column — the wizard and the drawer overlay on demand. */}
           <main className="mx-auto flex w-full max-w-[1500px] flex-1 items-start gap-5 px-5 py-5">
             <section className="min-w-0 flex-1">
               {credentials.isPending ? (
@@ -190,9 +198,15 @@ export default function App() {
               )}
             </section>
 
-            {setupNeeded ? <OnboardingGuide /> : <TradeRail />}
+            {setupNeeded && <OnboardingGuide />}
           </main>
 
+          {configured && (
+            <>
+              <StrategyWizard onViewPositions={() => selectTab('positions')} />
+              <OrderTicketDrawer />
+            </>
+          )}
           <SettingsDrawer open={settingsOpen} onClose={() => setSettingsOpen(false)} />
           {/* Mounted only while open, so the guide is fetched on first request. */}
           {guideOpen && (
@@ -203,5 +217,32 @@ export default function App() {
         </div>
       </TrackedAddressProvider>
     </TradeFlowProvider>
+  );
+}
+
+/** Opens the manual order-ticket drawer. Must render inside TradeFlowProvider. */
+function OrderTicketButton() {
+  const flow = useTradeFlow();
+  return (
+    <button
+      type="button"
+      aria-label="Order ticket"
+      title="The manual order ticket — free-form Boros and CrossEx orders. The cards' own buttons walk you through a full strategy."
+      onClick={flow.openRail}
+      className="rounded-md border border-ink-700 bg-ink-900 px-2.5 py-1 text-xs font-semibold text-ink-300 transition-colors hover:border-ink-500 hover:text-ink-100"
+    >
+      Order ticket
+    </button>
+  );
+}
+
+/** The manual ticket, mounted ONLY while its drawer is open — a closed drawer
+ * cannot sit armed with a stale order. Closing also clears any prefills. */
+function OrderTicketDrawer() {
+  const flow = useTradeFlow();
+  return (
+    <Drawer open={flow.railOpen} title="Order ticket" onClose={flow.closeRail}>
+      <TradeRail />
+    </Drawer>
   );
 }

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -3,36 +3,44 @@ import { useEffect, type ReactNode } from 'react';
 interface Props {
   open: boolean;
   title: string;
+  /** While locked (execution in flight) the ✕ is hidden and Escape/backdrop
+   * are ignored — closing unmounts the children, and an executing ticket's
+   * result would die with them. Mirrors Modal's prop of the same name. */
+  locked?: boolean;
   onClose: () => void;
   children: ReactNode;
 }
 
 /** Right-side overlay drawer (Settings). Escape or backdrop click closes. */
-export function Drawer({ open, title, onClose, children }: Props) {
+export function Drawer({ open, title, locked = false, onClose, children }: Props) {
   useEffect(() => {
-    if (!open) return;
+    if (!open || locked) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      // e.repeat: a HELD Escape auto-repeats, and surfaces with an arm-then-
+      // confirm close guard would see the repeat as the confirming second call.
+      if (e.key === 'Escape' && !e.repeat) onClose();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [open, onClose]);
+  }, [open, locked, onClose]);
 
   if (!open) return null;
   return (
     <div className="fixed inset-0 z-50" role="dialog" aria-modal="true" aria-label={title}>
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-[2px]" onClick={onClose} />
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-[2px]" onClick={locked ? undefined : onClose} />
       <div className="absolute inset-y-0 right-0 flex w-[380px] max-w-[92vw] flex-col border-l border-ink-700 bg-ink-900 shadow-2xl">
         <div className="flex items-center justify-between border-b border-ink-800 px-5 py-4">
           <h2 className="text-sm font-semibold text-ink-100">{title}</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="close"
-            className="rounded-md px-2 py-0.5 text-ink-400 transition-colors hover:bg-ink-800 hover:text-ink-100"
-          >
-            ✕
-          </button>
+          {!locked && (
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="close"
+              className="rounded-md px-2 py-0.5 text-ink-400 transition-colors hover:bg-ink-800 hover:text-ink-100"
+            >
+              ✕
+            </button>
+          )}
         </div>
         <div className="flex-1 overflow-y-auto px-5 py-4">{children}</div>
       </div>

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -18,7 +18,10 @@ export function Modal({ title, locked = false, onClose, widthClass = 'w-[700px]'
   useEffect(() => {
     if (locked) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      // e.repeat: a HELD Escape auto-repeats, and surfaces with an arm-then-
+      // confirm close guard (the wizard's leave warning) would see the repeat
+      // as the confirming second call.
+      if (e.key === 'Escape' && !e.repeat) onClose();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);

--- a/web/src/lib/boros.test.ts
+++ b/web/src/lib/boros.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { isUsdCollateral, sizeUnitForBase } from './boros';
+
+describe('sizeUnitForBase', () => {
+  it('sizes the coin-margined coins in their own token', () => {
+    // ETH and BTC are the coin-collateral markets on Boros, so the perp box
+    // must match the Boros leg's unit or the hedge needs an eyeballed FX step.
+    expect(sizeUnitForBase('ETH')).toBe('base');
+    expect(sizeUnitForBase('BTC')).toBe('base');
+    expect(sizeUnitForBase('eth')).toBe('base');
+  });
+
+  it('sizes every other coin in dollars', () => {
+    // HYPE and the rest are USDT-collateral on Boros: a token unit here is a
+    // conversion imposed for nothing.
+    expect(sizeUnitForBase('HYPE')).toBe('usd');
+    expect(sizeUnitForBase('SOL')).toBe('usd');
+    expect(sizeUnitForBase(null)).toBe('usd');
+    expect(sizeUnitForBase(undefined)).toBe('usd');
+  });
+});
+
+describe('isUsdCollateral', () => {
+  it('counts USDC as dollars, not just USDT', () => {
+    // The bug this replaced tested `!== 'USDT'` alone, so a USDC-collateral
+    // group was handed a token quantity and armed the tickets in base units.
+    expect(isUsdCollateral('USDT')).toBe(true);
+    expect(isUsdCollateral('USDC')).toBe(true);
+    expect(isUsdCollateral('usdc')).toBe(true);
+    expect(isUsdCollateral('ETH')).toBe(false);
+    expect(isUsdCollateral('')).toBe(false);
+    expect(isUsdCollateral(null)).toBe(false);
+  });
+});

--- a/web/src/lib/boros.ts
+++ b/web/src/lib/boros.ts
@@ -39,3 +39,35 @@ export function crossexVenueFor(borosVenue: string | null | undefined): string |
   if (!borosVenue) return null;
   return BOROS_VENUE_TO_CROSSEX[borosVenue.trim().toUpperCase()] ?? null;
 }
+
+/**
+ * Which unit a coin's size box should default to, for BOTH the perp legs and
+ * the Boros legs of the same strategy.
+ *
+ * The rule follows the Boros collateral, because that is the leg with no say
+ * in the matter: an ETH-collateral market denominates size in ETH, a
+ * USDT-collateral market in USDT. Sizing the perp in the same unit is what
+ * makes a hedge exact — matching an ETH Boros leg from a USD box means
+ * eyeballing an FX conversion, and the error surfaces later as a position the
+ * card flags as imbalanced.
+ *
+ * ETH and BTC are the coin-margined markets on Boros today; every other coin
+ * (HYPE and the rest) is quoted against USDT/USDC, so a token unit there is a
+ * conversion imposed for no reason — the user is handed a quantity when the
+ * number that matters, on both legs, is dollars.
+ *
+ * ⚠ Keep this the single source for that choice. When the ticket knows the
+ * market's actual collateral it should prefer THAT (see BorosPairTicket's
+ * prefill); this answers the same question for callers that only have a coin.
+ */
+const COIN_MARGINED = new Set(['ETH', 'BTC']);
+
+export function sizeUnitForBase(base: string | null | undefined): 'base' | 'usd' {
+  return base && COIN_MARGINED.has(base.toUpperCase()) ? 'base' : 'usd';
+}
+
+/** The same rule expressed as a collateral symbol, for labelling a size box. */
+export function isUsdCollateral(collateral: string | null | undefined): boolean {
+  const c = (collateral ?? '').toUpperCase();
+  return c === 'USDT' || c === 'USDC';
+}

--- a/web/src/panels/ClosePairForm.test.tsx
+++ b/web/src/panels/ClosePairForm.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * The pair-close form's slippage control.
+ *
+ * This path used to send NO `slippagePct` at all and expose no input, so the
+ * user's setting was silently the 0.5% default — the setting was not
+ * "respected" because it could not be expressed. The single-leg ClosePopover
+ * always had the control; this is the two-leg surface catching up.
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import type { ActionInput, PreviewResponse } from '../api/types';
+import { baseHandlers, previewFor } from '../test/fixtures';
+import { env, server } from '../test/server';
+import { renderWithClient } from '../test/utils';
+import { ClosePairForm } from './PerpOnlyBox';
+
+const LEGS = [
+  { symbol: 'BYBIT_FUTURE_HYPE_USDT', qty: 1.89, venue: 'BYBIT' },
+  { symbol: 'HYPERLIQUID_FUTURE_HYPE_USDC', qty: 1.89, venue: 'HYPERLIQUID' },
+];
+
+/** Captures every previewed action so we can read the slippage actually sent. */
+function previewSpy(seen: ActionInput[][]) {
+  return http.post('/api/preview', async ({ request }) => {
+    const { actions } = (await request.json()) as { actions: ActionInput[] };
+    seen.push(actions);
+    return HttpResponse.json(
+      env<PreviewResponse>({
+        previews: actions.map((a) =>
+          previewFor(a, {
+            side: 'SELL',
+            type: 'LIMIT',
+            tif: 'IOC',
+            reduceOnly: true,
+            qty: '1.89',
+            price: '80',
+            estNotional: 151,
+            closing: { positionQty: '1.89', upnl: '1', mark: 80 },
+          }),
+        ),
+      }),
+    );
+  });
+}
+
+describe('ClosePairForm — the slippage the user sets is the slippage sent', () => {
+  it('sends the typed slippage on BOTH legs', async () => {
+    const seen: ActionInput[][] = [];
+    server.use(...baseHandlers(), previewSpy(seen));
+    renderWithClient(<ClosePairForm base="HYPE" legs={LEGS} />);
+
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0), { timeout: 4000 });
+    // The default is stated, not implied.
+    const slipOf = (as: ActionInput[]) =>
+      as.map((a) => (a.kind === 'close-position' ? a.slippagePct : undefined));
+    expect(slipOf(seen.at(-1)!)).toEqual([0.5, 0.5]);
+
+    const slip = screen.getByLabelText('Slippage %');
+    await userEvent.clear(slip);
+    await userEvent.type(slip, '2');
+
+    // Both legs, not just the one that carries the band.
+    await waitFor(() => expect(slipOf(seen.at(-1)!)).toEqual([2, 2]), { timeout: 4000 });
+  });
+
+  it('refuses an out-of-range slippage instead of silently defaulting', async () => {
+    const seen: ActionInput[][] = [];
+    server.use(...baseHandlers(), previewSpy(seen));
+    renderWithClient(<ClosePairForm base="HYPE" legs={LEGS} />);
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0), { timeout: 4000 });
+
+    const slip = screen.getByLabelText('Slippage %');
+    await userEvent.clear(slip);
+    await userEvent.type(slip, '50');
+
+    expect(await screen.findByText(/slippage must be in \(0, 10\]/)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Close both/ })).toBeDisabled(),
+    );
+  });
+
+  it('states that only the first leg carries the band', async () => {
+    // The old copy promised "mark ± slippage" for the whole close, but the
+    // hedge leg is deliberately a plain MARKET IOC (see decide.ts) — a
+    // book-mid limit band gets price-limit-rejected and would strand it.
+    server.use(...baseHandlers(), previewSpy([]));
+    renderWithClient(<ClosePairForm base="HYPE" legs={LEGS} />);
+    // The note rides as the tooltip on the "reduce-only IOC marketable limit"
+    // affordance, so assert the title rather than visible text.
+    const badge = await screen.findByText(/reduce-only IOC marketable limit/);
+    expect(badge).toHaveAttribute(
+      'title',
+      expect.stringContaining("the hedge leg is sent at market, inside the venue's own price band"),
+    );
+  });
+});

--- a/web/src/panels/ClosePairForm.test.tsx
+++ b/web/src/panels/ClosePairForm.test.tsx
@@ -6,11 +6,11 @@
  * "respected" because it could not be expressed. The single-leg ClosePopover
  * always had the control; this is the two-leg surface catching up.
  */
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
-import type { ActionInput, PreviewResponse } from '../api/types';
+import type { ActionInput, DealRequest, PreviewResponse } from '../api/types';
 import { baseHandlers, previewFor } from '../test/fixtures';
 import { env, server } from '../test/server';
 import { renderWithClient } from '../test/utils';
@@ -95,4 +95,47 @@ describe('ClosePairForm — the slippage the user sets is the slippage sent', ()
       expect.stringContaining("the hedge leg is sent at market, inside the venue's own price band"),
     );
   });
+});
+
+describe('ClosePairForm — slippage is part of the close intent', () => {
+  it('mints a NEW deal id when slippage changes after a lost response', async () => {
+    /**
+     * Mirrors PairTicket's size-unit regression: `slippagePct` rides the wire
+     * and sets the close's price band, so it must be in the intentKey. Without
+     * it, a lost-response confirm at 0.5% followed by an edit to 2% produced a
+     * byte-identical key — the persisted deal id was resent, the server
+     * deduped it into the ORIGINAL band, and the form showed the new one.
+     */
+    const dealCalls: DealRequest[] = [];
+    server.use(
+      ...baseHandlers(),
+      previewSpy([]),
+      http.post('/api/deals', async ({ request }) => {
+        dealCalls.push((await request.json()) as DealRequest);
+        return HttpResponse.json(
+          { ok: false, error: { category: 'network', message: 'socket hang up', retryable: true } },
+          { status: 500 },
+        );
+      }),
+    );
+    renderWithClient(<ClosePairForm base="HYPE" legs={LEGS} />);
+
+    const btn = await screen.findByRole('button', { name: /Close both/ });
+    await waitFor(() => expect(btn).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(btn);
+    await waitFor(() => expect(dealCalls).toHaveLength(1), { timeout: 2_000 });
+
+    const slip = screen.getByLabelText('Slippage %');
+    await userEvent.clear(slip);
+    await userEvent.type(slip, '2');
+
+    const btn2 = screen.getByRole('button', { name: /Close both/ });
+    await waitFor(() => expect(btn2).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(btn2);
+    await waitFor(() => expect(dealCalls).toHaveLength(2), { timeout: 2_000 });
+
+    // A different band is a different order ⇒ a different id, so the server
+    // cannot dedupe the 2% close into the 0.5% one.
+    expect(dealCalls[1].id).not.toBe(dealCalls[0].id);
+  }, 15_000);
 });

--- a/web/src/panels/OnboardingGuide.tsx
+++ b/web/src/panels/OnboardingGuide.tsx
@@ -3,13 +3,15 @@ import { useTradeFlowOptional } from '../trade/TradeFlow';
 import { Ext, GATE_API_KEYS_URL, GATE_CROSSEX_URL, GATE_SIGNUP_URL, Step, useNudge } from './onboardingBits';
 
 /** First-run right rail: the 4-step Gate onboarding with the credentials form.
- * Replaces the order ticket while credentials are unconfigured. An Execute click
- * on a card bumps the trade-flow prefill nonce — the pair is already staged for
- * the real ticket, so the guide answers by scrolling to and flashing the API-key
- * form, the one step standing between the click and an armed ticket. */
+ * Replaces the order ticket while credentials are unconfigured. Clicking a
+ * card's "Open this strategy" bumps `setupNonce` — the wizard deliberately
+ * stays shut, since with no keys it could not execute — and the guide answers
+ * by scrolling to and flashing the API-key form, the one step standing between
+ * that click and a wizard that can trade. (The prefill nonce still counts too:
+ * the strategy-box cues arm the ticket directly.) */
 export function OnboardingGuide() {
   const flow = useTradeFlowOptional();
-  const nonce = flow?.pairPrefill?.nonce ?? 0;
+  const nonce = (flow?.setupNonce ?? 0) + (flow?.pairPrefill?.nonce ?? 0);
   const { ref: formRef, flash } = useNudge(nonce);
 
   return (

--- a/web/src/panels/OpportunitiesPanel.test.tsx
+++ b/web/src/panels/OpportunitiesPanel.test.tsx
@@ -3,16 +3,8 @@
  * cohort lives in test/fixtures; degraded variants are spelled per case. */
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
-import type {
-  ActionInput,
-  OpportunityLeg,
-  OpportunityPair,
-  PreviewResponse,
-  PreviewResult,
-  SymbolRule,
-} from '../api/types';
+import type { OpportunityLeg, OpportunityPair, SymbolRule } from '../api/types';
 import {
   baseHandlers,
   ETH_GATE,
@@ -24,13 +16,11 @@ import {
   opportunitiesHandler,
   OPP_MATURITY,
   OPP_NT,
-  previewFor,
   symbolHandlers,
 } from '../test/fixtures';
-import { env, server } from '../test/server';
+import { server } from '../test/server';
 import { renderWithClient } from '../test/utils';
-import { PairTicket } from '../trade/PairTicket';
-import { TradeFlowProvider, useTradeFlow } from '../trade/TradeFlow';
+import { useTradeFlow } from '../trade/TradeFlow';
 import { OPPORTUNITIES_STORAGE_KEY, OpportunitiesPanel } from './OpportunitiesPanel';
 import { OPPORTUNITY_FILTERS_STORAGE_KEY } from './opportunityFilters';
 
@@ -42,9 +32,10 @@ const paramsOf = (url: string) => Object.fromEntries(new URL(url).searchParams);
 /** The card's collapse toggle, one per group. */
 const toggles = () => screen.getAllByRole('button', { name: /^(Show|Hide) details for/ });
 
-/** The hedge action. Its accessible name is the aria-label, which carries the
- * card's identity — many cards per cohort differ only by their legs. */
-const executeButtons = () => screen.getAllByRole('button', { name: /^Hedge the perps / });
+/** The card's one CTA — opens the guided wizard. Its accessible name is the
+ * aria-label, which carries the card's identity — many cards per cohort
+ * differ only by their legs. */
+const executeButtons = () => screen.getAllByRole('button', { name: /^Open this strategy — / });
 
 /** Every knob lives inside the collapsed assumptions strip — open it first. */
 const openAssumptions = () =>
@@ -462,7 +453,7 @@ describe('OpportunitiesPanel — collapse', () => {
     await waitFor(() => expect(toggles()).toHaveLength(1));
     expect(screen.getByText('7.0% APR')).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /^Hedge the perps for ETH short Hyperliquid/ }),
+      screen.getByRole('button', { name: /^Open this strategy — ETH short Hyperliquid/ }),
     ).toBeInTheDocument();
     expect(toggles()[0]).toHaveTextContent('More details');
     expect(toggles()[0]).toHaveAttribute('aria-expanded', 'false');
@@ -946,84 +937,45 @@ const ETH_HYPERLIQUID: SymbolRule = {
 };
 const ETH_BINANCE: SymbolRule = { ...ETH_GATE, symbol: 'BINANCE_FUTURE_ETH_USDT', exchange: 'BINANCE' };
 
-const TOUCH = { bestBid: 2499, bestAsk: 2501, mid: 2500 };
-
-/** POST /api/preview echoing taker/maker fees + a touch, as PairTicket.test does. */
-function previewHandler(calls: ActionInput[][]) {
-  return http.post('/api/preview', async ({ request }) => {
-    const { actions } = (await request.json()) as { actions: ActionInput[] };
-    calls.push(actions);
-    const previews = actions.map((a, i): PreviewResult => {
-      const fees = { makerRate: 0.0002, takerRate: 0.0005, specialOverride: false, quote: 'USDT' };
-      if (a.kind === 'open-limit') {
-        return previewFor(a, {
-          index: i,
-          type: 'LIMIT',
-          tif: 'POC',
-          price: a.price || String(TOUCH.mid),
-          qty: '4',
-          estNotional: 10_000,
-          restEstimate: TOUCH,
-          fees: { ...fees, est: { maker: 2 } },
-        });
-      }
-      return previewFor(a, {
-        index: i,
-        qty: '4',
-        estNotional: 10_000,
-        fillEstimate: {
-          qty: '4',
-          avgPrice: 2500.5,
-          worstPrice: 2501,
-          midPrice: TOUCH.mid,
-          slippagePct: 0.02,
-          source: 'venue-orderbook',
-          confidence: 'high',
-          venue: a.symbol.split('_')[0],
-        },
-        fees: { ...fees, est: { taker: 5 } },
-      });
-    });
-    return HttpResponse.json(env<PreviewResponse>({ previews }));
-  });
+/** The last wizard intent the panel opened — the panel's whole execution
+ * contract now: the wizard (mounted in App, not here) arms the tickets from
+ * this, and prefill→ticket is covered by the tickets' own suites. */
+const wizardSeen: Array<Record<string, unknown>> = [];
+function WizardProbe() {
+  const flow = useTradeFlow();
+  const w = flow.wizard as unknown as Record<string, unknown> | null;
+  if (w && wizardSeen.at(-1) !== w) wizardSeen.push(w);
+  return null;
 }
 
-describe('OpportunitiesPanel → Boros prefill', () => {
-  it('arms the Boros ticket with BOTH legs at the card\'s own maturity', async () => {
-    // Regression, twice over:
-    //  1. the maturity did not travel, so a venue+base match took whichever
-    //     expiry came first — the two legs landed on DIFFERENT maturities, and
-    //     since each leg filters the other by maturity, BOTH then vanished
-    //     from their own dropdowns and the ticket rendered empty;
-    //  2. an unresolved market left the PREVIOUS prefill's leg in place, which
-    //     filtered the other leg down to whatever could pair with the stale one.
+describe('OpportunitiesPanel → wizard intent', () => {
+  it('opens the wizard with BOTH Boros legs at the card\'s own maturity', async () => {
+    // Regression heritage (from the old direct-prefill contract): the maturity
+    // must travel, or a venue+base match takes whichever expiry comes first —
+    // the two legs then land on DIFFERENT maturities, and since each leg
+    // filters the other by maturity, BOTH vanish from their own dropdowns and
+    // the ticket renders empty.
     server.use(
       ...baseHandlers(),
       ...symbolHandlers([ETH_HYPERLIQUID, ETH_BINANCE]),
       opportunitiesHandler(makeOpportunitiesResult()),
     );
-    const seen: Array<Record<string, unknown>> = [];
-    function Probe() {
-      const flow = useTradeFlow();
-      const p = flow.borosOpenPrefill;
-      if (p && !seen.some((x) => x.nonce === p.nonce)) seen.push({ ...p });
-      return null;
-    }
+    wizardSeen.length = 0;
     renderWithClient(
-      <TradeFlowProvider>
+      <>
         <OpportunitiesPanel />
-        <Probe />
-      </TradeFlowProvider>,
+        <WizardProbe />
+      </>,
     );
 
     await waitFor(() => expect(toggles()).toHaveLength(1));
-    await userEvent.click(screen.getByRole('button', { name: /^Lock the rate for / }));
+    await userEvent.click(screen.getByRole('button', { name: /^Open this strategy — / }));
 
-    await waitFor(() => expect(seen).toHaveLength(1));
-    const sent = seen[0];
-    // Both venues travel — this opens the PAIR, not one leg.
-    expect(sent.longVenue).toBeTruthy();
-    expect(sent.shortVenue).toBeTruthy();
+    await waitFor(() => expect(wizardSeen).toHaveLength(1));
+    const sent = wizardSeen[0];
+    // Both Boros venues travel — step 1 opens the PAIR, not one leg.
+    expect(sent.borosLongVenue).toBeTruthy();
+    expect(sent.borosShortVenue).toBeTruthy();
     expect(sent.base).toBe('ETH');
     // The pin: the cohort's maturity rides along, so the ticket cannot resolve
     // the two legs to different expiries.
@@ -1032,46 +984,38 @@ describe('OpportunitiesPanel → Boros prefill', () => {
   });
 });
 
-describe('OpportunitiesPanel → PairTicket prefill', () => {
-  it('arms the ticket with the size, the maker mode and the server-supplied legs', async () => {
-    const calls: ActionInput[][] = [];
+describe('OpportunitiesPanel → wizard intent, perp half', () => {
+  it('carries the priced size, the panel\'s entry mode and the CrossEx venue keys', async () => {
     server.use(
       ...baseHandlers(),
       ...symbolHandlers([ETH_HYPERLIQUID, ETH_BINANCE]),
-      previewHandler(calls),
       opportunitiesHandler(makeOpportunitiesResult()),
     );
+    wizardSeen.length = 0;
     renderWithClient(
       <>
         <OpportunitiesPanel />
-        <PairTicket />
+        <WizardProbe />
       </>,
     );
 
     await waitFor(() => expect(toggles()).toHaveLength(1));
-    // The panel's entry mode is what the ticket gets armed with.
+    // The panel's entry mode is what step 2 gets armed with.
     await openAssumptions();
     const panelModes = screen.getByRole('radiogroup', { name: 'Perp entry mode' });
     await userEvent.click(within(panelModes).getByRole('radio', { name: /Limit \+ hedge/ }));
     await userEvent.click(
-      screen.getByRole('button', { name: /^Hedge the perps for ETH short Hyperliquid/ }),
+      screen.getByRole('button', { name: /^Open this strategy — ETH short Hyperliquid/ }),
     );
 
-    await waitFor(() =>
-      expect(screen.getByLabelText('Size per leg (USDT)')).toHaveValue('10000'),
-    );
-    const ticketModes = screen.getByRole('radiogroup', { name: 'Pair execution mode' });
-    expect(within(ticketModes).getByRole('radio', { name: /Limit \+ hedge/ })).toHaveAttribute(
-      'aria-checked',
-      'true',
-    );
-
-    // Boros SHORT on Hyperliquid ⇒ perp SELL there; Boros LONG on Binance ⇒ BUY.
-    await waitFor(() => expect(calls.at(-1)).toHaveLength(2), { timeout: 4000 });
-    const legs = calls.at(-1)!;
-    expect(legs[0]).toMatchObject({ symbol: 'BINANCE_FUTURE_ETH_USDT', side: 'BUY' });
-    expect(legs[1]).toMatchObject({ symbol: 'HYPERLIQUID_FUTURE_ETH_USDC', side: 'SELL' });
-    expect(legs.some((a) => a.kind === 'open-limit' && a.pairRole === 'maker')).toBe(true);
+    await waitFor(() => expect(wizardSeen).toHaveLength(1));
+    const sent = wizardSeen[0];
+    // CrossEx venue keys, NOT the Boros ones — the two halves are addressed
+    // differently even when they sit at the same exchange.
+    expect(sent.crossexLongVenue).toBe('BINANCE');
+    expect(sent.crossexShortVenue).toBe('HYPERLIQUID');
+    expect(sent.notionalUsd).toBe(10_000);
+    expect(sent.perpMode).toBe('maker');
   });
 });
 
@@ -1199,13 +1143,11 @@ describe('OpportunitiesPanel — every viable pair', () => {
   });
 });
 
-describe('OpportunitiesPanel → PairTicket prefill, runner-up pairs', () => {
-  it('arms the ticket with the legs of the card that was CLICKED, not the group best', async () => {
-    const calls: ActionInput[][] = [];
+describe('OpportunitiesPanel → wizard intent, runner-up pairs', () => {
+  it('opens the wizard for the card that was CLICKED, not the group best', async () => {
     server.use(
       ...baseHandlers(),
       ...symbolHandlers([ETH_HYPERLIQUID, ETH_BINANCE, ETH_GATE]),
-      previewHandler(calls),
       // One ETH cohort, two venue combinations: Binance at 12%, Gate at 4%.
       opportunitiesHandler(
         makeOpportunitiesResult({
@@ -1220,29 +1162,25 @@ describe('OpportunitiesPanel → PairTicket prefill, runner-up pairs', () => {
         }),
       ),
     );
+    wizardSeen.length = 0;
     renderWithClient(
       <>
         <OpportunitiesPanel />
-        <PairTicket />
+        <WizardProbe />
       </>,
     );
 
     await waitFor(() => expect(toggles()).toHaveLength(2));
     // The RUNNER-UP — the card the old one-per-group list could not even show.
-    await userEvent.click(executeFor(/^Hedge the perps for ETH short Hyperliquid \/ long Gate/));
+    await userEvent.click(executeFor(/^Open this strategy — ETH short Hyperliquid \/ long Gate/));
 
-    await waitFor(() => expect(calls.at(-1)).toHaveLength(2), { timeout: 4000 });
-    const legs = calls.at(-1) as ActionInput[];
-    // Gate's legs, not the 12% Binance pair's.
-    expect(legs.map((a) => a.symbol).sort()).toEqual([
-      'GATE_FUTURE_ETH_USDT',
-      'HYPERLIQUID_FUTURE_ETH_USDC',
-    ]);
-    expect(legs.find((a) => a.symbol === 'GATE_FUTURE_ETH_USDT')).toMatchObject({ side: 'BUY' });
-    expect(legs.find((a) => a.symbol === 'HYPERLIQUID_FUTURE_ETH_USDC')).toMatchObject({
-      side: 'SELL',
-    });
-    expect(legs.some((a) => a.symbol === 'BINANCE_FUTURE_ETH_USDT')).toBe(false);
+    await waitFor(() => expect(wizardSeen).toHaveLength(1));
+    const sent = wizardSeen[0];
+    // Gate's legs, not the 12% Binance pair's — on BOTH halves.
+    expect(sent.crossexLongVenue).toBe('GATE');
+    expect(sent.crossexShortVenue).toBe('HYPERLIQUID');
+    expect(sent.borosLongVenue).toBe('GATE');
+    expect(sent.borosShortVenue).toBe('HYPERLIQUID');
   });
 });
 

--- a/web/src/panels/OpportunitiesPanel.tsx
+++ b/web/src/panels/OpportunitiesPanel.tsx
@@ -48,7 +48,7 @@ import { SegmentedToggle } from '../components/SegmentedToggle';
 import { Skeleton } from '../components/Skeleton';
 import { microLabelClass } from '../components/Th';
 import { SideVenue } from '../components/VenueChip';
-import { borosMarketUrl } from '../lib/boros';
+import { borosMarketUrl, isUsdCollateral } from '../lib/boros';
 import {
   fmtAge,
   fmtDateUtc,
@@ -389,8 +389,7 @@ const OpportunityCard = memo(function OpportunityCard({
   group,
   pair,
   notionalUsd,
-  onExecute,
-  onExecuteBoros,
+  onOpenStrategy,
   unconfigured,
 }: {
   /** The cohort the pair belongs to — collateral, maturity, underlying. */
@@ -400,13 +399,15 @@ const OpportunityCard = memo(function OpportunityCard({
   pair: OpportunityPair;
   /** The notional the RESPONSE priced — the waterfall converts APRs with it. */
   notionalUsd: number;
-  /** null when there is no trade-flow provider — the button then explains itself.
-   * `sizeBase` arms the perps in the Boros collateral when that IS the base
-   * coin, so both legs match without an eyeballed conversion. */
-  onExecute: ((pair: OpportunityPair, sizeBase?: number) => void) | null;
-  /** Arms the BOROS ticket with this pair's two rate legs. */
-  onExecuteBoros?: ((pair: OpportunityPair, maturitySec?: number) => void) | null;
-  /** First-run view: symbols are expectedly absent, so Execute stays enabled
+  /** Opens the guided 2-step wizard for this pair — Boros rate legs first,
+   * then the perp hedge. null when there is no trade-flow provider (the
+   * landing build); the button then explains itself. `sizeBase` sizes the
+   * legs in the Boros collateral when that IS the base coin, so all four
+   * match without an eyeballed conversion. */
+  onOpenStrategy:
+    | ((pair: OpportunityPair, maturitySec: number, sizeBase?: number) => void)
+    | null;
+  /** First-run view: symbols are expectedly absent, so the CTA stays enabled
    * and clicking it nudges the setup guide instead of dead-ending. */
   unconfigured: boolean;
 }) {
@@ -434,8 +435,13 @@ const OpportunityCard = memo(function OpportunityCard({
   const maturityTitle = `Matures ${fmtDateUtc(group.maturity)} UTC · ${fmtAge(group.secondsToMaturity * 1000)} left`;
   // Token-margined groups also size in the collateral token — bracket the
   // notional with that amount (USDT groups stay pure-dollar).
+  // ⚠ USDC counts as dollars too — testing `!== 'USDT'` alone handed a
+  // USDC-collateral group a token quantity, which then armed both tickets in
+  // "base" units for a market whose size is already dollars.
   const collateralQty =
-    group.collateral !== 'USDT' && group.collateralPriceUsd !== null && group.collateralPriceUsd > 0
+    !isUsdCollateral(group.collateral) &&
+    group.collateralPriceUsd !== null &&
+    group.collateralPriceUsd > 0
       ? { qty: notionalUsd / group.collateralPriceUsd, symbol: group.collateral }
       : null;
   // Both legs unmapped ⇒ the ticket would arm nothing; one missing is fine (it
@@ -443,14 +449,14 @@ const OpportunityCard = memo(function OpportunityCard({
   // different assets, and the ticket only takes one base.
   const basesDiffer = pair.shortLeg.base !== pair.longLeg.base;
   const noSymbols = !pair.shortLeg.crossexSymbol && !pair.longLeg.crossexSymbol;
-  const executeDisabled = (noSymbols && !unconfigured) || basesDiffer || onExecute === null;
+  const executeDisabled = (noSymbols && !unconfigured) || basesDiffer || onOpenStrategy === null;
   const executeTitle = basesDiffer
     ? `The legs trade different assets (${pair.shortLeg.base} vs ${pair.longLeg.base}) — the pair ticket takes one base`
     : unconfigured
-      ? 'Add your Gate API key in the setup guide on the right — clicking stages this pair for the ticket'
+      ? 'Add your Gate API key in the setup guide on the right — clicking walks you through the legs'
       : noSymbols
         ? `Neither ${pair.shortLeg.venue} nor ${pair.longLeg.venue} lists a CrossEx perp for ${pair.base}`
-        : 'Prefills the pair ticket with these perp legs — you still confirm the order there';
+        : 'Opens this strategy step by step — lock the Boros rate first, then hedge with the perps. You confirm each order yourself.';
   const detailsDisabled =
     !canChartProfit(pair) && !canChartCapital(pair) && pair.execSpreadApr === null;
   const detailsTitle = detailsDisabled
@@ -602,63 +608,52 @@ const OpportunityCard = memo(function OpportunityCard({
               </Stat>
             )}
           </div>
-          {/* Buttons only. The sequence caption used to stack under them here,
-              which made this column ~22px taller than the figures beside it
-              and left that much dead band inside the row; it rides the footer
-              line now, still right-aligned under "Hedge the perps". With it
-              gone the two sides are naturally the same height and the row is
-              exactly as tall as its content. */}
+          {/* The action only. The sequence caption used to stack under the
+              buttons here, which made this column ~22px taller than the
+              figures beside it and left that much dead band inside the row;
+              both it and Details are gone from this row now, so the two sides
+              are naturally the same height. */}
           <div className="flex shrink-0 items-center gap-2">
-            {/* PRIMARY — locking the fixed spread IS the trade; the perps
-                only hedge what this leg buys, so it comes first and hedging
-                second. Both carry the same identity as Details: many cards
-                per cohort now differ only by their legs. */}
+            {/* ONE action: the strategy is two ordered executions, and two
+                side-by-side buttons styled primary/secondary read as
+                alternatives — the opposite of the truth. The wizard this opens
+                states the order (rate legs, then the hedge) as numbered steps
+                and hands off to Positions when both are on.
+
+                Details is NOT here: it moved to the footer line below as a
+                quiet text link, so this row holds only the action that opens
+                a position. */}
             <button
               type="button"
               className="btn btn-primary px-4 font-semibold"
-              aria-label={`Lock the rate for ${base} short ${prettyVenue(pair.shortLeg.venue)} / long ${prettyVenue(pair.longLeg.venue)}, ${group.collateral}-margined ${fmtDateUtc(group.maturity)}`}
+              aria-label={`Open this strategy — ${base} short ${prettyVenue(pair.shortLeg.venue)} / long ${prettyVenue(pair.longLeg.venue)}, ${group.collateral}-margined ${fmtDateUtc(group.maturity)}`}
               disabled={executeDisabled}
-              title={
-                executeTitle ??
-                'Prefills the Boros ticket with both rate legs — this is the spread you are buying, so lock it first'
-              }
-              onClick={() => pair && onExecuteBoros?.(pair, group.maturity)}
-            >
-              Lock the rate
-            </button>
-            <button
-              type="button"
-              className="btn px-4 font-semibold"
-              aria-label={`Hedge the perps for ${base} short ${prettyVenue(pair.shortLeg.venue)} / long ${prettyVenue(pair.longLeg.venue)}, ${group.collateral}-margined ${fmtDateUtc(group.maturity)}`}
-              disabled={executeDisabled}
-              title={
-                executeTitle ?? 'Prefills the pair ticket with the two perp legs that hedge the spread'
-              }
+              title={executeTitle}
               onClick={() =>
-                // Size the perps in the Boros collateral when that IS the
-                // base coin, so the two legs match without an eyeballed
-                // conversion; USDT-margined cohorts keep the dollar figure.
+                // Size in the Boros collateral when that IS the base coin, so
+                // all four legs match without an eyeballed conversion;
+                // USDT-margined cohorts keep the dollar figure.
                 pair &&
-                onExecute?.(
+                onOpenStrategy?.(
                   pair,
+                  group.maturity,
                   collateralQty && collateralQty.symbol.toUpperCase() === pair.base.toUpperCase()
                     ? collateralQty.qty
                     : undefined,
                 )
               }
             >
-              Hedge the perps
+              Open this strategy →
             </button>
           </div>
         </div>
 
-        {/* Footer line — the two quiet notes the card still owes, on one row
-            so neither costs its own band: the expand toggle left, the sequence
-            caption right under the buttons it captions. */}
+        {/* Footer line — the quiet note the card still owes, kept off the
+            action row so it costs no band of its own: the expand toggle. */}
         <div className="mt-2.5 flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
-          {/* Details as a dotted-underline text link rather than a third
+          {/* Details as a dotted-underline text link rather than a second
               button: expanding is the quiet, reversible move and should not
-              carry the weight of the two that open positions. Still a real
+              carry the weight of the one that opens a position. Still a real
               <button> — it owns aria-expanded and must stay keyboard- and
               screen-reader-addressable; only its chrome is gone. */}
           <button
@@ -672,14 +667,10 @@ const OpportunityCard = memo(function OpportunityCard({
           >
             {open ? 'Hide details' : 'More details'}
           </button>
-          {/* ml-auto so it stays pinned right when the row wraps on a phone and
-              Details is alone on the line above. nowrap keeps the phrase whole:
-              it is one instruction, and breaking after "then" reads as two.
-              Hedging before the spread is locked leaves you holding naked perp
-              exposure. */}
-          <span className="ml-auto whitespace-nowrap text-[10px] text-ink-500">
-            lock the rate first, then hedge
-          </span>
+          {/* The "lock the rate first, then hedge" caption that sat here is
+              gone with the two buttons it captioned: one CTA now opens the
+              whole strategy, and the wizard states that order as numbered
+              steps instead of a 10px footnote nobody had to read. */}
         </div>
 
         {open && (
@@ -910,49 +901,38 @@ export function OpportunitiesPanel({ unconfigured = false }: { unconfigured?: bo
 
   // Stable identity, or every card re-renders on each keystroke and the memo
   // above buys nothing.
-  const execute = useCallback(
-    (pair: OpportunityPair, sizeBase?: number) =>
-      flow?.prefillPair({
+  //
+  // Venues travel twice because the two halves are addressed differently:
+  // the Boros legs by their OWN venue keys (`longLeg.venue`), the perps by
+  // the CrossEx ones — a card's Boros leg and its perp leg sit at the same
+  // venue but under different keys, and crossing the two would arm tickets
+  // with markets that do not exist.
+  const openStrategy = useCallback(
+    (pair: OpportunityPair, maturitySec: number, sizeBase?: number) => {
+      // First run: there are no keys to execute with, so opening a two-step
+      // execution wizard would dead-end. Ask for setup instead — the guide
+      // answers by flashing the API-key form, the one step between this click
+      // and a wizard that can actually trade.
+      if (unconfigured) return flow?.requestSetup();
+      return flow?.openWizard({
         base: pair.base,
-        longVenue: pair.longLeg.crossexVenue,
-        shortVenue: pair.shortLeg.crossexVenue,
-        notionalUsd: pricedNotionalUsd,
-        // Present only for token-margined cohorts, where the collateral IS the
-        // base coin and the perp can be sized in the same unit as the Boros leg.
-        ...(sizeBase !== undefined && sizeBase > 0
-          ? { sizeUnit: 'base' as const, sizeBase }
-          : {}),
-        mode: entryMode === 'maker-hedge' ? 'maker' : 'market',
-      }),
-    [flow, pricedNotionalUsd, entryMode],
-  );
-
-  /**
-   * The other half of the trade this card describes.
-   *
-   * The Boros legs are named by their OWN venues (`longLeg.venue`), not the
-   * CrossEx ones the perps use — a card's Boros leg and its perp leg sit at
-   * the same venue but are addressed differently, and crossing the two would
-   * arm the ticket with markets that do not exist.
-   *
-   * Size travels as USD only: a card is priced at a USD notional and holds no
-   * base-coin quantity, so the ticket uses this figure on USD-collateral
-   * markets and leaves the field empty rather than inventing a conversion.
-   */
-  const executeBoros = useCallback(
-    (pair: OpportunityPair, maturitySec?: number) =>
-      flow?.prefillBorosOpen({
-        base: pair.base,
-        longVenue: pair.longLeg.venue,
-        shortVenue: pair.shortLeg.venue,
-        maturity: maturitySec,
+        borosLongVenue: pair.longLeg.venue,
+        borosShortVenue: pair.shortLeg.venue,
         // ⚠ Without this a venue+base match takes whichever maturity comes
         // first, so the two legs can land on DIFFERENT expiries — and since
         // each leg filters the other by maturity, both then vanish from their
         // own dropdowns and the ticket looks empty and broken.
-        size: pricedNotionalUsd,
-      }),
-    [flow, pricedNotionalUsd],
+        maturity: maturitySec,
+        crossexLongVenue: pair.longLeg.crossexVenue,
+        crossexShortVenue: pair.shortLeg.crossexVenue,
+        notionalUsd: pricedNotionalUsd,
+        // Present only for token-margined cohorts, where the collateral IS the
+        // base coin and every leg can be sized in the same unit.
+        ...(sizeBase !== undefined && sizeBase > 0 ? { sizeBase } : {}),
+        perpMode: entryMode === 'maker-hedge' ? 'maker' : 'market',
+      });
+    },
+    [flow, pricedNotionalUsd, entryMode, unconfigured],
   );
 
   const summary = assumptionsOpen
@@ -1197,8 +1177,7 @@ export function OpportunitiesPanel({ unconfigured = false }: { unconfigured?: bo
               group={row.group}
               pair={row.pair}
               notionalUsd={pricedNotionalUsd}
-              onExecute={flow ? execute : null}
-              onExecuteBoros={flow ? executeBoros : null}
+              onOpenStrategy={flow ? openStrategy : null}
               unconfigured={unconfigured}
             />
           ))}

--- a/web/src/panels/PerpLegExpanded.tsx
+++ b/web/src/panels/PerpLegExpanded.tsx
@@ -17,6 +17,7 @@ import { useTradeFlowOptional } from '../trade/TradeFlow';
 export function PositionRowActions({
   position,
   attributedQty,
+  hedgedSibling,
   onClosed,
   closeOnly = false,
   levOnly = false,
@@ -24,6 +25,8 @@ export function PositionRowActions({
   position: CrossexPosition;
   /** Size the strategy showing this row owns, when the venue leg is shared. */
   attributedQty?: number;
+  /** The leg this one hedges — closing this one leaves that one naked. */
+  hedgedSibling?: { venue: string; side: 'LONG' | 'SHORT' } | null;
   /** How much came off the venue, so the card can shrink a stated claim by it
    * — see ClosePopover's note on what "closed" means here. */
   onClosed?: (qty: number) => void;
@@ -92,6 +95,7 @@ export function PositionRowActions({
         <ClosePopover
           position={position}
           attributedQty={attributedQty}
+          hedgedSibling={hedgedSibling}
           onClosed={onClosed}
           onDismiss={() => setOpen(null)}
         />
@@ -104,6 +108,7 @@ export function PositionRowActions({
 export function PerpLegExpanded({
   position,
   attributedQty,
+  hedgedSibling,
   share = 1,
   levOnly = false,
   entryOverride = null,
@@ -111,6 +116,8 @@ export function PerpLegExpanded({
 }: {
   position: CrossexPosition | null;
   attributedQty?: number;
+  /** The leg this one hedges — see ClosePopover. */
+  hedgedSibling?: { venue: string; side: 'LONG' | 'SHORT' } | null;
   /** Hide [Close] here because the caller's collapsed row already has one.
    * Opt-in per call site, NOT the default: `PerpOnlyBox` has no per-row close
    * column — only a card-level [Close both] — so defaulting this on would
@@ -172,7 +179,12 @@ export function PerpLegExpanded({
           {fmtPct(position.upnlRate)}
         </span>
       </span>
-      <PositionRowActions position={position} attributedQty={attributedQty} levOnly={levOnly} />
+      <PositionRowActions
+        position={position}
+        attributedQty={attributedQty}
+        hedgedSibling={hedgedSibling}
+        levOnly={levOnly}
+      />
     </span>
   );
 }

--- a/web/src/panels/PerpOnlyBox.tsx
+++ b/web/src/panels/PerpOnlyBox.tsx
@@ -1,10 +1,20 @@
 /**
- * An incomplete 4-leg position box: a delta-neutral perp pair (or a stray
- * single leg) with NO Boros legs for its base. Absorbs the old ArbExposurePanel
- * row (LegChips, ExposureBadge, Close both) into the box form, and adds the
- * cue that completes the position:
+ * The DEGRADED view of an incomplete 4-leg position: a delta-neutral perp pair
+ * (or a stray single leg) whose base has no rollup in the strategy feed.
+ *
+ * ⚠ This is not the normal home for a Boros-less pair. The solver emits a
+ * `BASE#perps` rollup for pairless perps (returns.ts), so with a healthy feed
+ * such a pair renders as a full StrategyCard — with its projection, its cost
+ * controls and its in-app "Open the Boros legs →". This box is what remains
+ * when we cannot say that much: no address tracked, the feed pending or
+ * failed, or a partition that did not reconcile. A trading terminal must not
+ * hide live positions behind a dead Boros backend.
+ *
+ * It therefore mirrors StrategyCard's HEADER grammar (asset badge · venue pair
+ * · status, actions right) so the same position is recognisably the same
+ * object across both, while carrying only claims this path can support:
  *   - no tracked address        → inline AddressForm ("lock this rate on Boros")
- *   - address + settled feed    → "execute the fixed legs on Boros ↗" link-out
+ *   - address + settled feed    → the two feeds disagree; say so, claim nothing
  *   - strategy feed pending/err → neutral note, never a false "no Boros" claim
  */
 import { useMemo, useState } from 'react';
@@ -25,19 +35,6 @@ import { PerpLegExpanded } from './PerpLegExpanded';
 
 /** Which completion cue the box shows (decided by PositionsHome). */
 export type PerpOnlyCue = 'add-address' | 'execute-boros' | 'boros-pending' | null;
-
-/** One leg = "+BINANCE $9,387" (green) / "−HYPERLIQUID $9,389" (red), with a
- * small quote sub-label when the venue doesn't quote USDT. */
-function LegChip({ leg }: { leg: ExposureLeg }) {
-  const long = leg.side === 'LONG';
-  return (
-    <Chip sm tone={long ? 'green' : 'red'} className="num" title={leg.symbol}>
-      {long ? '+' : '−'}
-      {leg.exchange} {fmtUsd(leg.value, 0)}
-      {leg.quote !== 'USDT' && <span className="text-[9px] opacity-70">{leg.quote}</span>}
-    </Chip>
-  );
-}
 
 /** [Close both] — two close-position actions sharing a pairGroupId, executed
  * inline (hold-to-confirm). Renders nothing without the trade context (unit
@@ -128,25 +125,64 @@ export function PerpOnlyBox({
     },
   ];
 
+  // Venue pair for the header, in StrategyCard's order: long side first. A
+  // stray has one side only, and `⇄` is then omitted rather than pointing at
+  // nothing.
+  const longVenue = group.legs.find((l) => l.side === 'LONG')?.exchange ?? null;
+  const shortVenue = group.legs.find((l) => l.side === 'SHORT')?.exchange ?? null;
+
   return (
     <div className="card p-4">
+      {/* Identity in StrategyCard's grammar — WHAT · WHERE — so the same coin
+          is the same object whether or not its Boros legs were matched. This
+          box used to lead with a bare mono base and a row of green/red value
+          chips (the ArbExposurePanel row it grew out of): a second visual
+          language for a position that differs from a card only by what the
+          feed could tell us about it. There is no maturity here, and that
+          absence IS the position's defining fact — no rate is locked — so the
+          slot the card gives maturity is given to the status chip instead. */}
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="font-mono text-sm font-semibold text-ink-100">{group.base}</span>
-          <span className="inline-flex flex-wrap gap-1.5">
-            {group.legs.map((l) => (
-              <LegChip key={l.symbol} leg={l} />
-            ))}
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span
+            className="num flex h-6 w-6 items-center justify-center rounded-md border border-ink-700 bg-ink-800 text-[9px] font-semibold leading-none text-ink-300"
+            title={`${group.base} perp legs`}
+          >
+            {group.base}
           </span>
-          <span className="num text-xs text-ink-500">
-            net <SignedNumber value={group.netValue} format={(n) => fmtUsd(n, 0)} /> · gross{' '}
-            {fmtUsd(group.grossValue, 0)}
-          </span>
+          {(longVenue || shortVenue) && (
+            <>
+              <span className="text-ink-600">·</span>
+              <span className="text-sm font-medium text-ink-200">
+                {prettyVenue(longVenue ?? shortVenue ?? '')}
+                {longVenue && shortVenue && (
+                  <>
+                    <span className="mx-1 font-normal text-ink-500">⇄</span>
+                    {prettyVenue(shortVenue)}
+                  </>
+                )}
+              </span>
+            </>
+          )}
+          <span className="text-ink-600">·</span>
+          <span className="text-xs text-ink-300">no rate locked</span>
+          {stray ? (
+            <Chip sm tone="red">unpaired leg</Chip>
+          ) : (
+            <ExposureBadge group={group} />
+          )}
         </div>
-        <span className="inline-flex items-center gap-2">
-          {stray && <Chip sm tone="red">unpaired leg</Chip>}
-          <ExposureBadge group={group} />
-        </span>
+        {/* Right rail = ACTIONS, matching StrategyCard. `Close both` lived
+            alone at the bottom of the box, the one action on the page that
+            was not where every other card keeps its actions. */}
+        {!stray && (
+          <div className="flex items-center gap-2">
+            <CloseBoth base={group.base} legs={group.legs} />
+          </div>
+        )}
+      </div>
+      <div className="num mt-1 text-xs text-ink-500">
+        net <SignedNumber value={group.netValue} format={(n) => fmtUsd(n, 0)} /> · gross{' '}
+        {fmtUsd(group.grossValue, 0)}
       </div>
 
       {/* Completion cue. */}
@@ -173,17 +209,26 @@ export function PerpOnlyBox({
         </div>
       )}
       {cue === 'execute-boros' && (
+        /**
+         * A settled feed that returned NOTHING for a coin holding live perps —
+         * including no `BASE#perps` position, which the solver emits for
+         * exactly this shape. So the two feeds disagree, and the honest thing
+         * is to say so rather than to act certain.
+         *
+         * This used to be a link-out to boros.finance ("Execute the fixed legs
+         * on Boros ↗"), from the era before the terminal could open Boros legs
+         * itself. Two reasons it is gone rather than rewired to the wizard: it
+         * sent the user out of the app to size a hedge by hand that the app now
+         * sizes for them, and this box is the DEGRADED path — when the feed is
+         * healthy the position renders as a StrategyCard, which already offers
+         * "Open the Boros legs →". Putting a second, competing entry point here
+         * would arm a trade off a book we just said we cannot read.
+         */
         <div className="mt-2 text-xs text-ink-400">
           No Boros position found for {group.base}
-          {address ? ` on ${short(address)}` : ''} — this pair's funding rate is NOT locked.{' '}
-          <a
-            href="https://boros.finance"
-            target="_blank"
-            rel="noreferrer"
-            className="text-cyan-400 hover:text-cyan-300"
-          >
-            Execute the fixed legs on Boros ↗
-          </a>
+          {address ? ` on ${short(address)}` : ''} — this pair's funding rate is NOT locked. If you
+          hold Boros legs for it, the strategy feed and the positions feed disagree; reload, and
+          check the address is the one holding them.
         </div>
       )}
       {cue === 'boros-pending' && (
@@ -200,12 +245,6 @@ export function PerpOnlyBox({
           )}
         />
       </div>
-
-      {!stray && (
-        <div className="mt-2 flex justify-end">
-          <CloseBoth base={group.base} legs={group.legs} />
-        </div>
-      )}
     </div>
   );
 }
@@ -230,12 +269,29 @@ export function ClosePairForm({
 }) {
   const flow = useTradeFlowOptional();
   const pairGroupId = useMemo(() => uuid(), []);
-  const actions: ActionInput[] =
-    legs.length === 2
-      ? legs.map((l) => ({ kind: 'close-position' as const, symbol: l.symbol, pairGroupId }))
-      : [];
+  /**
+   * The same control the single-leg close offers.
+   *
+   * Without it this path sent no `slippagePct` at all and silently took the
+   * 0.5% default — the setting was not "respected" because it could not be
+   * expressed. Validated on the same (0,10] band the server enforces.
+   */
+  const [slipStr, setSlipStr] = useState('0.5');
+  const slip = Number(slipStr);
+  const slipInvalid = !Number.isFinite(slip) || slip <= 0 || slip > 10;
+  // null, not [] — ExecuteControl disables on `!actions`, and an empty array
+  // is truthy, so [] would leave the button live with nothing to send.
+  const actions: ActionInput[] | null =
+    legs.length === 2 && !slipInvalid
+      ? legs.map((l) => ({
+          kind: 'close-position' as const,
+          symbol: l.symbol,
+          pairGroupId,
+          slippagePct: slip,
+        }))
+      : null;
   // Not lazy: the dialog exists to show this, so it loads with the form.
-  const preview = usePreviewDebounced(`close-pair-${base}`, actions.length ? actions : null, {
+  const preview = usePreviewDebounced(`close-pair-${base}`, actions, {
     refetchInterval: 5000,
   });
   if (!flow || legs.length !== 2) return null;
@@ -252,8 +308,33 @@ export function ClosePairForm({
           const live = livePositions?.get(legs[i]?.symbol ?? '');
           return live ? Number(live.upnl) : null;
         }}
-        note="The close is sent as a reduce-only IOC limit at mark ± slippage — it can never increase the position and never rests on the book."
+        /**
+         * ⚠ Accurate for a PAIR, which is not what the single-leg note says.
+         *
+         * Only the first leg carries the mark ± slippage band; the hedge leg
+         * is sent as a plain MARKET IOC on purpose, because a book-mid limit
+         * band cannot reliably stay inside the venue's OWN price-limit band
+         * and gets rejected — which would leave the first leg closed and the
+         * second still open (see decide.ts). Claiming the band covers both
+         * would promise protection the hedge leg does not have.
+         */
+        note="The first leg is a reduce-only IOC limit at mark ± slippage; the hedge leg is sent at market, inside the venue's own price band. Neither can increase a position or rest on the book."
       />
+      <div className="flex items-center gap-2 text-xs">
+        <label htmlFor={`close-pair-slip-${base}`} className="w-24 text-ink-400">
+          Slippage %
+        </label>
+        <input
+          id={`close-pair-slip-${base}`}
+          className={`input num h-8 flex-1 px-2 py-1 ${slipInvalid ? 'border-rose-500' : ''}`}
+          inputMode="decimal"
+          value={slipStr}
+          onChange={(e) => setSlipStr(e.target.value)}
+        />
+      </div>
+      {slipInvalid && (
+        <span className="text-xs text-rose-400">slippage must be in (0, 10]</span>
+      )}
       <ExecuteControl
         scope={`close-both-${base}`}
         actions={actions}

--- a/web/src/panels/PerpOnlyBox.tsx
+++ b/web/src/panels/PerpOnlyBox.tsx
@@ -342,7 +342,13 @@ export function ClosePairForm({
         label="Close both ▸"
         // See CloseBoth: the per-mount pairGroupId would otherwise change the
         // intent identity on every remount and break idempotent recovery.
-        intentKey={['closeBoth', ...legs.map((l) => `${l.symbol}:${l.qty}`)].join('|')}
+        // ⚠ `slip` is part of the intent — it rides the wire as `slippagePct`
+        // and sets the close's price band. Without it here, a lost-response
+        // confirm followed by a slippage edit produced a byte-identical key,
+        // so the persisted deal id was resent and the server deduped it into
+        // the ORIGINAL band while the form showed the new one — the same bug
+        // class PairTicket's intentKey fixes by carrying `sizeUnit`.
+        intentKey={['closeBoth', String(slip), ...legs.map((l) => `${l.symbol}:${l.qty}`)].join('|')}
         buttonClassName="w-full"
         // The panel above already reviews this close; the hover card would
         // repeat it on top of the dialog. Errors still surface.

--- a/web/src/panels/PositionsHome.test.tsx
+++ b/web/src/panels/PositionsHome.test.tsx
@@ -6,7 +6,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it, vi } from 'vitest';
-import type { ActionInput, PositionsResponse, StrategyReturns } from '../api/types';
+import type { ActionInput, PositionsResponse, StrategyReturns, StrategyRollup } from '../api/types';
 import {
   makeCrossexPosition,
   makeExposureGroup,
@@ -21,6 +21,7 @@ import { renderWithClient } from '../test/utils';
 import { bookIdOf } from './bookId';
 import { STRATEGY_STORAGE_KEY } from './HomeControls';
 import { PositionsHome } from './PositionsHome';
+import { StrategyWizard } from '../trade/StrategyWizard';
 import { SettingsDrawer } from './SettingsDrawer';
 import { TrackedAddressProvider } from './trackedAddress';
 import { TradeFlowProvider, useTradeFlow } from '../trade/TradeFlow';
@@ -223,7 +224,7 @@ describe('PositionsHome — degraded states', () => {
 });
 
 describe('PositionsHome — box taxonomy & cues', () => {
-  it('without an address: perp pairs render as boxes with the add-address cue and ZERO strategy calls', async () => {
+  it('without an address: a pair renders as a full card, a stray as a box, and ZERO strategy calls', async () => {
     const requested: string[] = [];
     mockPositions({
       exposure: [
@@ -240,9 +241,16 @@ describe('PositionsHome — box taxonomy & cues', () => {
     renderWithClient(<PositionsHome />);
 
     expect(await screen.findByText('ETH')).toBeInTheDocument();
-    // Pair box: neutral badge + add-address cue; stray box: unpaired-leg chip.
-    expect(screen.getByText('neutral ✓')).toBeInTheDocument();
+    // The PAIR gets the same card a tracked position gets — a position must
+    // not change visual language because of an input not supplied yet.
+    expect(screen.getByText(/Track a Boros address to see whether these perps/)).toBeInTheDocument();
+    // ⚠ And it must claim NOTHING about Boros legs it never looked for.
+    expect(screen.queryByText(/No Boros legs yet/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Open the Boros legs/ })).not.toBeInTheDocument();
+    expect(screen.queryByText('missing')).not.toBeInTheDocument();
+    // The stray keeps the simpler box: one leg, so there is no pair to show.
     expect(screen.getByText('unpaired leg')).toBeInTheDocument();
+    // The one action that can change what we know.
     expect(screen.getAllByRole('button', { name: 'Add Boros address' }).length).toBeGreaterThan(0);
     expect(requested).toHaveLength(0);
   });
@@ -260,7 +268,16 @@ describe('PositionsHome — box taxonomy & cues', () => {
     expect(JSON.parse(localStorage.getItem(STRATEGY_STORAGE_KEY)!).address).toBe(ADDR);
   });
 
-  it('with a settled feed: a perp-only box carries the execute-on-Boros link-out', async () => {
+  it('with a settled feed that skipped a live coin: reports the disagreement, offers no trade', async () => {
+    // A successful feed returning NOTHING for a coin holding live perps — not
+    // even the `BASE#perps` rollup the solver emits for exactly this shape. So
+    // the two feeds disagree, and this box says so.
+    //
+    // It deliberately does NOT offer a way to open Boros legs here. It used to
+    // link out to boros.finance; when the feed is healthy this pair renders as
+    // a StrategyCard which already has the in-app CTA, so a second entry point
+    // on the degraded path would arm a trade off a book we just said we cannot
+    // read.
     localStorage.setItem(STRATEGY_STORAGE_KEY, JSON.stringify({ address: ADDR }));
     mockPositions({ exposure: [makeExposureGroup({ base: 'ETH' })] });
     mockStrategy(makeStrategyReturns()); // HYPE strategy — ETH stays perp-only
@@ -268,8 +285,9 @@ describe('PositionsHome — box taxonomy & cues', () => {
 
     expect(await screen.findByText('hedged ✓')).toBeInTheDocument();
     expect(screen.getByText(/No Boros position found for ETH/)).toBeInTheDocument();
-    const link = screen.getByRole('link', { name: /Execute the fixed legs on Boros/ });
-    expect(link).toHaveAttribute('href', 'https://boros.finance');
+    expect(screen.getByText(/the strategy feed and the positions feed disagree/)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Boros/ })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Execute the fixed legs/)).not.toBeInTheDocument();
   });
 
   it('a rollup base consumes its exposure group (no duplicate perp-only box)', async () => {
@@ -292,7 +310,19 @@ describe('PositionsHome — box taxonomy & cues', () => {
     expect(screen.queryByText(/No Boros position found for HYPE/)).not.toBeInTheDocument();
   });
 
-  it('ports the exposure chips: signed venue chips with quote sub-labels + Close both', async () => {
+  it('heads the degraded box in StrategyCard grammar: asset badge, venue pair, Close both', async () => {
+    // A FAILED feed (not merely untracked) is what keeps the box: an untracked
+    // pair now renders as a full card, so this fixture tracks an address and
+    // fails the strategy call.
+    localStorage.setItem(STRATEGY_STORAGE_KEY, JSON.stringify({ address: ADDR }));
+    server.use(
+      http.get('/api/strategy/:address', () =>
+        HttpResponse.json(
+          { ok: false, error: { category: 'unknown', message: 'down', retryable: true } },
+          { status: 503 },
+        ),
+      ),
+    );
     mockPositions({
       exposure: [
         makeExposureGroup({
@@ -309,9 +339,18 @@ describe('PositionsHome — box taxonomy & cues', () => {
       ],
     });
     renderWithClient(<PositionsHome />);
-    expect(await screen.findByText(/\+KRAKEN \$9,387/)).toBeInTheDocument();
-    expect(screen.getByText(/−HYPERLIQUID \$9,389/)).toBeInTheDocument();
+
+    // The header now reads like a StrategyCard's: asset badge, then the venue
+    // pair as ONE unit (long side first), not a row of signed value chips.
+    // The per-leg values live in the table below, where the card keeps them.
+    expect(await screen.findByTitle('BTC perp legs')).toHaveTextContent('BTC');
+    const header = screen.getByTitle('BTC perp legs').parentElement!;
+    expect(header).toHaveTextContent('Kraken');
+    expect(header).toHaveTextContent('Hyperliquid');
+    // The defining fact of this box, in the slot a card gives maturity.
+    expect(header).toHaveTextContent('no rate locked');
     expect(screen.getByText('neutral ✓')).toBeInTheDocument();
+    expect(screen.getByText(/net.*gross/)).toBeInTheDocument();
     // renderWithClient mounts TradeFlowProvider → the hold-button renders.
     expect(screen.getByRole('button', { name: 'Close both' })).toBeInTheDocument();
   });
@@ -1498,5 +1537,121 @@ describe('PositionsHome — Automatic forgets only this card', () => {
     // would mean the whole leg went back to the solver, which is the bug.
     await waitFor(() => expect(urls.length).toBeGreaterThan(1));
     expect(urls[urls.length - 1]).toContain('partition=');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "Open the perp legs" → the wizard, at the hedge step
+// ---------------------------------------------------------------------------
+
+describe('PositionsHome — resuming a half-open position', () => {
+  /** A rate-locked position with NO perp legs — what the resume cue fires on. */
+  const borosOnly = (over: Partial<StrategyRollup> = {}) =>
+    makeStrategyRollup({
+      strategyId: 'HYPE@boros-only',
+      legs: makeStrategyRollup().legs.filter((l) => l.kind === 'boros'),
+      hedgeChecks: { borosMatchRatio: 1, perpMatchRatio: 0, borosVsPerpRatio: 0, fullyHedged: false },
+      ...over,
+    });
+
+  /** App mounts the wizard beside the panel; these tests need the same pair. */
+  const mountHome = () =>
+    renderWithClient(
+      <>
+        <PositionsHome />
+        <StrategyWizard />
+      </>,
+    );
+
+  const openCue = async () => {
+    const cta = await screen.findByRole('button', { name: /Open the perp legs/ });
+    await userEvent.click(cta);
+  };
+
+  it('opens the WIZARD at step 2 — not the bare ticket', async () => {
+    localStorage.setItem(STRATEGY_STORAGE_KEY, JSON.stringify({ address: ADDR }));
+    mockPositions();
+    mockStrategy(makeStrategyReturns({ strategies: [borosOnly()] }));
+    mountHome();
+    await openCue();
+
+    // The wizard's own framing: it is FINISHING, not opening, and step 1 is
+    // already checked off.
+    expect(await screen.findByText('Finish this strategy')).toBeInTheDocument();
+    expect(screen.getByText('Lock the rate')).toBeInTheDocument();
+    expect(screen.getByText('Hedge the perps')).toBeInTheDocument();
+    // The Boros ticket is NOT mounted — those legs already exist.
+    expect(screen.queryByRole('radiogroup', { name: 'Boros ticket mode' })).not.toBeInTheDocument();
+  });
+
+  it('leaving without hedging warns — the rate is on and naked', async () => {
+    /**
+     * The guard used to test only whether THIS wizard had locked a rate, so a
+     * resume (which arrives with one already locked) closed silently — the one
+     * case where the exposure is guaranteed to exist.
+     */
+    localStorage.setItem(STRATEGY_STORAGE_KEY, JSON.stringify({ address: ADDR }));
+    mockPositions();
+    mockStrategy(makeStrategyReturns({ strategies: [borosOnly()] }));
+    mountHome();
+    await openCue();
+    await screen.findByText('Finish this strategy');
+
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(await screen.findByText(/until the perp legs open you hold directional exposure/)).toBeInTheDocument();
+  });
+
+  it('an UNEVEN book sizes the hedge off the larger Boros side, never the sum', async () => {
+    /**
+     * ⚠ The mis-hedge this guards: summing the two sides would arm the perps
+     * at double the exposure. A lopsided book must still hedge the side that
+     * actually carries risk.
+     */
+    localStorage.setItem(STRATEGY_STORAGE_KEY, JSON.stringify({ address: ADDR }));
+    mockPositions();
+    const legs = makeStrategyRollup().legs.filter((l) => l.kind === 'boros');
+    const uneven = legs.map((l, i) =>
+      i === 0 ? { ...l, notionalUsd: 40_000, notionalToken: 400 } : { ...l, notionalUsd: 10_000, notionalToken: 100 },
+    );
+    mockStrategy(makeStrategyReturns({ strategies: [borosOnly({ legs: uneven })] }));
+    mountHome();
+    await openCue();
+
+    // The perp box lands on the LARGER side (40,000), not 50,000.
+    const size = (await screen.findByLabelText(/Size per leg/)) as HTMLInputElement;
+    expect(size.value).toBe('40000');
+  });
+
+  it('a PARTIAL top-up stays on the bare ticket — no wizard', async () => {
+    /**
+     * "Complete the hedge" evens up one leg inside a position that already
+     * exists. Wrapping that in "step 2 of 2" would narrate a strategy the user
+     * is not opening — and the wizard would re-arm at the FULL size, not the
+     * gap.
+     */
+    localStorage.setItem(STRATEGY_STORAGE_KEY, JSON.stringify({ address: ADDR }));
+    mockPositions();
+    // A partially hedged book: both kinds present, sizes mismatched.
+    const all = makeStrategyRollup().legs;
+    const partial = all.map((l) =>
+      l.kind === 'perp' ? { ...l, notionalUsd: l.notionalUsd / 4, notionalToken: (l.notionalToken ?? 0) / 4 } : l,
+    );
+    mockStrategy(
+      makeStrategyReturns({
+        strategies: [
+          makeStrategyRollup({
+            legs: partial,
+            hedgeChecks: { borosMatchRatio: 1, perpMatchRatio: 0.25, borosVsPerpRatio: 0.25, fullyHedged: false },
+          }),
+        ],
+      }),
+    );
+    mountHome();
+
+    const cta = await screen.findByRole('button', { name: /Complete the hedge/ });
+    await userEvent.click(cta);
+    // No wizard framing anywhere.
+    expect(screen.queryByText('Finish this strategy')).not.toBeInTheDocument();
+    expect(screen.queryByText('Open this strategy')).not.toBeInTheDocument();
   });
 });

--- a/web/src/panels/PositionsHome.tsx
+++ b/web/src/panels/PositionsHome.tsx
@@ -27,7 +27,7 @@ import {
   type EntryOverride,
 } from './entryOverrideStore';
 import { AddressForm, short, StrategyFreshness, TotalsStrip } from './HomeControls';
-import { buildBoxes } from './homeBoxes';
+import { buildBoxes, rollupFromExposure } from './homeBoxes';
 import { useTrackedAddress } from './trackedAddress';
 import { PerpOnlyBox, type PerpOnlyCue } from './PerpOnlyBox';
 import { StrategyCard } from './StrategyCard';
@@ -47,7 +47,7 @@ import {
   type LegAssertion,
   type LegDestination,
 } from './PartitionEditor';
-import { crossexVenueFor } from '../lib/boros';
+import { crossexVenueFor, isUsdCollateral } from '../lib/boros';
 
 /** Stable empty list, so a callback's deps don't change every render. */
 const EMPTY_STRATEGIES: StrategyRollup[] = [];
@@ -149,6 +149,29 @@ function destinationsFor(
       borosMaturity: maturities.length ? Math.min(...maturities) : null,
     };
   });
+}
+
+/**
+ * The one action an untracked card can offer: name the address holding the
+ * Boros legs. Lazily reveals the form, exactly as PerpOnlyBox's add-address
+ * cue does — a full input row on every card would shout, and most users have
+ * one address to enter once.
+ */
+function AddBorosAddress({ onTrack }: { onTrack: (address: string) => void }) {
+  const [open, setOpen] = useState(false);
+  if (!open) {
+    return (
+      <>
+        <button type="button" className="btn-primary !py-1 !px-3 text-sm" onClick={() => setOpen(true)}>
+          Add Boros address
+        </button>
+        <span className="text-xs text-ink-500">
+          to see whether these perps have a locked rate
+        </span>
+      </>
+    );
+  }
+  return <AddressForm submitLabel="Track" onTrack={onTrack} onCancel={() => setOpen(false)} />;
 }
 
 export function PositionsHome() {
@@ -620,7 +643,10 @@ export function PositionsHome() {
        */
       // 0 is the sentinel for "no Boros legs, so no maturity" — and that is
       // exactly the card this cue fires on. Sending it would match no market
-      // at all, so it is omitted and the resolver falls back to venue+base.
+      // at all, so it is omitted; the ticket then resolves the two legs
+      // together, on the soonest maturity BOTH venues list (it used to take
+      // each venue's first row independently, which armed mismatched expiries).
+
       const maturity = s.maturity > 0 ? s.maturity : undefined;
       if (only) {
         // Exactly one venue travels, which is what puts the ticket in Single
@@ -662,7 +688,7 @@ export function PositionsHome() {
        * figure, which is the unit their Boros leg already uses.
        */
       const collateral = borosLegs.find((l) => l.collateral)?.collateral ?? '';
-      const usdPegged = collateral === 'USDT' || collateral === 'USDC';
+      const usdPegged = isUsdCollateral(collateral);
       // Only meaningful when the collateral IS the base coin — that is the
       // case where the Boros size and the perp quantity are the same number.
       const baseSized = !usdPegged && collateral.toUpperCase() === s.base.toUpperCase();
@@ -671,17 +697,56 @@ export function PositionsHome() {
           .filter((l) => l.side === side)
           .reduce((sum, l) => sum + (l.notionalToken ?? 0), 0);
       const baseQty = Math.max(sideBase('LONG'), sideBase('SHORT'));
+      const longVenue = borosLegs.find((l) => l.side === 'LONG')?.venue ?? null;
+      const shortVenue = borosLegs.find((l) => l.side === 'SHORT')?.venue ?? null;
+      const size = notionalUsd ?? Math.max(sideNotional('LONG'), sideNotional('SHORT'));
+      // ⚠ Only when the caller did NOT name its own USD size. A row asking
+      // for a partial top-up passes that figure, and the FULL base quantity
+      // would silently overrule it with a bigger order than the row offered.
+      const sizing =
+        baseSized && baseQty > 0 && notionalUsd === undefined
+          ? { sizeUnit: 'base' as const, sizeBase: baseQty }
+          : {};
+      /**
+       * A whole-position ask opens the guided wizard AT THE HEDGE STEP; a
+       * partial top-up (`notionalUsd` named by a missing-leg row) stays on the
+       * bare ticket.
+       *
+       * The wizard's job is to say what a complete strategy is and to guard
+       * the half-open state — which is exactly the position this cue fires on:
+       * rate locked, no hedge. A top-up is not that. It is one leg being
+       * evened up inside a position that already exists, so wrapping it in
+       * "step 2 of 2" would narrate a strategy the user is not opening.
+       */
+      if (notionalUsd === undefined) {
+        flow.openWizard({
+          base: s.base,
+          initialStep: 2,
+          // Unused at step 2 (the Boros ticket is never mounted), but they
+          // identify the wizard — the body is keyed on them, so a different
+          // position is a different wizard rather than a form-swap.
+          borosLongVenue: longVenue ?? '',
+          borosShortVenue: shortVenue ?? '',
+          maturity: s.maturity > 0 ? s.maturity : undefined,
+          // ⚠ Boros keys are NOT CrossEx keys. They are identity for every
+          // venue mapped today, which is exactly why omitting the translation
+          // looks correct — but Lighter is live on Boros with no CrossEx
+          // listing, and passing its raw key would arm a ticket for a venue
+          // that cannot fill it. `crossexVenueFor` returns null there, which
+          // correctly leaves the leg unselected.
+          crossexLongVenue: crossexVenueFor(longVenue),
+          crossexShortVenue: crossexVenueFor(shortVenue),
+          notionalUsd: size,
+          ...sizing,
+        });
+        return;
+      }
       flow.prefillPair({
         base: s.base,
-        longVenue: borosLegs.find((l) => l.side === 'LONG')?.venue ?? null,
-        shortVenue: borosLegs.find((l) => l.side === 'SHORT')?.venue ?? null,
-        notionalUsd: notionalUsd ?? Math.max(sideNotional('LONG'), sideNotional('SHORT')),
-        // ⚠ Only when the caller did NOT name its own USD size. A row asking
-        // for a partial top-up passes that figure, and the FULL base quantity
-        // would silently overrule it with a bigger order than the row offered.
-        ...(baseSized && baseQty > 0 && notionalUsd === undefined
-          ? { sizeUnit: 'base' as const, sizeBase: baseQty }
-          : {}),
+        longVenue,
+        shortVenue,
+        notionalUsd: size,
+        ...sizing,
       });
     });
 
@@ -821,7 +886,7 @@ export function PositionsHome() {
           <EmptyState
             icon="◎"
             title="No positions"
-            hint={`No perp positions in the connected account and no Boros positions on ${short(address)} (accountId 0). Open a delta-neutral pair from the order ticket to start a 4-leg position.`}
+            hint={`No perp positions in the connected account and no Boros positions on ${short(address)} (accountId 0). Pick a pair on the Opportunities tab and open it — the guided flow locks the rate, then hedges it.`}
           />
         )
       ) : (
@@ -855,6 +920,31 @@ export function PositionsHome() {
                     ? (leg) => overrideFor(entryRows, box.rollup.strategyId, leg)
                     : undefined
                 }
+              />
+            ) : /**
+             * No address tracked, and this is a real pair: render the SAME
+             * card as a tracked position. A position should not change visual
+             * language because of an input the user has not supplied yet — the
+             * only honest difference is that we cannot speak about its Boros
+             * legs, which `borosUnknown` enforces.
+             *
+             * The other degraded cases keep the simpler box: a stray is a
+             * single leg (no pair to show), and a FAILED or pending feed is
+             * not the same claim as an untracked one — there the card would
+             * have to explain a backend fault, which is what PerpOnlyBox's
+             * cues already do.
+             */
+            perpOnlyCue === 'add-address' && box.kind === 'perp-only' ? (
+              <StrategyCard
+                key={`untracked:${box.group.base}`}
+                bookId={bookId}
+                strategy={rollupFromExposure(box.group)}
+                perpSource={strategyData?.perpSource ?? null}
+                since={since}
+                onChangeSince={changeSince}
+                livePositions={livePositions}
+                borosUnknown
+                borosUnknownCta={<AddBorosAddress onTrack={track} />}
               />
             ) : (
               <PerpOnlyBox

--- a/web/src/panels/SharePositionModal.test.tsx
+++ b/web/src/panels/SharePositionModal.test.tsx
@@ -75,18 +75,18 @@ describe('SharePositionModal', () => {
     expect(screen.queryByRole('button', { name: 'Copy image' })).not.toBeInTheDocument();
   });
 
-  it('shows a link that decodes back to the exact payload', () => {
+  it('shows a link that decodes back to the exact payload', async () => {
     mount();
-    const input = screen.getByLabelText('Position share link') as HTMLInputElement;
+    const input = (await screen.findByLabelText('Position share link')) as HTMLInputElement;
     expect(input.value).toBe(buildShareUrl(payload));
     expect(input.value.startsWith('https://boros.pendle.finance/arbitrage-crossex/position?d=')).toBe(true);
     const d = new URL(input.value).searchParams.get('d') ?? '';
     expect(decodeSharePayload(d)).toEqual({ ok: true, payload });
   });
 
-  it('opens the X intent pre-filled with the tweet text and the link', () => {
+  it('opens the X intent pre-filled with the tweet text and the link', async () => {
     mount();
-    const x = screen.getByRole('link', { name: 'Share on X →' });
+    const x = await screen.findByRole('link', { name: 'Share on X →' });
     const href = x.getAttribute('href') ?? '';
     expect(href.startsWith('https://x.com/intent/post?text=')).toBe(true);
     const u = new URL(href);
@@ -100,7 +100,7 @@ describe('SharePositionModal', () => {
     const writeText = vi.fn(async () => {});
     vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } });
     mount();
-    await userEvent.click(screen.getByRole('button', { name: 'Copy link' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Copy link' }));
     expect(writeText).toHaveBeenCalledWith(buildShareUrl(payload));
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Link copied'));
   });
@@ -127,7 +127,7 @@ describe('SharePositionModal', () => {
     // The payload is byte-identical to the address-less one, so the public
     // link never carries the wallet.
     expect(bodies[0].d).toBe(encodeSharePayload(payload));
-    const input = screen.getByLabelText('Position share link') as HTMLInputElement;
+    const input = (await screen.findByLabelText('Position share link')) as HTMLInputElement;
     await waitFor(() => expect(input.value).toBe(buildShortShareUrl('Abc123_-xyz')));
     expect(input.value).not.toContain(TRACKED.toLowerCase());
     expect(input.value).not.toContain(TRACKED);
@@ -146,21 +146,26 @@ describe('SharePositionModal', () => {
     expect(Object.keys(bodies[0])).toEqual(['d']);
   });
 
-  it('upgrades the link (and the X intent) to the short URL once the backend mints a code', async () => {
+  it('shows the SHORT url first time — never the long one, then a swap', async () => {
+    /**
+     * The field used to render the long URL immediately and visibly flip to
+     * the short one a moment later. That reads as a glitch, and it puts a
+     * second URL under a selection the user may already be dragging. The field
+     * now holds for a short grace window, so the first link they see is final.
+     */
     server.use(shareLinkMints('Abc123_-xyz'));
     mount();
-    const input = screen.getByLabelText('Position share link') as HTMLInputElement;
-    // The long link is usable immediately — the upgrade is a background swap.
-    expect(input.value).toBe(buildShareUrl(payload));
-    await waitFor(() => expect(input.value).toBe(buildShortShareUrl('Abc123_-xyz')));
+    const input = (await screen.findByLabelText('Position share link')) as HTMLInputElement;
     expect(input.value).toBe('https://boros.pendle.finance/arbitrage-crossex/position?s=Abc123_-xyz');
+    // It was never the long URL on the way there.
+    expect(input.value).not.toBe(buildShareUrl(payload));
     const href = screen.getByRole('link', { name: 'Share on X →' }).getAttribute('href') ?? '';
     expect(new URL(href).searchParams.get('url')).toBe(buildShortShareUrl('Abc123_-xyz'));
   });
 
   it('keeps the long URL when the short-link mint fails — sharing never blocks on the backend', async () => {
     mount(); // beforeEach handler: /api/share-link 502s
-    const input = screen.getByLabelText('Position share link') as HTMLInputElement;
+    const input = (await screen.findByLabelText('Position share link')) as HTMLInputElement;
     expect(input.value).toBe(buildShareUrl(payload));
     // Give the rejected request time to settle; the value must not change.
     await waitFor(() => expect(input.value).toBe(buildShareUrl(payload)));
@@ -171,7 +176,7 @@ describe('SharePositionModal', () => {
     vi.mocked(renderShareCard).mockRejectedValueOnce(new Error('no canvas'));
     mount();
     expect(await screen.findByText(/Image generation failed — the link below still works/)).toBeInTheDocument();
-    expect(screen.getByLabelText('Position share link')).toBeInTheDocument();
+    expect(await screen.findByLabelText('Position share link')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Share on X →' })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Download PNG' })).not.toBeInTheDocument();
     expect(screen.queryByAltText('Position share card')).not.toBeInTheDocument();

--- a/web/src/panels/SharePositionModal.tsx
+++ b/web/src/panels/SharePositionModal.tsx
@@ -17,6 +17,13 @@ import { useTrackedAddressOptional } from './trackedAddress';
 const canCopyImage = () =>
   typeof ClipboardItem !== 'undefined' && typeof navigator.clipboard?.write === 'function';
 
+/**
+ * How long the link field waits for the short-code mint before falling back to
+ * the long URL. Long enough for a local round-trip, short enough that a dead
+ * backend costs no perceptible wait.
+ */
+const SHORT_LINK_GRACE_MS = 1_500;
+
 export function SharePositionModal({ payload, onClose }: { payload: SharePayloadV1; onClose: () => void }) {
   const toast = useToast();
   // The tracked address rides ALONGSIDE the payload when the code is minted —
@@ -38,30 +45,62 @@ export function SharePositionModal({ payload, onClose }: { payload: SharePayload
     }
   }, [payload]);
 
-  // Upgrade to a short link in the background: the long URL shows immediately
-  // and stays the silent fallback if the backend is slow, down, or throttled —
-  // sharing never waits on the network.
+  /**
+   * Upgrade to a short link in the background. The long URL remains the silent
+   * fallback if the backend is slow, down, or throttled — sharing never waits
+   * indefinitely on the network.
+   *
+   * ⚠ But it must not be shown and then REPLACED. Rendering the long URL
+   * immediately made the field visibly flip to the short one a moment later,
+   * which reads as a glitch and — worse — puts two different URLs in front of
+   * someone who may already be dragging a selection across the first.
+   *
+   * So the field holds until the mint settles, for a short grace window only.
+   * The mint is a local round-trip; if it has not answered within the window
+   * it is not going to be quick, and the long URL takes over for good.
+   */
   const [shortUrl, setShortUrl] = useState<string | null>(null);
+  const [mintSettled, setMintSettled] = useState(false);
   useEffect(() => {
     let cancelled = false;
     setShortUrl(null);
+    setMintSettled(false);
     let d: string;
     try {
       d = encodeSharePayload(payload);
     } catch {
+      // Nothing to mint from — the long URL is the only answer there is.
+      setMintSettled(true);
       return;
     }
+    // The window is the whole of the flicker guard: whatever happens, the user
+    // has a link by the time it elapses.
+    // Once this fires the long URL is committed: a late mint must NOT swap the
+    // field out from under a selection the user is already making. That delayed
+    // swap is the same flicker, just later.
+    let graceElapsed = false;
+    const timer = setTimeout(() => {
+      graceElapsed = true;
+      if (!cancelled) setMintSettled(true);
+    }, SHORT_LINK_GRACE_MS);
     postJson<{ code: string }>('/share-link', trackedAddress ? { d, address: trackedAddress } : { d })
       .then((r) => {
-        if (!cancelled && r?.code) setShortUrl(buildShortShareUrl(r.code));
+        if (cancelled || graceElapsed) return;
+        if (r?.code) setShortUrl(buildShortShareUrl(r.code));
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setMintSettled(true);
+      });
     return () => {
       cancelled = true;
+      clearTimeout(timer);
     };
   }, [payload, trackedAddress]);
 
-  const shareUrl = shortUrl ?? longUrl;
+  // Null while the mint is still in its grace window — the field renders its
+  // placeholder rather than a URL that is about to change.
+  const shareUrl = shortUrl ?? (mintSettled ? longUrl : null);
 
   useEffect(() => {
     let cancelled = false;
@@ -130,7 +169,7 @@ export function SharePositionModal({ payload, onClose }: { payload: SharePayload
           campaigns.
         </p>
 
-        {shareUrl && (
+        {shareUrl ? (
           <div className="flex items-center gap-2">
             <input
               readOnly
@@ -142,6 +181,12 @@ export function SharePositionModal({ payload, onClose }: { payload: SharePayload
             <button type="button" className="btn shrink-0" onClick={copyLink}>
               Copy link
             </button>
+          </div>
+        ) : (
+          // Held only for the grace window above — a placeholder the same
+          // height as the field, so nothing jumps when the link lands.
+          <div className="flex h-[34px] items-center rounded-lg border border-ink-800 bg-ink-950/60 px-2.5 text-[11px] text-ink-400">
+            <Spinner /> <span className="ml-2">Minting a short link…</span>
           </div>
         )}
 

--- a/web/src/panels/StrategyCard.tsx
+++ b/web/src/panels/StrategyCard.tsx
@@ -28,7 +28,7 @@
  *
  * Purely prop-driven — PositionsHome owns the queries.
  */
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import type {
   CrossexPosition,
   EntryCostMode,
@@ -184,6 +184,8 @@ export function StrategyCard({
   destinations,
   entryOverrides,
   bookId = '',
+  borosUnknown = false,
+  borosUnknownCta,
 }: {
   /** The custom strategy-start override (per wallet ?since=), editable from
    * the timeline's "Boros position open ✎" label. */
@@ -208,6 +210,19 @@ export function StrategyCard({
     s: StrategyRollup,
     only?: { side: 'LONG' | 'SHORT'; sizeUsd: number; sizeBase?: number },
   ) => void;
+  /**
+   * No Boros address is tracked, so we have NOT looked for this position's
+   * Boros legs.
+   *
+   * The card must then state the absence of information, never the absence of
+   * legs: "No Boros legs yet" is a claim about the user's book, and with
+   * nothing tracked we are in no position to make it. Suppresses the
+   * missing-leg rows and every cue that offers to open them, because both
+   * assert the same thing.
+   */
+  borosUnknown?: boolean;
+  /** Rendered in place of those cues — the "Add Boros address" control. */
+  borosUnknownCta?: ReactNode;
   /** Say where one of this position's legs belongs. Absent = the grouping is
    * read-only (the share page, tests that don't wire it). */
   onAssert?: (a: LegAssertion) => void;
@@ -394,7 +409,9 @@ export function StrategyCard({
     const pShort = sideSum('perp', 'SHORT');
     const grossBoros = bLong + bShort;
     const grossPerp = pLong + pShort;
-    if (!(checks.borosMatchRatio > 0.9)) {
+    // ⚠ Every cue in this block is a claim that a Boros leg is MISSING. With
+    // no address tracked we never looked, so none of them may be made.
+    if (!(checks.borosMatchRatio > 0.9) && !borosUnknown) {
       if (grossBoros === 0) {
         // Both sides missing, not one — and there is no Boros size to quote a
         // top-up against, so the perp book sizes it. Mirrors the perp cue below.
@@ -600,8 +617,27 @@ export function StrategyCard({
    * known — with no perp legs and no Boros legs there is no grid to complete,
    * and an orphan gets none of this by construction (`cardState`).
    */
+  /**
+   * The perp leg on the far side of this one, when the pair is genuinely a
+   * hedge (both perp sides present and this book is fully hedged).
+   *
+   * Closing one side of a delta-neutral pair stops the funding cancelling and
+   * leaves the other leg running directionally — a position the user did not
+   * choose to put on. Only offered when there IS something to un-hedge: on a
+   * half-built or already-lopsided book the row-level close is how the user
+   * fixes it, and the warning would be noise.
+   */
+  const hedgedSiblingOf = (leg: StrategyLeg): { venue: string; side: 'LONG' | 'SHORT' } | null => {
+    if (leg.kind !== 'perp' || !checks.fullyHedged) return null;
+    const far = perpLegs.find((o) => o.side !== leg.side && o.venue !== leg.venue);
+    return far ? { venue: far.venue, side: far.side } : null;
+  };
+
   const missingRows: MissingLegRow[] =
-    cardState === 'complete' || cardState === 'orphan'
+    // ⚠ A missing row asserts the leg is NOT open, and offers to open it. With
+    // no address tracked we never looked for the Boros legs, so the grid shows
+    // the perps alone rather than two rows claiming an absence.
+    cardState === 'complete' || cardState === 'orphan' || borosUnknown
       ? []
       : (['LONG', 'SHORT'] as const).flatMap((side) => {
           const venue = venueForSide(side);
@@ -1000,6 +1036,7 @@ export function StrategyCard({
             // acts on the whole position, so the popover has to open on THIS
             // position's size, not the venue's.
             attributedQty={(r.share ?? 1) < 0.999 ? r.notionalToken : undefined}
+            hedgedSibling={hedgedSiblingOf(r)}
             // …and the claim has to come down by what was closed, or the row
             // goes on asserting a size this card no longer holds.
             onClosed={(qty) => {
@@ -1123,7 +1160,14 @@ export function StrategyCard({
           that would lock their rate is missing. The card knows the venues and
           the size, so it hands them to the Boros ticket rather than leaving
           the user to rebuild that from the missing-leg rows one at a time. */}
-      {perpLegs.length === 2 && borosLegs.length === 0 && !matured && onOpenBorosLegs && (
+      {/* Nothing tracked: the card offers the one action that can change that,
+          in the slot the "Open the Boros legs" cue occupies on a tracked card.
+          It is not a trade — it is the missing input that would let us answer
+          whether these perps are hedged at all. */}
+      {borosUnknown && borosUnknownCta && (
+        <div className="mt-2 flex flex-wrap items-center gap-2">{borosUnknownCta}</div>
+      )}
+      {!borosUnknown && perpLegs.length === 2 && borosLegs.length === 0 && !matured && onOpenBorosLegs && (
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <button
             type="button"
@@ -1369,13 +1413,18 @@ export function StrategyCard({
                 ? 'Not part of any position. Assign it below, or close it.'
                 : cardState === 'mismatched'
                   ? 'Every leg is open in the right direction, but only the matched part is hedged.'
-                  : borosLegs.length === 0
-                    ? // A perp pair with no Boros side at all: the funding is
-                      // floating, and saying "once every leg is in place" would
-                      // imply the missing legs are a formality rather than the
-                      // whole trade.
-                      'No Boros legs yet — the funding is floating, so there is no locked rate to show.'
-                    : 'Rate, capital and ROI appear once every leg is in place.'}
+                  : borosUnknown
+                    ? // Nothing tracked ⇒ we never looked. Say what we know —
+                      // the perps are here — without claiming the user holds
+                      // no Boros legs.
+                      'Track a Boros address to see whether these perps have a locked rate.'
+                    : borosLegs.length === 0
+                      ? // A perp pair with no Boros side at all: the funding is
+                        // floating, and saying "once every leg is in place"
+                        // would imply the missing legs are a formality rather
+                        // than the whole trade.
+                        'No Boros legs yet — the funding is floating, so there is no locked rate to show.'
+                      : 'Rate, capital and ROI appear once every leg is in place.'}
             </span>
             {cardState !== 'orphan' && pairTopUpUsd !== null && !matured && onOpenPerpLegs && (
               <button
@@ -1543,6 +1592,7 @@ export function StrategyCard({
                   // close acts on the whole position, so the popover has to
                   // open on THIS position's size, not the venue's.
                   attributedQty={(l.share ?? 1) < 0.999 ? l.notionalToken : undefined}
+                  hedgedSibling={hedgedSiblingOf(l)}
                   share={l.share ?? 1}
                   // The collapsed row this expands from already carries the
                   // dedicated [Close] (`closeOnly` above), so a second one here

--- a/web/src/panels/homeBoxes.ts
+++ b/web/src/panels/homeBoxes.ts
@@ -16,6 +16,7 @@
 import type {
   ExposureGroup,
   PositionsResponse,
+  StrategyLeg,
   StrategyReturns,
   StrategyRollup,
 } from '../api/types';
@@ -59,4 +60,91 @@ export function buildBoxes(
       group,
     })),
   ];
+}
+
+/**
+ * An ExposureGroup rendered as a StrategyRollup, so the degraded path can use
+ * the SAME card as everything else.
+ *
+ * A position should not change visual language because of what the Boros feed
+ * could tell us about it. Everything here comes from the positions feed — the
+ * perp legs, their sides, their notionals — and every field the strategy
+ * solver would have computed is left at the value that means "not known":
+ * no Boros legs, no maturity, no capital, no projection.
+ *
+ * ⚠ The card must NOT then claim the Boros legs are MISSING. With no address
+ * tracked we have not looked, and "no Boros legs yet" is a statement about the
+ * user's book that we are in no position to make — see `borosUnknown` on
+ * StrategyCard, which is what this pairs with.
+ *
+ * Perp-only numbers stay honest: uPnL and funding are per-leg facts the perp
+ * feed knows, so they show. The rate/capital/ROI block does not, because
+ * `fullyHedged: false` gates it — the same gate a half-built tracked position
+ * passes through.
+ */
+export function rollupFromExposure(group: ExposureGroup): StrategyRollup {
+  const legs: StrategyLeg[] = group.legs.map((l) => ({
+    kind: 'perp' as const,
+    venue: l.exchange,
+    base: group.base,
+    side: l.side,
+    notionalUsd: l.value,
+    notionalToken: l.qty,
+    symbol: l.symbol,
+    cashFlowUsd: 0,
+    mtmUsd: 0,
+    tradePnlUsd: 0,
+    feesUsd: 0,
+    netUsd: 0,
+    openedAt: null,
+    warnings: [],
+  }));
+  return {
+    // Distinct from every server id (`BASE#perps`, `BASE@maturity`) so a
+    // membership pin can never be filed against a card that only exists
+    // because the feed is down.
+    strategyId: `${group.base}#untracked`,
+    attribution: { source: 'unhedged', confidence: 'measured', pinned: false },
+    base: group.base,
+    // 0 is the "no Boros legs, so no maturity" sentinel the cards already read.
+    maturity: 0,
+    legs,
+    hedge: 'unhedged',
+    hedgeChecks: {
+      borosMatchRatio: 0,
+      perpMatchRatio: 1,
+      borosVsPerpRatio: 0,
+      fullyHedged: false,
+    },
+    capitalUsd: 0,
+    capitalSplit: { perpUsd: 0, borosUsd: 0 },
+    realizedPnlUsd: 0,
+    realizedApr: null,
+    spread: 0,
+    lockedAprOnCapital: 0,
+    spreadReturnUsd: null,
+    expectedPnlToMaturityUsd: null,
+    elapsedSeconds: null,
+    clockBasis: null,
+    clockStartSec: null,
+    secondsToMaturity: 0,
+    notionalMismatchUsd: Math.abs(group.netValue),
+    perpEntryCostParts: [],
+    feesUsd: {
+      paid: {
+        perpTradingUsd: 0,
+        perpEntrySlippageUsd: null,
+        borosTradeUsd: 0,
+        borosSettlementUsd: 0,
+        totalUsd: 0,
+      },
+      future: {
+        perpExitFeesUsd: 0,
+        perpExitSlippageUsd: null,
+        borosSettlementUsd: 0,
+        totalUsd: 0,
+      },
+    },
+    warnings: [],
+  };
 }

--- a/web/src/trade/BorosPairBits.tsx
+++ b/web/src/trade/BorosPairBits.tsx
@@ -458,7 +458,13 @@ export function PairResultReport({
   collateral: string;
   onComplete: () => void;
   onRetry: () => void;
-  onDismiss: () => void;
+  /**
+   * Omit where the report IS the surface rather than an overlay on a form —
+   * the wizard's completed step 1, which has no armed ticket to return to.
+   * Rendering a dead "Dismiss" there would offer to hide the step's own
+   * content.
+   */
+  onDismiss?: () => void;
   busy?: boolean;
 }) {
   const tone = result.partial ? 'amber' : 'green';
@@ -589,7 +595,7 @@ export function PairResultReport({
             Leave it
           </button>
         </div>
-      ) : (
+      ) : onDismiss ? (
         <button
           type="button"
           onClick={onDismiss}
@@ -597,7 +603,7 @@ export function PairResultReport({
         >
           Dismiss
         </button>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/web/src/trade/BorosPairTicket.test.tsx
+++ b/web/src/trade/BorosPairTicket.test.tsx
@@ -13,6 +13,7 @@ import { STRATEGY_STORAGE_KEY } from '../panels/HomeControls';
 import { server } from '../test/server';
 import { renderWithClient } from '../test/utils';
 import { BorosPairTicket } from './BorosPairTicket';
+import { useTradeFlow, type BorosOpenPrefill } from './TradeFlow';
 
 const ADDRESS = '0x1111111111111111111111111111111111111111';
 const HL = 155;
@@ -1003,5 +1004,112 @@ describe('BorosPairTicket — the size unit', () => {
     );
     await user.selectOptions(screen.getByLabelText('Leg A'), '400');
     expect(screen.getByText('Size per leg (BTC)')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Card cue prefill ("Open the Boros legs") — maturity agreement
+// ---------------------------------------------------------------------------
+
+function BorosPrefillHarness({ prefill }: { prefill: Omit<BorosOpenPrefill, 'nonce'> }) {
+  const flow = useTradeFlow();
+  return (
+    <>
+      <button type="button" onClick={() => flow.prefillBorosOpen(prefill)}>
+        fire
+      </button>
+      <BorosPairTicket />
+    </>
+  );
+}
+
+describe('BorosPairTicket — the cue prefill lands both legs on ONE maturity', () => {
+  /**
+   * The shape that broke live: the cue fires from a card with NO Boros legs,
+   * so it carries no maturity, and each venue lists a different set. Gate had
+   * exactly one ETH market (the later one is absent) while Hyperliquid listed
+   * the FAR maturity first — so resolving each leg independently armed
+   * Gate-near against HL-far, a pair that cannot trade.
+   */
+  const SEP = MATURITY;
+  const DEC = MATURITY + 90 * 86_400;
+  const twoVenues = () =>
+    handlers({
+      ctx: context({
+        markets: [
+          // Hyperliquid lists the FAR maturity first — the list order that
+          // produced the bug.
+          marketRow({ marketId: 901, name: 'Hyperliquid ETH Dec', venue: 'Hyperliquid', maturity: DEC }),
+          marketRow({ marketId: 902, name: 'Hyperliquid ETH Sep', venue: 'Hyperliquid', maturity: SEP }),
+          // Gate lists only the near one.
+          marketRow({ marketId: 903, name: 'Gate ETH Sep', venue: 'Gate', maturity: SEP }),
+        ],
+      }),
+    });
+
+  it("picks the maturity the two venues SHARE, not each venue's first row", async () => {
+    server.use(...twoVenues());
+    const user = userEvent.setup();
+    renderWithClient(
+      <BorosPrefillHarness
+        prefill={{ base: 'ETH', longVenue: 'Gate', shortVenue: 'Hyperliquid', size: 1000 }}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'fire' }));
+
+    // Both legs on 902/903 (Sep). Before the fix leg B armed 901 (Dec) and the
+    // ticket reported "different maturity" about a pair nobody chose.
+    await waitFor(() => expect(screen.getByLabelText('Leg A')).toHaveValue('903'));
+    expect(screen.getByLabelText('Leg B')).toHaveValue('902');
+    expect(screen.queryByText(/different maturity/)).not.toBeInTheDocument();
+  });
+
+  it('arms neither leg when the venues share no maturity', async () => {
+    // An impossible pair must stay unarmed: a ticket holding two markets that
+    // cannot trade together is worse than an empty one.
+    server.use(
+      ...handlers({
+        ctx: context({
+          markets: [
+            marketRow({ marketId: 911, name: 'Hyperliquid ETH Dec', venue: 'Hyperliquid', maturity: DEC }),
+            marketRow({ marketId: 912, name: 'Gate ETH Sep', venue: 'Gate', maturity: SEP }),
+          ],
+        }),
+      }),
+    );
+    const user = userEvent.setup();
+    renderWithClient(
+      <BorosPrefillHarness
+        prefill={{ base: 'ETH', longVenue: 'Gate', shortVenue: 'Hyperliquid', size: 1000 }}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'fire' }));
+
+    await waitFor(() => expect(screen.getByLabelText('Leg A')).toHaveValue(''));
+    expect(screen.getByLabelText('Leg B')).toHaveValue('');
+  });
+});
+
+describe('BorosPairTicket — slippage is stated, not silently clamped', () => {
+  it('blocks confirm when the typed slippage exceeds the cap', async () => {
+    /**
+     * `pctToApr` clamps to MAX_SLIP_PCT, so typing 50 left "50" on screen while
+     * 10 went on the wire — and clamping client-side made the server's own
+     * "reject, never silently coerce" guard unreachable. The number shown must
+     * be the number sent, or the user must be told it is not.
+     */
+    server.use(...handlers());
+    const user = userEvent.setup();
+    renderWithClient(<BorosPairTicket />);
+    await fillTicket(user);
+
+    const slip = screen.getByLabelText(/Max slippage/);
+    await user.clear(slip);
+    await user.type(slip, '50');
+
+    expect(await screen.findByText(/Max slippage cannot exceed/)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Confirm/ })).toBeDisabled(),
+    );
   });
 });

--- a/web/src/trade/BorosPairTicket.test.tsx
+++ b/web/src/trade/BorosPairTicket.test.tsx
@@ -1107,9 +1107,35 @@ describe('BorosPairTicket — slippage is stated, not silently clamped', () => {
     await user.clear(slip);
     await user.type(slip, '50');
 
-    expect(await screen.findByText(/Max slippage cannot exceed/)).toBeInTheDocument();
+    expect(await screen.findByText(/Max slippage must be greater than 0/)).toBeInTheDocument();
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /Confirm/ })).toBeDisabled(),
     );
+  });
+
+  it('blocks confirm on a typed ZERO — the seeded default must not go out silently', async () => {
+    /**
+     * The check used to be one-sided: only `> MAX_SLIP_PCT` was flagged, while
+     * a typed 0 (or a cleared box, or a negative) fell through to `pctToApr`'s
+     * fallback — the order went out carrying the SEEDED default as its rate
+     * bound, a bound the user explicitly did not choose, with "0" on screen.
+     */
+    server.use(...handlers());
+    const user = userEvent.setup();
+    renderWithClient(<BorosPairTicket />);
+    await fillTicket(user);
+
+    const slip = screen.getByLabelText(/Max slippage/);
+    await user.clear(slip);
+    await user.type(slip, '0');
+
+    expect(await screen.findByText(/Max slippage must be greater than 0/)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Confirm/ })).toBeDisabled(),
+    );
+
+    // A cleared box is the same dishonesty — empty on screen, seed on the wire.
+    await user.clear(slip);
+    expect(await screen.findByText(/Max slippage must be greater than 0/)).toBeInTheDocument();
   });
 });

--- a/web/src/trade/BorosPairTicket.tsx
+++ b/web/src/trade/BorosPairTicket.tsx
@@ -42,6 +42,7 @@ import { HoldToConfirmButton } from '../components/HoldToConfirmButton';
 import { QueryError } from '../components/QueryError';
 import { SegmentedToggle } from '../components/SegmentedToggle';
 import { amountError } from '../lib/amount';
+import { isUsdCollateral } from '../lib/boros';
 import { useNow } from '../lib/useNow';
 import { uuid } from '../lib/uuid';
 import { useTrackedAddressOptional } from '../panels/trackedAddress';
@@ -85,8 +86,21 @@ const newOrderIds = () => ({ a: `a-${uuid()}`, b: `b-${uuid()}` });
 
 /** `active` = the ticket is the visible venue. A hidden-but-mounted ticket
  * (see TradeRail) keeps its report and completion state but stops polling the
- * simulation — a quote nobody can see should not cost a request every 4s. */
-export function BorosPairTicket({ active = true }: { active?: boolean } = {}) {
+ * simulation — a quote nobody can see should not cost a request every 4s.
+ * `onExecuted` fires on every accepted execution (full, partial, or a
+ * completion) with the venue's result — the wizard advances its step off it. */
+export function BorosPairTicket({
+  active = true,
+  onExecuted,
+}: {
+  active?: boolean;
+  /**
+   * The collateral travels WITH the result: it is what the size figures are
+   * denominated in, and the caller (the wizard) renders its own receipt from
+   * these. Re-deriving it there could disagree with the ticket that traded.
+   */
+  onExecuted?: (result: BorosPairResult, collateral: string) => void;
+} = {}) {
   const tracked = useTrackedAddressOptional();
   const agent = useBorosAgent();
 
@@ -147,10 +161,10 @@ export function BorosPairTicket({ active = true }: { active?: boolean } = {}) {
     // ticket) was dropped and the ticket just sat empty. `marketsReady` in the
     // deps re-runs it the moment the list is there.
     if (!openNonce || !openPrefill || markets.length === 0) return;
-    const pick = (venue: string | null) =>
+    const at = (venue: string | null) =>
       venue === null
-        ? undefined
-        : markets.find(
+        ? []
+        : markets.filter(
             (m) =>
               m.venue.toUpperCase() === venue.toUpperCase() &&
               m.base.toUpperCase() === openPrefill.base.toUpperCase() &&
@@ -158,8 +172,42 @@ export function BorosPairTicket({ active = true }: { active?: boolean } = {}) {
               // wrong one gives two legs that cannot pair with each other.
               (openPrefill.maturity === undefined || m.maturity === openPrefill.maturity),
           );
-    const long = pick(openPrefill.longVenue);
-    const short = pick(openPrefill.shortVenue);
+    const longAt = at(openPrefill.longVenue);
+    const shortAt = at(openPrefill.shortVenue);
+    /**
+     * ⚠ Resolve the two legs TOGETHER, on a maturity they SHARE.
+     *
+     * Taking each leg's first match independently is a bug the caller cannot
+     * fix from outside: the cue that opens a card's missing Boros legs has no
+     * maturity to send (that card has no Boros legs, so its maturity is the 0
+     * sentinel), and the venues then land wherever their own list order puts
+     * them. Observed live: Gate lists exactly one ETH market (25 Sep) while
+     * Hyperliquid lists 25 Dec FIRST — so the ticket armed Gate-Sep against
+     * HL-Dec, a pair that cannot trade. Each leg then filtered the other out
+     * of its own dropdown and the ticket reported "different maturity" about
+     * a pair the user never chose.
+     *
+     * The intersection is both the fix and the honest answer: when the two
+     * venues share no maturity there is no pair to arm, and leaving the legs
+     * unresolved beats arming an impossible one.
+     *
+     * Soonest shared maturity wins — the nearest expiry is the liquid one.
+     */
+    type Market = (typeof markets)[number];
+    const soonest = (ms: Market[]): Market | undefined =>
+      [...ms].sort((a, b) => a.maturity - b.maturity)[0];
+    let long: Market | undefined;
+    let short: Market | undefined;
+    if (longAt.length > 0 && shortAt.length > 0) {
+      const shortMaturities = new Set(shortAt.map((m) => m.maturity));
+      long = soonest(longAt.filter((m) => shortMaturities.has(m.maturity)));
+      short = long ? shortAt.find((m) => m.maturity === long!.maturity) : undefined;
+    } else {
+      // Single-leg prefills: only one side was asked for, so there is nothing
+      // to agree with and the soonest at that venue is the right default.
+      long = soonest(longAt);
+      short = soonest(shortAt);
+    }
     /**
      * One venue = one leg. A missing-leg row asks for exactly the leg it is
      * missing, so opening a PAIR here would silently create a second position
@@ -204,8 +252,7 @@ export function BorosPairTicket({ active = true }: { active?: boolean } = {}) {
      * Unknown collateral leaves the field empty rather than guessing.
      */
     const picked = long ?? short;
-    const unit = picked?.collateral ?? '';
-    const usdPegged = unit === 'USDT' || unit === 'USDC';
+    const usdPegged = isUsdCollateral(picked?.collateral);
     const chosen = usdPegged ? openPrefill.size : openPrefill.sizeBase;
     setSizeStr(chosen !== undefined && chosen > 0 ? String(Number(chosen.toPrecision(8))) : '');
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -314,6 +361,23 @@ export function BorosPairTicket({ active = true }: { active?: boolean } = {}) {
   };
   const aprA = pctToApr(perLeg ? slipStrA : slipStrShared, seededShared);
   const aprB = pctToApr(perLeg ? slipStrB : slipStrShared, seededShared);
+  /**
+   * ⚠ Say when the typed number is not the sent number.
+   *
+   * `pctToApr` clamps to MAX_SLIP_PCT, so typing 50 left "50" on screen while
+   * 10 went on the wire — and because the client clamped first, the server's
+   * own guard ("silently coercing a bad value would set the rate bound the
+   * order actually carries, so it is rejected instead", borosPair.ts) could
+   * never fire. The clamp stays as the last line of defence; this makes the
+   * disagreement visible instead of silent.
+   */
+  const slipOutOfRange = (raw: string): boolean => {
+    const n = Number(raw);
+    return raw.trim() !== '' && Number.isFinite(n) && n > MAX_SLIP_PCT;
+  };
+  const slipInvalid = perLeg
+    ? slipOutOfRange(slipStrA) || slipOutOfRange(slipStrB)
+    : slipOutOfRange(slipStrShared);
 
   const request = useMemo<BorosPairRequest | null>(() => {
     /**
@@ -404,6 +468,14 @@ export function BorosPairTicket({ active = true }: { active?: boolean } = {}) {
 
   const blockers = [
     ...(gate?.blockers ?? []),
+    ...(slipInvalid
+      ? [
+          {
+            code: 'slippage-out-of-range',
+            message: `Max slippage cannot exceed ${MAX_SLIP_PCT}% APR — lower it, or the order would carry a rate bound you did not choose.`,
+          },
+        ]
+      : []),
     ...(quoteStale
       ? [{ code: 'stale-simulation', message: 'The quote is out of date — waiting for a fresh one.' }]
       : []),
@@ -429,6 +501,8 @@ export function BorosPairTicket({ active = true }: { active?: boolean } = {}) {
         onSuccess: (res) => {
           setReport(res.result);
           setReportReplayed(Boolean(res.replayed));
+          // A replay is the EARLIER submission's result — it already fired.
+          if (!res.replayed) onExecuted?.(res.result, simulation?.collateral ?? '');
           setAcknowledged(false);
           // This execution is DONE — the ids have served their replay-protection
           // purpose. Fresh ones now, so a later confirm of the same unchanged
@@ -745,7 +819,22 @@ export function BorosPairTicket({ active = true }: { active?: boolean } = {}) {
             setOrderIds(newOrderIds());
             setReport(null);
           }}
-          onDismiss={() => setReport(null)}
+          onDismiss={() => {
+            /**
+             * ⚠ Clear the size with the report.
+             *
+             * Dismiss returns the ticket to its ordinary armed state, and
+             * `sizeStr` still held the ORIGINAL request — so on a partial fill
+             * the Confirm underneath came back armed for the WHOLE pair, on
+             * top of the part that had already filled. (Fresh order ids mean
+             * the replay guard does not cover it.) The size that produced this
+             * report has been spent; re-entering one is the point of
+             * dismissing rather than using Complete or Retry, which set their
+             * own sizes.
+             */
+            setSizeStr('');
+            setReport(null);
+          }}
         />
       )}
 

--- a/web/src/trade/BorosPairTicket.tsx
+++ b/web/src/trade/BorosPairTicket.tsx
@@ -92,6 +92,7 @@ const newOrderIds = () => ({ a: `a-${uuid()}`, b: `b-${uuid()}` });
 export function BorosPairTicket({
   active = true,
   onExecuted,
+  onBusyChange,
 }: {
   active?: boolean;
   /**
@@ -100,6 +101,15 @@ export function BorosPairTicket({
    * these. Re-deriving it there could disagree with the ticket that traded.
    */
   onExecuted?: (result: BorosPairResult, collateral: string) => void;
+  /**
+   * True while an execution is in flight. The surface hosting this ticket
+   * (wizard modal, order-ticket drawer) locks its close controls off it:
+   * unmounting mid-execution skips the mutate-level onSuccess, so the fill
+   * report — including a partial fill's Complete/Unwind remediation — and the
+   * replay-protection order ids would die with the component while the order
+   * executes at the venue regardless.
+   */
+  onBusyChange?: (busy: boolean) => void;
 } = {}) {
   const tracked = useTrackedAddressOptional();
   const agent = useBorosAgent();
@@ -372,8 +382,14 @@ export function BorosPairTicket({
    * disagreement visible instead of silent.
    */
   const slipOutOfRange = (raw: string): boolean => {
+    // ⚠ Two-sided on purpose. Flagging only the too-large direction left the
+    // other half of the same dishonesty in place: a typed zero, negative, or
+    // cleared value fell through to `pctToApr`'s fallback and the order went
+    // out carrying the SEEDED default as its rate bound — a bound the user
+    // explicitly did not choose, with nothing on screen saying so. (The boxes
+    // are seeded, so an empty value only exists after a deliberate clear.)
     const n = Number(raw);
-    return raw.trim() !== '' && Number.isFinite(n) && n > MAX_SLIP_PCT;
+    return raw.trim() === '' || !Number.isFinite(n) || n <= 0 || n > MAX_SLIP_PCT;
   };
   const slipInvalid = perLeg
     ? slipOutOfRange(slipStrA) || slipOutOfRange(slipStrB)
@@ -444,6 +460,20 @@ export function BorosPairTicket({
   const execute = useExecuteBorosPair();
   const cancelClose = useBorosCancelAndClose();
 
+  // Tell the host surface an execution is in flight, so it can lock its close
+  // controls (see the prop doc). Cleared on unmount so a host never stays
+  // locked by a ticket that is gone. A follow-up could make an interrupted
+  // execution genuinely recoverable — persist the in-flight order ids the way
+  // pendingBasket.ts does and re-POST on remount to hit the server's replay
+  // memo — but while the report lives only in this component, blocking the
+  // close is what keeps a live fill visible.
+  const busy = execute.isPending;
+  useEffect(() => {
+    onBusyChange?.(busy);
+    return () => onBusyChange?.(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [busy]);
+
   /**
    * Freshness is judged HERE, not by the server's gate.
    *
@@ -472,7 +502,7 @@ export function BorosPairTicket({
       ? [
           {
             code: 'slippage-out-of-range',
-            message: `Max slippage cannot exceed ${MAX_SLIP_PCT}% APR — lower it, or the order would carry a rate bound you did not choose.`,
+            message: `Max slippage must be greater than 0 and at most ${MAX_SLIP_PCT}% APR — the order would otherwise carry a rate bound you did not choose.`,
           },
         ]
       : []),

--- a/web/src/trade/CloseBorosForm.tsx
+++ b/web/src/trade/CloseBorosForm.tsx
@@ -410,7 +410,12 @@ export function CloseBorosForm({
                     </span>
                   </span>
                   <span className="flex justify-between text-ink-400">
-                    <span>est. PnL at that rate</span>
+                    {/* "before fees" because it IS: estPnl is
+                        (locked − exec) × size × years, with no fee term. The
+                        drag is quoted once below rather than subtracted here,
+                        which would need a per-leg apportionment the simulation
+                        does not return. */}
+                    <span>est. PnL at that rate, before fees</span>
                     {estPnl !== null ? (
                       <SignedNumber value={estPnl} format={(n) => fmtUsd(n)} />
                     ) : (
@@ -446,6 +451,16 @@ export function CloseBorosForm({
           );
         })}
       </div>
+
+      {/* One line, once, from the figure the simulation already returns — the
+          per-leg PnL above is a rate difference and carries no fee term, so
+          without this the screen showed only the flattering half. */}
+      {sim.data?.simulation.feeDragApr != null && (
+        <span className="text-[11px] text-ink-500">
+          Boros taker + settlement fees ≈ {fmtPct(sim.data.simulation.feeDragApr)} APR on the size
+          closed.
+        </span>
+      )}
 
       <label className="flex items-center gap-2 text-[11px] text-ink-400">
         <span className="w-20">Slippage %</span>

--- a/web/src/trade/ClosePopover.test.tsx
+++ b/web/src/trade/ClosePopover.test.tsx
@@ -1,8 +1,10 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
+import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { ActionInput, DealRequest, PreviewResponse } from '../api/types';
+import type { ActionInput, CrossexPosition, DealRequest, PreviewResponse } from '../api/types';
+import { sig } from '../lib/fmt';
 import { baseHandlers, ethPosition, makeCrossexPosition, previewFor } from '../test/fixtures';
 import { env, server } from '../test/server';
 import { renderWithClient } from '../test/utils';
@@ -357,5 +359,72 @@ describe('ClosePopover — closing one side of a hedge', () => {
     renderWithClient(<ClosePopover position={ethPosition} onDismiss={() => {}} />);
     await screen.findByText(/marketable limit px/);
     expect(screen.queryByText(/leaves that one unhedged/)).not.toBeInTheDocument();
+  });
+});
+
+describe('ClosePopover — the conversion mark is latched at open', () => {
+  const hype = makeCrossexPosition({
+    symbol: 'BYBIT_FUTURE_HYPE_USDT',
+    positionQty: '1.89',
+    markPrice: '80',
+    entryPrice: '78',
+  });
+
+  /** Simulates the 4s positions poll delivering a refreshed position whose
+   * mark has turned unusable while the dialog is up. */
+  function MarkFlipHarness() {
+    const [pos, setPos] = useState<CrossexPosition>(hype);
+    return (
+      <>
+        <button type="button" onClick={() => setPos(makeCrossexPosition({ ...hype, markPrice: '0' }))}>
+          break-mark
+        </button>
+        <ClosePopover position={pos} onDismiss={() => {}} />
+      </>
+    );
+  }
+
+  it('a mark that breaks mid-dialog does NOT relabel the typed USD figure', async () => {
+    /**
+     * `effUnit` used to re-derive from the LIVE markPrice each render while
+     * the typed digits persisted — a mark arriving as ''/'0' mid-edit flipped
+     * the unit to 'base' and re-read "$50" as 50 HYPE (~40× the close), with
+     * only the label quietly changing. The mark is latched at open now.
+     */
+    server.use(...baseHandlers(), closePreviewHandler());
+    renderWithClient(<MarkFlipHarness />);
+    await screen.findByText(/marketable limit px/);
+
+    await userEvent.click(screen.getByRole('radio', { name: 'partial' }));
+    await userEvent.type(screen.getByLabelText('Close value'), '50');
+    await userEvent.click(screen.getByRole('button', { name: 'break-mark' }));
+
+    // Still a DOLLAR box, still converting at the mark the dialog opened with.
+    expect(screen.getByLabelText('Close value')).toHaveValue('50');
+    expect(screen.queryByLabelText('Close qty')).not.toBeInTheDocument();
+    expect(await screen.findByText(/0\.625/)).toBeInTheDocument();
+  });
+
+  it('accepts the USD maximum the dialog itself displays', async () => {
+    /**
+     * The max is DISPLAYED via sig() (round-to-nearest) but was validated by
+     * exact conversion: whenever sig rounded up, typing the placeholder's own
+     * figure converted to a hair above posQty and was refused by an error
+     * naming the very number it rejected. Within rounding distance the entry
+     * is accepted and the wire qty is clamped to the position.
+     */
+    server.use(...baseHandlers(), closePreviewHandler());
+    renderWithClient(
+      <ClosePopover position={makeCrossexPosition({ ...hype, markPrice: '80.001' })} onDismiss={() => {}} />,
+    );
+    await screen.findByText(/marketable limit px/);
+    await userEvent.click(screen.getByRole('radio', { name: 'partial' }));
+
+    // The placeholder's own stated max: sig(1.89 × 80.001) rounds UP.
+    const max = sig(1.89 * 80.001);
+    await userEvent.type(screen.getByLabelText('Close value'), max);
+
+    expect(screen.queryByText(/close size exceeds position/)).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Close now ▸' })).toBeEnabled());
   });
 });

--- a/web/src/trade/ClosePopover.test.tsx
+++ b/web/src/trade/ClosePopover.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ActionInput, DealRequest, PreviewResponse } from '../api/types';
-import { baseHandlers, ethPosition, previewFor } from '../test/fixtures';
+import { baseHandlers, ethPosition, makeCrossexPosition, previewFor } from '../test/fixtures';
 import { env, server } from '../test/server';
 import { renderWithClient } from '../test/utils';
 import { ClosePopover } from './ClosePopover';
@@ -97,7 +97,9 @@ describe('ClosePopover', () => {
     await userEvent.click(screen.getByRole('radio', { name: 'partial' }));
     await userEvent.type(screen.getByLabelText('Close qty'), '0.5'); // position is 0.3
 
-    expect(await screen.findByText(/close qty exceeds position \(0\.3\)/)).toBeInTheDocument();
+    // ETH is coin-margined, so the box defaults to the coin and the error
+    // names the limit in that unit.
+    expect(await screen.findByText(/close size exceeds position \(0\.3 ETH\)/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Close now ▸' })).toBeDisabled();
   });
 
@@ -246,5 +248,114 @@ describe('ClosePopover', () => {
     expect(await screen.findByRole('alert', {}, { timeout: 3_000 })).toHaveTextContent(
       /venue rejected the close/,
     );
+  });
+});
+
+describe('ClosePopover — sizing a close in dollars', () => {
+  /**
+   * A HYPE position's Boros leg is USDT-collateral and reads $100, so closing
+   * it in coin units meant converting by eye on the very leg where a slip
+   * leaves a naked remainder. The unit follows the same rule as the tickets.
+   */
+  const hypePosition = makeCrossexPosition({
+    symbol: 'BYBIT_FUTURE_HYPE_USDT',
+    positionQty: '1.89',
+    markPrice: '80',
+    entryPrice: '78',
+  });
+
+  it('defaults a non-coin-margined position to USDT and converts at the mark', async () => {
+    server.use(...baseHandlers(), closePreviewHandler());
+    renderWithClient(<ClosePopover position={hypePosition} onDismiss={() => {}} />);
+    await screen.findByText(/marketable limit px/);
+
+    await userEvent.click(screen.getByRole('radio', { name: 'partial' }));
+    // Dollars, not coins — the box says so.
+    const box = screen.getByLabelText('Close value');
+    await userEvent.type(box, '50');
+
+    // 50 USDT at mark 80 = 0.625 HYPE, and the converted figure is SHOWN
+    // rather than left to be inferred. (The shared preview fixture answers
+    // with an ETH-sized position, so the button's own enablement is covered by
+    // the ETH cases above; what matters here is the unit and the conversion.)
+    expect(await screen.findByText(/0\.625/)).toBeInTheDocument();
+    expect(screen.getByText(/at mark/)).toBeInTheDocument();
+  });
+
+  it('validates a USD entry against the position VALUE, not its quantity', async () => {
+    // 1.89 @ 80 = $151.20. A $200 close must be refused; without converting
+    // first, 200 > 1.89 would be refused for the wrong reason and $1 would be
+    // wrongly ACCEPTED as if it were 1 coin.
+    server.use(...baseHandlers(), closePreviewHandler());
+    renderWithClient(<ClosePopover position={hypePosition} onDismiss={() => {}} />);
+    await screen.findByText(/marketable limit px/);
+
+    await userEvent.click(screen.getByRole('radio', { name: 'partial' }));
+    await userEvent.type(screen.getByLabelText('Close value'), '200');
+    expect(await screen.findByText(/close size exceeds position/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close now ▸' })).toBeDisabled();
+  });
+
+  it('falls back to COIN units when the mark is unusable — never sends dollars as qty', async () => {
+    /**
+     * The unit default is 'usd' for every non-ETH/BTC coin, and the toggle was
+     * the only thing gated on having a mark. A position whose markPrice is
+     * empty/zero therefore sat in 'usd' with no way out, and the conversion
+     * fell through to the raw entry — a "$50" close would have sent 50 HYPE.
+     */
+    server.use(...baseHandlers(), closePreviewHandler());
+    renderWithClient(
+      <ClosePopover position={makeCrossexPosition({ ...hypePosition, markPrice: '0' })} onDismiss={() => {}} />,
+    );
+    await screen.findByText(/marketable limit px/);
+    await userEvent.click(screen.getByRole('radio', { name: 'partial' }));
+
+    // Coin units, and the USD toggle is not offered at all.
+    expect(screen.getByLabelText('Close qty')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Close value')).not.toBeInTheDocument();
+    expect(screen.queryByRole('radiogroup', { name: 'Close size unit' })).not.toBeInTheDocument();
+    // And the limit is stated in coins, so 2 (> 1.89) is refused.
+    await userEvent.type(screen.getByLabelText('Close qty'), '2');
+    expect(await screen.findByText(/close size exceeds position \(1\.89 HYPE\)/)).toBeInTheDocument();
+  });
+
+  it('keeps the SIZE when the unit is toggled, not the digits', async () => {
+    // Relabelling 0.63 as $0.63 would silently resize the close by the mark.
+    server.use(...baseHandlers(), closePreviewHandler());
+    renderWithClient(<ClosePopover position={hypePosition} onDismiss={() => {}} />);
+    await screen.findByText(/marketable limit px/);
+
+    await userEvent.click(screen.getByRole('radio', { name: 'partial' }));
+    await userEvent.type(screen.getByLabelText('Close value'), '80');
+    await userEvent.click(screen.getByRole('radio', { name: 'HYPE' }));
+    // $80 at mark 80 is 1 HYPE.
+    expect(screen.getByLabelText('Close qty')).toHaveValue('1');
+  });
+});
+
+describe('ClosePopover — closing one side of a hedge', () => {
+  it('warns that the far leg is left unhedged, and stays silent when there is none', async () => {
+    /**
+     * A delta-neutral pair earns because the two floating legs cancel. Closing
+     * one end leaves the other running as a directional funding bet the user
+     * did not choose to put on — and the row-level Close said nothing about
+     * that (only the card-level "Close perp pair" is self-describing).
+     */
+    server.use(...baseHandlers(), closePreviewHandler());
+    const { unmount } = renderWithClient(
+      <ClosePopover
+        position={ethPosition}
+        hedgedSibling={{ venue: 'HYPERLIQUID', side: 'SHORT' }}
+        onDismiss={() => {}}
+      />,
+    );
+    expect(await screen.findByText(/Closing it leaves that one unhedged/)).toBeInTheDocument();
+    expect(screen.getByText(/Hyperliquid short/)).toBeInTheDocument();
+    unmount();
+
+    // No sibling (an unpaired leg) ⇒ nothing to un-hedge, so no noise.
+    renderWithClient(<ClosePopover position={ethPosition} onDismiss={() => {}} />);
+    await screen.findByText(/marketable limit px/);
+    expect(screen.queryByText(/leaves that one unhedged/)).not.toBeInTheDocument();
   });
 });

--- a/web/src/trade/ClosePopover.tsx
+++ b/web/src/trade/ClosePopover.tsx
@@ -16,7 +16,8 @@ import { Modal } from '../components/Modal';
 import { SegmentedToggle } from '../components/SegmentedToggle';
 import { SignedNumber } from '../components/SignedNumber';
 import { SideChip, SymbolCell } from '../components/VenueChip';
-import { fmtUsd, sig } from '../lib/fmt';
+import { fmtUsd, parseSymbol, prettyVenue, sig } from '../lib/fmt';
+import { sizeUnitForBase } from '../lib/boros';
 import { ExecuteControl } from './ExecuteControl';
 import { feeText, PreviewFallback, ViolationList } from './previewBits';
 import { usePreviewDebounced } from './usePreview';
@@ -42,10 +43,25 @@ interface Props {
    * claiming size it already sold, taken out of whoever shares the leg.
    */
   onClosed?: (qty: number) => void;
+  /**
+   * This leg is one side of a hedge, so closing it leaves the other side naked.
+   *
+   * A delta-neutral pair earns because the two floating legs cancel; close one
+   * and what remains is a directional funding bet the user did not choose to
+   * put on. The card-level "Close perp pair" says what it does by its name —
+   * this row-level control did not, and said nothing about the consequence.
+   */
+  hedgedSibling?: { venue: string; side: 'LONG' | 'SHORT' } | null;
   onDismiss: () => void;
 }
 
-export function ClosePopover({ position, attributedQty, onClosed, onDismiss }: Props) {
+export function ClosePopover({
+  position,
+  attributedQty,
+  onClosed,
+  hedgedSibling,
+  onDismiss,
+}: Props) {
   const wholeQty = Math.abs(Number(position.positionQty));
   // A shared leg: this card owns less than the venue holds.
   const shared =
@@ -56,6 +72,43 @@ export function ClosePopover({ position, attributedQty, onClosed, onDismiss }: P
   const [slipStr, setSlipStr] = useState('0.5');
   const [mode, setMode] = useState<'full' | 'partial'>(shared ? 'partial' : 'full');
   const [qtyStr, setQtyStr] = useState(shared ? String(Number(attributedQty.toPrecision(8))) : '');
+  /**
+   * Which unit the partial box is in.
+   *
+   * A close has to be sizeable in DOLLARS because that is the unit the other
+   * half of the trade uses: a HYPE position's Boros leg is USDT-collateral and
+   * its notional reads $100, so closing "0.63 HYPE" to match it means doing an
+   * FX conversion by eye — on the leg where a slip leaves a naked remainder.
+   * Follows the same rule as the tickets (ETH/BTC in the coin, everything else
+   * in dollars) so one strategy is sized in one unit end to end.
+   *
+   * The wire format is unchanged: the server's close action takes `qty` only,
+   * so a USD figure is converted here, at the mark the dialog already shows.
+   */
+  const base = parseSymbol(position.symbol).base;
+  /**
+   * ⚠ A shared leg PREFILLS the box with a base quantity (the size this card
+   * owns), so the unit must start as `base` regardless of the coin's default —
+   * otherwise 0.63 HYPE would be relabelled as $0.63. The user can switch, and
+   * the toggle converts the figure with it.
+   */
+  const [unit, setUnit] = useState<'base' | 'usd'>(() =>
+    shared ? 'base' : sizeUnitForBase(base),
+  );
+  const mark = Number(position.markPrice);
+  const markOk = Number.isFinite(mark) && mark > 0;
+  /**
+   * ⚠ USD is only a legal unit while there is a mark to convert AT.
+   *
+   * Gating the toggle on `markOk` was not enough: the DEFAULT is 'usd' for
+   * every non-ETH/BTC coin, so a position whose `markPrice` arrives empty,
+   * zero or unparseable sat in 'usd' with the toggle hidden — and the
+   * conversion fell through to `entered`, sending a DOLLAR figure as a base
+   * quantity. A "$50" partial close of HYPE would have sent 50 HYPE. Every
+   * read of the unit goes through this, so the box, the validation, the wire
+   * value and `onClosed` can never disagree about what the number means.
+   */
+  const effUnit: 'base' | 'usd' = markOk ? unit : 'base';
   const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -69,10 +122,19 @@ export function ClosePopover({ position, attributedQty, onClosed, onDismiss }: P
   const posQty = Math.abs(Number(position.positionQty));
   const slip = Number(slipStr);
   const slipInvalid = !Number.isFinite(slip) || slip <= 0 || slip > 10;
-  const qtyNum = Number(qtyStr);
+  const entered = Number(qtyStr);
+  /**
+   * The order is always sent in base units. A USD entry converts at the mark —
+   * the same price the preview below quotes — and with no usable mark the USD
+   * option is not offered at all, so this cannot silently divide by a stale or
+   * zero price.
+   */
+  const qtyNum = effUnit === 'usd' ? entered / mark : entered;
   const partialMissing = mode === 'partial' && qtyStr.trim() === '';
   const partialInvalid =
-    mode === 'partial' && qtyStr.trim() !== '' && (!Number.isFinite(qtyNum) || qtyNum <= 0 || qtyNum > posQty);
+    mode === 'partial' &&
+    qtyStr.trim() !== '' &&
+    (!Number.isFinite(entered) || entered <= 0 || !Number.isFinite(qtyNum) || qtyNum <= 0 || qtyNum > posQty);
 
   const action = useMemo<ActionInput | null>(() => {
     if (slipInvalid || partialMissing || partialInvalid) return null;
@@ -80,9 +142,9 @@ export function ClosePopover({ position, attributedQty, onClosed, onDismiss }: P
       kind: 'close-position',
       symbol: position.symbol,
       slippagePct: slip,
-      ...(mode === 'partial' ? { qty: qtyStr } : {}),
+      ...(mode === 'partial' ? { qty: String(Number(qtyNum.toPrecision(8))) } : {}),
     };
-  }, [slipInvalid, partialMissing, partialInvalid, position.symbol, slip, mode, qtyStr]);
+  }, [slipInvalid, partialMissing, partialInvalid, position.symbol, slip, mode, qtyNum]);
 
   const preview = usePreviewDebounced(`close-${position.symbol}`, action ? [action] : null, {
     debounceMs: 300,
@@ -146,22 +208,67 @@ export function ClosePopover({ position, attributedQty, onClosed, onDismiss }: P
                 : `This position holds ${sig(attributedQty ?? 0)} of the ${sig(wholeQty)} on the venue; the rest belongs to another position.`}
             </p>
           )}
+          {hedgedSibling && (
+            /* The consequence, not the mechanics: this pair earns because the
+               two floating legs cancel, and closing one end leaves the other
+               running as a directional funding bet. */
+            <p className="rounded-lg border border-amber-500/40 bg-amber-500/[0.08] px-2.5 py-1.5 leading-relaxed text-amber-100">
+              This leg hedges the {prettyVenue(hedgedSibling.venue)} {hedgedSibling.side.toLowerCase()}{' '}
+              leg. Closing it leaves that one unhedged — its funding stops cancelling and becomes a
+              directional position.
+            </p>
+          )}
           {mode === 'partial' && (
             <div className="flex items-center gap-2">
               <label htmlFor={`close-qty-${position.symbol}`} className="w-24 text-ink-400">
-                Close qty
+                Close {effUnit === 'usd' ? 'value' : 'qty'}
               </label>
               <input
                 id={`close-qty-${position.symbol}`}
                 className={`input num h-8 flex-1 px-2 py-1 ${partialInvalid ? 'border-rose-500' : ''}`}
                 inputMode="decimal"
-                placeholder={`≤ ${sig(posQty)}`}
+                placeholder={effUnit === 'usd' ? `≤ ${sig(posQty * mark)}` : `≤ ${sig(posQty)}`}
                 value={qtyStr}
                 onChange={(e) => setQtyStr(e.target.value)}
               />
+              {/* Only when a mark is available to convert with. */}
+              {markOk && (
+                <SegmentedToggle<'base' | 'usd'>
+                  ariaLabel="Close size unit"
+                  value={unit}
+                  onChange={(u) => {
+                    // Carry the SIZE across the switch, not the digits: the box
+                    // holds one number and relabelling it would silently resize
+                    // the close by the mark price.
+                    const n = Number(qtyStr);
+                    if (Number.isFinite(n) && n > 0) {
+                      const asQty = unit === 'usd' ? n / mark : n;
+                      setQtyStr(String(Number((u === 'usd' ? asQty * mark : asQty).toPrecision(8))));
+                    }
+                    setUnit(u);
+                  }}
+                  options={[
+                    { value: 'base', label: <span className="text-xs">{base}</span> },
+                    { value: 'usd', label: <span className="text-xs">USDT</span> },
+                  ]}
+                />
+              )}
             </div>
           )}
-          {partialInvalid && <span className="text-rose-400">close qty exceeds position ({sig(posQty)})</span>}
+          {partialInvalid && (
+            <span className="text-rose-400">
+              close size exceeds position (
+              {effUnit === 'usd' ? `${sig(posQty * mark)} USDT` : `${sig(posQty)} ${base}`})
+            </span>
+          )}
+          {mode === 'partial' && effUnit === 'usd' && !partialInvalid && qtyStr.trim() !== '' && (
+            // The converted figure is what actually goes to the venue, so it
+            // is shown rather than left to be inferred from the preview.
+            <span className="text-ink-500">
+              ≈ <span className="num">{sig(qtyNum)}</span> {base} at mark{' '}
+              <span className="num">{sig(mark)}</span>
+            </span>
+          )}
 
           {action && (
             <div className="flex flex-col gap-1 rounded-lg border border-ink-800 bg-ink-950/60 px-2.5 py-2">

--- a/web/src/trade/ClosePopover.tsx
+++ b/web/src/trade/ClosePopover.tsx
@@ -95,7 +95,17 @@ export function ClosePopover({
   const [unit, setUnit] = useState<'base' | 'usd'>(() =>
     shared ? 'base' : sizeUnitForBase(base),
   );
-  const mark = Number(position.markPrice);
+  /**
+   * ⚠ LATCHED at dialog open, not read live. The `position` prop refreshes
+   * from the 4s positions poll while the dialog is up, and `effUnit` below is
+   * derived from the mark — so a mark that turned empty/zero mid-dialog would
+   * silently re-read a typed "$300" as 300 COINS (and a recovering mark would
+   * divide typed coins by it), with only the label quietly changing. The
+   * conversion price the user was shown when they started typing is the one
+   * every read uses until the dialog closes; the preview below still quotes
+   * live prices server-side.
+   */
+  const [mark] = useState(() => Number(position.markPrice));
   const markOk = Number.isFinite(mark) && mark > 0;
   /**
    * ⚠ USD is only a legal unit while there is a mark to convert AT.
@@ -129,12 +139,24 @@ export function ClosePopover({
    * option is not offered at all, so this cannot silently divide by a stale or
    * zero price.
    */
-  const qtyNum = effUnit === 'usd' ? entered / mark : entered;
+  const rawQty = effUnit === 'usd' ? entered / mark : entered;
+  /**
+   * The displayed maximum is `sig()`-rounded to-nearest, so typing the
+   * dialog's OWN stated limit ("≤ 151.2019") can convert to a hair above
+   * `posQty` — refusing it would reject the very figure the placeholder and
+   * the error message name. Sizes within rounding distance are accepted and
+   * clamped to the position, so nothing can over-close.
+   */
+  const qtyNum = Math.min(rawQty, posQty);
   const partialMissing = mode === 'partial' && qtyStr.trim() === '';
   const partialInvalid =
     mode === 'partial' &&
     qtyStr.trim() !== '' &&
-    (!Number.isFinite(entered) || entered <= 0 || !Number.isFinite(qtyNum) || qtyNum <= 0 || qtyNum > posQty);
+    (!Number.isFinite(entered) ||
+      entered <= 0 ||
+      !Number.isFinite(rawQty) ||
+      rawQty <= 0 ||
+      rawQty > posQty * (1 + 1e-6));
 
   const action = useMemo<ActionInput | null>(() => {
     if (slipInvalid || partialMissing || partialInvalid) return null;

--- a/web/src/trade/PairTicket.test.tsx
+++ b/web/src/trade/PairTicket.test.tsx
@@ -490,6 +490,56 @@ describe('PairTicket idempotency across remount', () => {
     // dedupes it into the ORIGINAL deal instead of opening a second pair.
     expect(dealCalls[1].id).toBe(dealCalls[0].id);
   });
+
+  it('mints a NEW deal id when the size UNIT changes — the same digits are a different order', async () => {
+    /**
+     * The mirror of the test above, and the more dangerous direction.
+     *
+     * `sizeUnit` decides whether the box's digits go on the wire as `qty`
+     * (coins) or `notional` (USD), and the toggle deliberately keeps the
+     * figure. With the unit missing from `intentKey`, a lost-response confirm
+     * followed by USDT→ETH produced a byte-identical key: the persisted id was
+     * resent, the server deduped it, and the user was shown "2000 ETH" while
+     * the original $2000 order stood — displayed size ≠ executed size, by the
+     * coin price.
+     */
+    const dealCalls: DealRequest[] = [];
+    server.use(
+      ...baseHandlers(),
+      ...ethSymbolHandlers(),
+      previewHandler({ calls: [] }),
+      http.post('/api/deals', async ({ request }) => {
+        dealCalls.push((await request.json()) as DealRequest);
+        return HttpResponse.json(
+          { ok: false, error: { category: 'network', message: 'socket hang up', retryable: true } },
+          { status: 500 },
+        );
+      }),
+    );
+
+    renderWithClient(<PairTicket />);
+    await fillTwoVenuePair(); // leaves the box in USDT at 1000
+    await waitFor(() => expect(screen.getByLabelText(/Maker price/)).toHaveValue('2497'), { timeout: 4000 });
+    const btn = screen.getByRole('button', { name: 'Execute pair ▸' });
+    await waitFor(() => expect(btn).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(btn);
+    await waitFor(() => expect(dealCalls).toHaveLength(1), { timeout: 2_000 });
+
+    // Same digits, different unit — the toggle keeps "1000" in the box.
+    await userEvent.click(
+      within(screen.getByRole('radiogroup', { name: 'Size unit' })).getByRole('radio', { name: 'ETH' }),
+    );
+    expect(screen.getByLabelText('Size per leg (ETH)')).toHaveValue('1000');
+
+    const btn2 = screen.getByRole('button', { name: 'Execute pair ▸' });
+    await waitFor(() => expect(btn2).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(btn2);
+    await waitFor(() => expect(dealCalls).toHaveLength(2), { timeout: 2_000 });
+
+    // A different order ⇒ a different id, so the server cannot dedupe it into
+    // the dollar-denominated one.
+    expect(dealCalls[1].id).not.toBe(dealCalls[0].id);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -673,5 +723,63 @@ describe('notional validation', () => {
     await userEvent.type(notional, '7668.31');
     expect(screen.queryByRole('alert')).toBeNull();
     expect(notional).not.toHaveAttribute('aria-invalid');
+  });
+});
+
+describe('PairTicket — the size unit follows the coin', () => {
+  it('defaults ETH to the coin and HYPE to dollars, and re-follows after a prefill', async () => {
+    /**
+     * The unit is half of a hedge, not a preference: ETH/BTC are coin-margined
+     * on Boros so the perp is sized in the coin, every other coin is
+     * USDT-collateral so both legs share the dollar figure.
+     *
+     * The regression this pins: a prefill PINS the unit (it puts one number in
+     * the box and names its unit). The rail's ticket is never remounted, so a
+     * pin that outlived its prefill left every LATER manual coin change stuck
+     * on the previous coin's unit — a HYPE pair sized in "ETH".
+     */
+    server.use(...baseHandlers(), ...ethSymbolHandlers(), previewHandler({ calls: [] }));
+    renderWithClient(
+      <PrefillHarness
+        prefills={[{ base: 'ETH', longVenue: 'OKX', shortVenue: 'GATE', notionalUsd: 1234.6 }]}
+      />,
+    );
+
+    // The prefill carries no base quantity, so it honestly falls back to USD
+    // and pins that — the box must NOT be relabelled ETH under its own figure.
+    await userEvent.click(screen.getByRole('button', { name: 'fire-0' }));
+    await waitFor(() => expect(screen.getByLabelText('Size per leg (USDT)')).toHaveValue('1235'));
+
+    // Now the user picks a DIFFERENT coin by hand. The pin belonged to the
+    // prefill and must not survive it — HYPE is USDT-collateral on Boros, so
+    // dollars is right here and stays right.
+    await userEvent.click(screen.getByRole('button', { name: 'HYPE' }));
+    await waitFor(() => expect(screen.getByLabelText('Size per leg (USDT)')).toBeInTheDocument());
+
+    // And back to a coin-margined one: the box must follow to ETH, which is
+    // what the stuck pin prevented.
+    await userEvent.click(screen.getByRole('button', { name: 'ETH' }));
+    await waitFor(() => expect(screen.getByLabelText('Size per leg (ETH)')).toBeInTheDocument());
+  });
+
+  it('clears the size when the coin changes — a USD figure is never relabelled as coins', async () => {
+    /**
+     * Releasing the unit pin without clearing the number turns "2000" typed as
+     * DOLLARS for HYPE into 2000 ETH the moment ETH is picked — and `sizeField`
+     * flips the wire key from `notional` to `qty`, mis-sizing the order by a
+     * factor of the coin price.
+     */
+    server.use(...baseHandlers(), ...ethSymbolHandlers(), previewHandler({ calls: [] }));
+    renderWithClient(<PairTicket />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'HYPE' }));
+    const usdBox = await screen.findByLabelText('Size per leg (USDT)');
+    await userEvent.type(usdBox, '2000');
+    expect(usdBox).toHaveValue('2000');
+
+    await userEvent.click(screen.getByRole('button', { name: 'ETH' }));
+    // The unit follows the new coin — and the old coin's figure does not.
+    const ethBox = await screen.findByLabelText('Size per leg (ETH)');
+    expect(ethBox).toHaveValue('');
   });
 });

--- a/web/src/trade/PairTicket.tsx
+++ b/web/src/trade/PairTicket.tsx
@@ -14,6 +14,7 @@ import { useSymbolDetail, useSymbolsByBase } from '../api/queries';
 import type { ActionInput, PreviewResult, RestEstimate } from '../api/types';
 import { SegmentedToggle } from '../components/SegmentedToggle';
 import { amountError } from '../lib/amount';
+import { sizeUnitForBase } from '../lib/boros';
 import { fmtUsd } from '../lib/fmt';
 import { uuid } from '../lib/uuid';
 import { ExecuteControl } from './ExecuteControl';
@@ -43,7 +44,9 @@ function restOffsetPrice(rest: RestEstimate, isBuy: boolean): number {
   return px > 0 ? Number(px.toFixed(12)) : touch;
 }
 
-export function PairTicket() {
+/** `onExecuted` fires once the pair is ACCEPTED (the 202 that opens the deal
+ * view) — execution itself is asynchronous and tracked by the DealModal. */
+export function PairTicket({ onExecuted }: { onExecuted?: () => void } = {}) {
   const [base, setBase] = useState<string | null>(null);
   const [longSym, setLongSym] = useState<string | null>(null);
   const [shortSym, setShortSym] = useState<string | null>(null);
@@ -55,12 +58,17 @@ export function PairTicket() {
    * has always taken either — `resolveQty` converts notional→qty at preview —
    * so this is a labelling and routing choice, not new sizing maths.
    *
-   * Base leads because it is what makes a hedge EXACT: the Boros leg of an
-   * ETH-collateral market is denominated in ETH, so sizing the perp in USDT
-   * meant eyeballing an FX conversion to make the two legs match, and any
-   * error showed up later as a position the card flags as imbalanced.
+   * The default follows the coin, not a fixed preference: it is what makes a
+   * hedge EXACT. An ETH-collateral Boros leg is denominated in ETH, so sizing
+   * its perp in USDT means eyeballing an FX conversion and the error surfaces
+   * later as a position the card flags as imbalanced. But the same argument
+   * runs the other way for every USDT-collateral coin (HYPE and the rest),
+   * where 'base' was imposing exactly that needless conversion — the Boros
+   * side is in dollars, so the perp box should be too. See sizeUnitForBase.
    */
-  const [sizeUnit, setSizeUnit] = useState<'base' | 'usd'>('base');
+  const [sizeUnit, setSizeUnit] = useState<'base' | 'usd'>('usd');
+  /** True once the user picks the unit by hand — stop following the coin. */
+  const [unitPinned, setUnitPinned] = useState(false);
   const [nonce, setNonce] = useState(0);
   const flow = useTradeFlowOptional();
   const [mode, setMode] = useState<ExecMode>('maker');
@@ -68,6 +76,22 @@ export function PairTicket() {
   /** True once the user typed a price — stop auto-tracking the touch. */
   const [pricePinned, setPricePinned] = useState(false);
   const [timeoutSec, setTimeoutSec] = useState<TimeoutChoice>('300');
+
+  /**
+   * Follow the coin until the user says otherwise.
+   *
+   * The size box is not a preference, it is half of a hedge: the unit that
+   * makes the two legs match is a property of the coin's Boros market, so it
+   * has to move when the coin does. Pinned the moment the toggle is touched —
+   * an explicit choice must never be overwritten by picking a venue.
+   *
+   * A prefill pins too (see below): it puts one number in the box and names
+   * its unit, so the coin must not relabel it afterwards.
+   */
+  useEffect(() => {
+    if (unitPinned || !base) return;
+    setSizeUnit(sizeUnitForBase(base));
+  }, [base, unitPinned]);
 
   const venues = useSymbolsByBase(base);
   const longDetail = useSymbolDetail(longSym);
@@ -105,6 +129,17 @@ export function PairTicket() {
       setSizeUnit('usd');
       setNotionalStr(String(Math.max(1, Math.round(prefill.notionalUsd))));
     }
+    /**
+     * ⚠ PIN it. The caller has just put ONE number in the box and named its
+     * unit; the coin-following effect must not then relabel that number.
+     *
+     * The case that bites is an ETH prefill carrying no base quantity: it
+     * falls back to the USD figure above, and an unpinned effect would flip
+     * the unit to ETH underneath it — reading $1,235 as 1,235 ETH. The prefill
+     * is always the more specific answer, because callers that know the Boros
+     * collateral derive the unit from it rather than from the coin.
+     */
+    setUnitPinned(true);
     // Same invariant as the manual mode toggle: a mode switch un-pins the price
     // so the maker leg resumes tracking the touch.
     if (prefill.mode) {
@@ -269,7 +304,10 @@ export function PairTicket() {
       ? acts.map((a) => (a.kind === 'open-limit' && a.pairRole === 'maker' ? { ...a, pegToTouch: true } : a))
       : acts;
 
-  const stageDone = () => setNonce((n) => n + 1); // next pair gets a fresh group id
+  const stageDone = () => {
+    setNonce((n) => n + 1); // next pair gets a fresh group id
+    onExecuted?.();
+  };
 
   // Total initial margin the pair posts — Σ notional/leverage over the open
   // legs, from the same estimator the execute gate uses.
@@ -283,11 +321,25 @@ export function PairTicket() {
           setBase(b);
           setLongSym(null);
           setShortSym(null);
+          // ⚠ Release the prefill's pin — AND clear the number with it.
+          //
+          // The pin stops the coin relabelling a figure the CALLER put in the
+          // box; picking a coin by hand ends that, and the new coin's own unit
+          // must win. But releasing alone would relabel whatever is already
+          // typed: "2000" meant as dollars for HYPE becomes 2000 ETH the
+          // moment ETH is picked, and `sizeField` flips the wire key from
+          // `notional` to `qty` — the exact factor-of-the-coin-price mis-size
+          // that key pair exists to prevent. The size belonged to the old
+          // coin; it does not survive the switch.
+          setUnitPinned(false);
+          setNotionalStr('');
         }}
         onClear={() => {
           setBase(null);
           setLongSym(null);
           setShortSym(null);
+          setUnitPinned(false);
+          setNotionalStr('');
         }}
       />
 
@@ -319,18 +371,22 @@ export function PairTicket() {
           <label htmlFor="pair-notional" className="text-[11px] text-ink-400">
             Size per leg{base || sizeUnit === 'usd' ? ` (${sizeUnit === 'base' ? base : 'USDT'})` : ''}
           </label>
-          {/* Sizing in the BASE coin is what makes the hedge exact — the Boros
-              leg of an ETH-collateral market is denominated in ETH, so a USDT
-              perp size had to be converted by eye. The toggle stays because a
-              USD-collateral market (HYPE) genuinely wants the USD figure, and
-              because some users think in notional regardless. */}
+          {/* The unit follows the coin (see sizeUnitForBase): ETH/BTC are
+              coin-margined on Boros, so the perp is sized in the coin and the
+              hedge is exact; every other coin is USDT-collateral there, so the
+              dollar figure is the one both legs share. The toggle stays because
+              some users think in notional regardless — and once used, it pins. */}
           {/* No coin picked yet ⇒ nothing sensible to call the base unit, so
               the choice is withheld rather than shown as "Base". */}
           {base && (
           <SegmentedToggle<'base' | 'usd'>
             ariaLabel="Size unit"
             value={sizeUnit}
-            onChange={setSizeUnit}
+            onChange={(u) => {
+              // An explicit choice wins over the coin's default from here on.
+              setUnitPinned(true);
+              setSizeUnit(u);
+            }}
             options={[
               // Always the actual coin (ETH / BTC) — "Base" is jargon that
               // names a role rather than the unit the number is in. Before a
@@ -458,10 +514,19 @@ export function PairTicket() {
         // pair. The group id still rides in the actions (it only labels the
         // executed legs as one group); POST /deals dedupes on the deal id alone,
         // so a recovered resend with a different group id is still a no-op.
+        // ⚠ `sizeUnit` is part of the intent, not presentation. It decides
+        // whether the SAME digits go on the wire as `qty` (base coin) or
+        // `notional` (USD) — a factor-of-the-coin-price difference — and the
+        // toggle deliberately keeps the figure. Without it here, a
+        // lost-response confirm followed by a unit flip produced a
+        // byte-identical key, so the recovered basketId was resent and the
+        // server deduped it: the user was shown "2000 ETH" while the ORIGINAL
+        // $2000 order stood.
         intentKey={[
           longSym,
           shortSym,
           notionalStr,
+          sizeUnit,
           mode,
           makerLegPick,
           timeoutSec,

--- a/web/src/trade/SingleTicket.test.tsx
+++ b/web/src/trade/SingleTicket.test.tsx
@@ -268,7 +268,9 @@ describe('no Review card on a single order', () => {
     server.use(...baseHandlers(), ...btcSymbolHandlers(), echoPreviewHandler());
     renderWithClient(<SingleTicket />);
     await pickBinanceBtc();
-    await userEvent.type(screen.getByPlaceholderText(/notional/), '500');
+    // BTC is coin-margined on Boros, so the box defaults to the coin — the
+    // same rule the pair ticket follows, so one strategy is sized in one unit.
+    await userEvent.type(screen.getByPlaceholderText(/qty \(BTC\)/), '0.01');
 
     const execute = await screen.findByRole('button', { name: /Execute now/ });
     await userEvent.hover(execute);
@@ -278,5 +280,24 @@ describe('no Review card on a single order', () => {
     expect(screen.queryByRole('tooltip')).toBeNull();
     // The inline preview is still there — nothing was lost by removing it.
     expect(await screen.findByText(/est fee/)).toBeInTheDocument();
+  });
+});
+
+describe('SingleTicket — the size unit follows the coin', () => {
+  it('defaults BTC to the coin, and the toggle still wins', async () => {
+    /**
+     * Same rule as the pair ticket (`sizeUnitForBase`): BTC/ETH are
+     * coin-margined on Boros, so sizing the perp in the coin makes the hedge
+     * exact instead of an eyeballed FX step. The Single ticket used to
+     * hardcode USDT regardless of coin.
+     */
+    server.use(...baseHandlers(), ...btcSymbolHandlers(), echoPreviewHandler());
+    renderWithClient(<SingleTicket />);
+    await pickBinanceBtc();
+
+    expect(await screen.findByPlaceholderText(/qty \(BTC\)/)).toBeInTheDocument();
+    // An explicit choice still overrides the default.
+    await userEvent.click(screen.getByRole('radio', { name: 'USDT' }));
+    expect(screen.getByPlaceholderText(/notional/)).toBeInTheDocument();
   });
 });

--- a/web/src/trade/SingleTicket.tsx
+++ b/web/src/trade/SingleTicket.tsx
@@ -11,6 +11,7 @@ import type { ActionInput, Side } from '../api/types';
 import { SegmentedToggle } from '../components/SegmentedToggle';
 import { fmtUsd, parseSymbol, sig } from '../lib/fmt';
 import { amountError } from '../lib/amount';
+import { sizeUnitForBase } from '../lib/boros';
 import { formatRestPrice } from '../lib/ticks';
 import { ExecuteControl } from './ExecuteControl';
 import { feeText, PreviewFallback, SlippageBadge, ViolationList } from './previewBits';
@@ -46,6 +47,8 @@ export function SingleTicket() {
   const [side, setSide] = useState<Side>('BUY');
   const [type, setType] = useState<'MARKET' | 'LIMIT'>('MARKET');
   const [sizeMode, setSizeMode] = useState<SizeMode>('usdt');
+  /** True once the unit is chosen explicitly — by the toggle or a prefill. */
+  const [unitPinned, setUnitPinned] = useState(false);
   const [sizeStr, setSizeStr] = useState('');
   const [priceStr, setPriceStr] = useState('');
   const [priceFlash, setPriceFlash] = useState(false);
@@ -87,6 +90,10 @@ export function SingleTicket() {
       setSizeMode('usdt');
       setSizeStr(String(Math.max(1, Math.round(perpPrefill.notionalUsd))));
     }
+    // The caller put ONE number in the box and named its unit; the coin must
+    // not relabel it afterwards. (Released when the user picks a coin/symbol
+    // by hand — see the effect below.)
+    setUnitPinned(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prefillNonce]);
 
@@ -107,6 +114,16 @@ export function SingleTicket() {
   const detail = useSymbolDetail(symbol);
 
   const base = symbol ? parseSymbol(symbol).base : '';
+  /**
+   * Follow the coin, exactly as the pair ticket does: ETH/BTC are coin-margined
+   * on Boros so the perp is sized in the coin and the hedge is exact; every
+   * other coin is USDT-collateral there, so dollars is the unit both legs
+   * share. Only until the unit is chosen explicitly.
+   */
+  useEffect(() => {
+    if (unitPinned || !base) return;
+    setSizeMode(sizeUnitForBase(base) === 'base' ? 'base' : 'usdt');
+  }, [base, unitPinned]);
   const sizeNum = Number(sizeStr);
   const sizeErr = amountError(sizeStr);
   const sizeOk = Number.isFinite(sizeNum) && sizeNum > 0;
@@ -187,7 +204,24 @@ export function SingleTicket() {
 
   return (
     <div className="flex flex-col gap-3">
-      <SymbolCombobox value={symbol} onSelect={setSymbol} onClear={() => setSymbol(null)} />
+      <SymbolCombobox
+        value={symbol}
+        // Picking a symbol by hand ends the prefill's claim on the unit: the
+        // new coin's own default must win, or the ticket stays stuck on the
+        // last prefill's unit for the life of the (never-remounted) drawer.
+        onSelect={(sym) => {
+          setSymbol(sym);
+          // See PairTicket: releasing the pin without clearing the figure
+          // would relabel a USD number as coins (and flip `notional`→`qty`).
+          setUnitPinned(false);
+          setSizeStr('');
+        }}
+        onClear={() => {
+          setSymbol(null);
+          setUnitPinned(false);
+          setSizeStr('');
+        }}
+      />
       <SideToggle value={side} onChange={changeSide} />
       <SegmentedToggle<'MARKET' | 'LIMIT'>
         ariaLabel="Order type"
@@ -207,7 +241,11 @@ export function SingleTicket() {
           <SegmentedToggle<SizeMode>
             ariaLabel="Size mode"
             value={sizeMode}
-            onChange={setSizeMode}
+            onChange={(m) => {
+              // An explicit choice wins over the coin's default from here on.
+              setUnitPinned(true);
+              setSizeMode(m);
+            }}
             options={[
               { value: 'usdt', label: <span className="text-xs">USDT</span> },
               { value: 'base', label: <span className="text-xs">{base || 'qty'}</span> },

--- a/web/src/trade/StrategyWizard.test.tsx
+++ b/web/src/trade/StrategyWizard.test.tsx
@@ -1,0 +1,298 @@
+/** The wizard's contract with the prefill channel: a fresh open arms step 1
+ * (the Boros pair) from the intent; a resume (initialStep 2) arms the perp
+ * ticket instead and never mounts the Boros one. Prefill→ticket mechanics are
+ * the tickets' own suites; panel→intent is the OpportunitiesPanel suite. */
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { useEffect, useRef } from 'react';
+import { describe, expect, it } from 'vitest';
+import { ETH_GATE, symbolHandlers } from '../test/fixtures';
+import { env, server } from '../test/server';
+import { renderWithClient } from '../test/utils';
+import { StrategyWizard } from './StrategyWizard';
+import { useTradeFlow, type StrategyWizardIntent } from './TradeFlow';
+
+const INTENT: StrategyWizardIntent = {
+  base: 'ETH',
+  borosLongVenue: 'BINANCE',
+  borosShortVenue: 'HYPERLIQUID',
+  maturity: 1_760_000_000,
+  // Deliberately unmapped venues: the perp legs stay unselected, so no
+  // preview fires and the test needs no preview handler.
+  crossexLongVenue: 'OKX',
+  crossexShortVenue: 'GATE',
+  notionalUsd: 10_000,
+  perpMode: 'maker',
+};
+
+/** No agent, no tracked address: the Boros ticket renders its connect prompt
+ * and prices nothing — the wizard's own prefill still fires. */
+const agentHandlers = () => [
+  http.get('/api/boros/agent', () =>
+    HttpResponse.json(
+      env({
+        configured: false,
+        root: null,
+        rootMasked: null,
+        accountId: 0,
+        expiry: null,
+        expired: false,
+        canProvision: true,
+      }),
+    ),
+  ),
+  http.get('/api/boros/pair/context', () => HttpResponse.json(env({ markets: [] }))),
+];
+
+const prefillsSeen: Array<{ kind: 'boros' | 'pair'; payload: Record<string, unknown> }> = [];
+function Probe() {
+  const flow = useTradeFlow();
+  const b = flow.borosOpenPrefill;
+  const p = flow.pairPrefill;
+  if (b && !prefillsSeen.some((x) => x.kind === 'boros' && x.payload.nonce === b.nonce))
+    prefillsSeen.push({ kind: 'boros', payload: { ...b } });
+  if (p && !prefillsSeen.some((x) => x.kind === 'pair' && x.payload.nonce === p.nonce))
+    prefillsSeen.push({ kind: 'pair', payload: { ...p } });
+  return null;
+}
+
+function Launch({ intent }: { intent: StrategyWizardIntent }) {
+  const flow = useTradeFlow();
+  const fired = useRef(false);
+  useEffect(() => {
+    if (fired.current) return;
+    fired.current = true;
+    flow.openWizard(intent);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return null;
+}
+
+const renderWizard = (intent: StrategyWizardIntent) => {
+  prefillsSeen.length = 0;
+  return renderWithClient(
+    <>
+      <Launch intent={intent} />
+      <StrategyWizard />
+      <Probe />
+    </>,
+  );
+};
+
+describe('StrategyWizard → prefills', () => {
+  it('a fresh open arms step 1 with the Boros pair — venues, maturity, size', async () => {
+    server.use(...agentHandlers(), ...symbolHandlers([ETH_GATE]));
+    renderWizard(INTENT);
+
+    await waitFor(() => expect(prefillsSeen).toHaveLength(1));
+    expect(prefillsSeen[0].kind).toBe('boros');
+    expect(prefillsSeen[0].payload).toMatchObject({
+      base: 'ETH',
+      longVenue: 'BINANCE',
+      shortVenue: 'HYPERLIQUID',
+      maturity: 1_760_000_000,
+      size: 10_000,
+    });
+    // Step 1 is the lit step; the perp ticket is not on screen yet.
+    expect(screen.getByText('Lock the rate')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Size per leg/)).not.toBeInTheDocument();
+  });
+
+  it('a resume (initialStep 2) arms the perp ticket and never mounts the Boros one', async () => {
+    server.use(...agentHandlers(), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...INTENT, initialStep: 2 });
+
+    await waitFor(() => expect(prefillsSeen).toHaveLength(1));
+    expect(prefillsSeen[0].kind).toBe('pair');
+    expect(prefillsSeen[0].payload).toMatchObject({
+      base: 'ETH',
+      longVenue: 'OKX',
+      shortVenue: 'GATE',
+      notionalUsd: 10_000,
+      mode: 'maker',
+    });
+    // The perp ticket is live at step 2; the Boros ticket is absent entirely —
+    // those rate legs already exist as a position.
+    expect(screen.getByLabelText(/Size per leg/)).toBeInTheDocument();
+    expect(screen.queryByRole('radiogroup', { name: 'Boros ticket mode' })).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A succeeded step is a receipt, not a form
+// ---------------------------------------------------------------------------
+
+const HL_M = 155;
+const BN_M = 158;
+const MAT = 1_800_000_000;
+const market = (over: Record<string, unknown> = {}) => ({
+  marketId: HL_M,
+  name: 'Hyperliquid ETH 31 Aug 2026',
+  venue: 'HYPERLIQUID',
+  base: 'ETH',
+  tokenId: 3,
+  collateral: 'USDT',
+  maturity: MAT,
+  midApr: 0.09,
+  markApr: 0.09,
+  maxRateDeviationApr: 0.02,
+  isolatedOnly: false,
+  onIsolatedMargin: false,
+  isolatedHasPositionOrOrders: false,
+  currentSize: 0,
+  collateralPriceUsd: 1,
+  ...over,
+});
+
+/** A wizard whose Boros step can actually be filled and executed. */
+const tradableHandlers = (result: Record<string, unknown>, collateral = 'USDT') => [
+  http.get('/api/boros/agent', () =>
+    HttpResponse.json(
+      env({
+        configured: true,
+        root: '0x1111111111111111111111111111111111111111',
+        rootMasked: '0x1111…1111',
+        accountId: 0,
+        expiry: null,
+        expired: false,
+        canProvision: true,
+      }),
+    ),
+  ),
+  http.get('/api/boros/pair/context', () =>
+    HttpResponse.json(
+      env({
+        markets: [market({ collateral }), market({ marketId: BN_M, name: 'Binance ETH 31 Aug 2026', venue: 'BINANCE', collateral })],
+        crossByToken: [{ tokenId: 3, available: 500_000 }],
+        isolatedByMarket: [],
+        defaultSlippageApr: 0.0025,
+        maxSlippageApr: 0.1,
+      }),
+    ),
+  ),
+  http.post('/api/boros/pair/simulate', () =>
+    HttpResponse.json(
+      env({
+        simulation: {
+          collateral,
+          spreadApr: 0.045,
+          worstCaseSpreadApr: 0.02,
+          legA: { marketId: HL_M, direction: 'short', execApr: 0.09, feeSize: 4, marginRequired: 1, sizing: { currentSize: 0, resultingSize: -1000, flips: false } },
+          legB: { marketId: BN_M, direction: 'long', execApr: 0.042, feeSize: 4, marginRequired: 1, sizing: { currentSize: 0, resultingSize: 1000, flips: false } },
+          takerFeeSize: 8,
+          costToCrossSize: 0,
+          feeDragApr: 0.003,
+          marginRequiredTotal: 2,
+          hedgedSize: 1000,
+          unhedgedSize: 0,
+          collateralPriceUsd: 1,
+          secondsToMaturity: 1_000_000,
+          reasons: [],
+        },
+        gate: { blockers: [], warnings: [], requiresAcknowledgement: false, opposingLegs: [] },
+        eligibility: { eligible: true, code: null, reason: null },
+        simulatedAtMs: Date.now(),
+        gasBalanceUsd: 100,
+      }),
+    ),
+  ),
+  http.post('/api/boros/pair/execute', () =>
+    HttpResponse.json(env({ result, estimate: null, warnings: [] })),
+  ),
+];
+
+const CLEAN_FILL = {
+  legA: { marketId: HL_M, direction: 'short', filledSize: 1000, shortfallSize: 0, execApr: 0.09, feeSize: 4, failure: null },
+  legB: { marketId: BN_M, direction: 'long', filledSize: 1000, shortfallSize: 0, execApr: 0.042, feeSize: 4, failure: null },
+  hedgedSize: 1000,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: 0.045,
+  partial: false,
+  bothLegsSubmitted: true,
+};
+
+describe('StrategyWizard — the hedge is sized off the EXECUTED collateral', () => {
+  it('an ETH-collateral fill with no sizeBase arms the perps in DOLLARS, not the coin count', async () => {
+    /**
+     * The old branch asked "did the caller supply a base quantity?" — which is
+     * a question about what the OPPORTUNITY card knew, not about the market
+     * that traded. An ETH cohort whose collateral price is unavailable arrives
+     * with no `sizeBase`, so a 2-ETH fill fell into the "USD-margined" branch
+     * and armed the perp pair at $2 against a ~$9,000 rate leg.
+     *
+     * With no conversion available the honest move is to keep the intent's USD
+     * figure, never to pass a coin count as dollars.
+     */
+    const ethFill = {
+      ...CLEAN_FILL,
+      hedgedSize: 2, // 2 ETH
+    };
+    server.use(...tradableHandlers(ethFill, 'ETH'), ...symbolHandlers([ETH_GATE]));
+    renderWizard({
+      ...INTENT,
+      maturity: MAT,
+      borosLongVenue: 'BINANCE',
+      borosShortVenue: 'HYPERLIQUID',
+      notionalUsd: 9000,
+      sizeBase: undefined, // no collateral price ⇒ the card could not convert
+    });
+
+    await waitFor(() => expect(screen.getByLabelText('Leg A')).toHaveValue(String(BN_M)));
+    // With no `sizeBase` the prefill leaves the size empty (it has no coin
+    // quantity to put there) — the user types the ETH size themselves. That
+    // is precisely the path that produced the mis-sized hedge.
+    fireEvent.change(screen.getByLabelText(/^Size per leg/), { target: { value: '2' } });
+
+    const confirm = await screen.findByRole('button', { name: /Confirm — 2 Boros market orders/ });
+    await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(confirm);
+
+    await screen.findByRole('button', { name: /Rate locked/ }, { timeout: 4000 });
+    fireEvent.click(screen.getByRole('button', { name: /Rate locked/ }));
+
+    // The perp prefill carries the USD intent (9000), NOT the 2-coin fill.
+    await waitFor(() => {
+      const pair = prefillsSeen.find((x) => x.kind === 'pair');
+      expect(pair?.payload.notionalUsd).toBe(9000);
+    });
+    const pair = prefillsSeen.find((x) => x.kind === 'pair');
+    expect(pair?.payload.sizeBase).toBeUndefined();
+  });
+});
+
+describe('StrategyWizard — step 1 becomes a receipt once the rate is locked', () => {
+  it('replaces the Boros form with the fill summary — ONE CTA, not two', async () => {
+    /**
+     * The bug this pins: the ticket stayed mounted and ARMED under the wizard's
+     * advance button, so the modal showed both `Confirm — 2 Boros market
+     * orders` and `Rate locked ✓ — hedge the perps`. The same pair could then
+     * be fired a second time by a user the wizard had just told the rate was
+     * locked.
+     */
+    server.use(...tradableHandlers(CLEAN_FILL), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...INTENT, maturity: MAT, borosLongVenue: 'BINANCE', borosShortVenue: 'HYPERLIQUID' });
+
+    // The wizard's own prefill arms both legs and the size; just wait for it.
+    await waitFor(() =>
+      expect(screen.getByLabelText('Leg A')).toHaveValue(String(BN_M)),
+    );
+    expect(screen.getByLabelText('Leg B')).toHaveValue(String(HL_M));
+
+    const confirm = await screen.findByRole('button', { name: /Confirm — 2 Boros market orders/ });
+    await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(confirm);
+
+    // The receipt appears…
+    await screen.findByText(/1,000 USDT hedged/, undefined, { timeout: 4000 });
+    // …and the form is GONE: no confirm, no size box, nothing to re-fire.
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /Confirm — 2 Boros market orders/ })).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByLabelText(/^Size per leg/)).not.toBeInTheDocument();
+    // Exactly one way forward.
+    expect(screen.getByRole('button', { name: /Rate locked ✓ — hedge the perps/ })).toBeInTheDocument();
+    // And no Dismiss — the receipt IS the step; hiding it would blank it.
+    expect(screen.queryByRole('button', { name: 'Dismiss' })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/trade/StrategyWizard.test.tsx
+++ b/web/src/trade/StrategyWizard.test.tsx
@@ -145,7 +145,16 @@ const market = (over: Record<string, unknown> = {}) => ({
 });
 
 /** A wizard whose Boros step can actually be filled and executed. */
-const tradableHandlers = (result: Record<string, unknown>, collateral = 'USDT') => [
+/** Pass an ARRAY of results to script SEQUENTIAL executions (a partial then
+ * its completion, a retry, a close): call N answers with results[N], and the
+ * last one repeats. A single result behaves as before. */
+const tradableHandlers = (result: Record<string, unknown> | Record<string, unknown>[], collateral = 'USDT') => {
+  const sequence = Array.isArray(result) ? result : [result];
+  let call = 0;
+  return tradableHandlersSeq(() => sequence[Math.min(call++, sequence.length - 1)], collateral);
+};
+
+const tradableHandlersSeq = (next: () => Record<string, unknown>, collateral: string) => [
   http.get('/api/boros/agent', () =>
     HttpResponse.json(
       env({
@@ -197,7 +206,7 @@ const tradableHandlers = (result: Record<string, unknown>, collateral = 'USDT') 
     ),
   ),
   http.post('/api/boros/pair/execute', () =>
-    HttpResponse.json(env({ result, estimate: null, warnings: [] })),
+    HttpResponse.json(env({ result: next(), estimate: null, warnings: [] })),
   ),
 ];
 
@@ -295,4 +304,375 @@ describe('StrategyWizard — step 1 becomes a receipt once the rate is locked', 
     // And no Dismiss — the receipt IS the step; hiding it would blank it.
     expect(screen.queryByRole('button', { name: 'Dismiss' })).not.toBeInTheDocument();
   });
+});
+
+// ---------------------------------------------------------------------------
+// The step-1 BOOK: every execution folds; "locked" means the book is clean
+// ---------------------------------------------------------------------------
+
+/** The sentinel a not-submitted leg comes back as (orders.ts `notSubmitted`). */
+const NOT_SUBMITTED = {
+  marketId: 0,
+  direction: 'short',
+  filledSize: 0,
+  shortfallSize: 0,
+  execApr: null,
+  feeSize: null,
+  failure: null,
+};
+
+/** Both legs venue-rejected: fills 0 under a 200. The old receipt gate read
+ * `unhedgedSize > 0`, which is 0 here — and showed "Rate locked ✓". */
+const ZERO_FILL = {
+  legA: { marketId: HL_M, direction: 'short', filledSize: 0, shortfallSize: 1000, execApr: null, feeSize: null, failure: { code: 'rate-deviation', message: 'rate moved beyond the band' } },
+  legB: { marketId: BN_M, direction: 'long', filledSize: 0, shortfallSize: 1000, execApr: null, feeSize: null, failure: { code: 'rate-deviation', message: 'rate moved beyond the band' } },
+  hedgedSize: 0,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: null,
+  partial: true,
+  bothLegsSubmitted: true,
+};
+
+/** Leg A fills whole, leg B falls 400 short: 600 hedged, 400 directional. */
+const PARTIAL_600 = {
+  legA: { marketId: HL_M, direction: 'short', filledSize: 1000, shortfallSize: 0, execApr: 0.09, feeSize: 4, failure: null },
+  legB: { marketId: BN_M, direction: 'long', filledSize: 600, shortfallSize: 400, execApr: 0.042, feeSize: 3, failure: null },
+  hedgedSize: 600,
+  unhedgedSize: 400,
+  unhedgedLeg: 'A',
+  realisedSpreadApr: null,
+  partial: true,
+  bothLegsSubmitted: true,
+};
+
+/** The 400-unit one-leg completion of PARTIAL_600's deficient leg B. */
+const COMPLETION_400 = {
+  legA: NOT_SUBMITTED,
+  legB: { marketId: BN_M, direction: 'long', filledSize: 400, shortfallSize: 0, execApr: 0.041, feeSize: 2, failure: null },
+  hedgedSize: 0,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: null,
+  partial: false,
+  bothLegsSubmitted: false,
+};
+
+/** The same completion, FAILED at the venue — still a 200. */
+const COMPLETION_FAIL = {
+  legA: NOT_SUBMITTED,
+  legB: { marketId: BN_M, direction: 'long', filledSize: 0, shortfallSize: 400, execApr: null, feeSize: null, failure: { code: 'insufficient-depth', message: 'not enough depth inside the band' } },
+  hedgedSize: 0,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: null,
+  partial: true,
+  bothLegsSubmitted: false,
+};
+
+/** Both legs short by DIFFERENT amounts: 500 hedged, 200 directional. */
+const UNEVEN_PARTIAL = {
+  legA: { marketId: HL_M, direction: 'short', filledSize: 700, shortfallSize: 300, execApr: 0.09, feeSize: 3, failure: null },
+  legB: { marketId: BN_M, direction: 'long', filledSize: 500, shortfallSize: 500, execApr: 0.042, feeSize: 2, failure: null },
+  hedgedSize: 500,
+  unhedgedSize: 200,
+  unhedgedLeg: 'A',
+  realisedSpreadApr: null,
+  partial: true,
+  bothLegsSubmitted: true,
+};
+
+/** The pair-shaped retry Retry arms for UNEVEN_PARTIAL (min shortfall 300),
+ * filling clean. The book is then 1000/800 — still 200 directional. */
+const RETRY_300 = {
+  legA: { marketId: HL_M, direction: 'short', filledSize: 300, shortfallSize: 0, execApr: 0.088, feeSize: 1, failure: null },
+  legB: { marketId: BN_M, direction: 'long', filledSize: 300, shortfallSize: 0, execApr: 0.043, feeSize: 1, failure: null },
+  hedgedSize: 300,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: 0.045,
+  partial: false,
+  bothLegsSubmitted: true,
+};
+
+/** A deliberate one-leg lock (the ticket's Single mode). */
+const SINGLE_LOCK = {
+  legA: { marketId: HL_M, direction: 'short', filledSize: 1000, shortfallSize: 0, execApr: 0.09, feeSize: 4, failure: null },
+  legB: NOT_SUBMITTED,
+  hedgedSize: 0,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: null,
+  partial: false,
+  bothLegsSubmitted: false,
+};
+
+/** The close that unwinds SINGLE_LOCK — opposite direction, same market. */
+const SINGLE_CLOSE = {
+  legA: { marketId: HL_M, direction: 'long', filledSize: 1000, shortfallSize: 0, execApr: 0.091, feeSize: 4, failure: null },
+  legB: NOT_SUBMITTED,
+  hedgedSize: 0,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: null,
+  partial: false,
+  bothLegsSubmitted: false,
+};
+
+const WIZ = { ...INTENT, maturity: MAT, borosLongVenue: 'BINANCE', borosShortVenue: 'HYPERLIQUID' };
+
+/** Arm, wait for the tradable state, hold-to-confirm the pair. */
+const confirmPair = async () => {
+  await waitFor(() => expect(screen.getByLabelText('Leg A')).toHaveValue(String(BN_M)));
+  const confirm = await screen.findByRole('button', { name: /Confirm — 2 Boros market orders/ });
+  await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 4000 });
+  fireEvent.pointerDown(confirm);
+};
+
+describe('StrategyWizard — the book decides, not the last result', () => {
+  it('a ZERO fill keeps the live ticket: no receipt, no Continue, Retry works', async () => {
+    /**
+     * The receipt gate used to read `unhedgedSize > 0`, and a both-legs-zero
+     * rejection reports unhedgedSize 0 — so nothing filled, the ticket
+     * unmounted, and "Rate locked ✓ — hedge the perps" armed a FULL-SIZE perp
+     * pair against a rate position that does not exist, over dead
+     * Complete/Retry buttons.
+     */
+    server.use(...tradableHandlers(ZERO_FILL), ...symbolHandlers([ETH_GATE]));
+    renderWizard(WIZ);
+    await confirmPair();
+
+    // The ticket's own failure report, with its REAL remediation…
+    expect(await screen.findByRole('button', { name: 'Retry' }, { timeout: 4000 })).toBeEnabled();
+    // …and nothing claiming a rate was locked.
+    expect(screen.queryByRole('button', { name: /Rate locked/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Continue anyway/ })).not.toBeInTheDocument();
+  }, 15_000);
+
+  it('a partial and its completion make ONE aggregate receipt, sizing the hedge', async () => {
+    /**
+     * The old merge kept the PRE-completion hedgedSize (600) and the receipt
+     * described whichever result came last — the book is what actually traded:
+     * 1000/1000 after the top-up.
+     */
+    server.use(...tradableHandlers([PARTIAL_600, COMPLETION_400]), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...WIZ, notionalUsd: 1000 });
+    await confirmPair();
+
+    // Partial: the wizard names the unmatched size and the ticket stays live.
+    expect(await screen.findByText(/400 USDT is unmatched/, undefined, { timeout: 4000 })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rate locked/ })).not.toBeInTheDocument();
+
+    // Complete the deficient leg through the ticket's own report.
+    fireEvent.click(screen.getByRole('button', { name: 'Complete now at market' }));
+    const complete = await screen.findByRole('button', { name: /^Confirm — complete leg/ }, { timeout: 4000 });
+    await waitFor(() => expect(complete).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(complete);
+
+    // ONE receipt, reading the AGGREGATE — not the 400 top-up, not the stale 600.
+    await screen.findByText(/1,000 USDT hedged/, undefined, { timeout: 4000 });
+    fireEvent.click(screen.getByRole('button', { name: /Rate locked/ }));
+    await waitFor(() => {
+      const pair = prefillsSeen.find((x) => x.kind === 'pair');
+      expect(pair?.payload.notionalUsd).toBe(1000);
+    });
+  }, 20_000);
+
+  it('a FAILED completion leaves the residual standing', async () => {
+    // The old merge zeroed unhedgedSize on ANY completion result — including
+    // one whose leg filled nothing — erasing a residual that still exists.
+    server.use(...tradableHandlers([PARTIAL_600, COMPLETION_FAIL]), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...WIZ, notionalUsd: 1000 });
+    await confirmPair();
+    await screen.findByText(/400 USDT is unmatched/, undefined, { timeout: 4000 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Complete now at market' }));
+    const complete = await screen.findByRole('button', { name: /^Confirm — complete leg/ }, { timeout: 4000 });
+    await waitFor(() => expect(complete).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(complete);
+
+    // The completion failed at the venue: the round-trip settles back into a
+    // live one-leg report with remediation (clicking Complete cleared the
+    // pair report, so this button is the failed completion's own)…
+    expect(
+      await screen.findByRole('button', { name: /Retry the rest/ }, { timeout: 4000 }),
+    ).toBeInTheDocument();
+    // …and the 400 stays flagged; nothing claims the rate is locked. (The old
+    // merge zeroed the residual here and rendered the receipt.)
+    expect(screen.getByText(/400 USDT is unmatched/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rate locked/ })).not.toBeInTheDocument();
+  }, 20_000);
+
+  it('a pair-shaped Retry ADDS to the book — the hedge is the aggregate', async () => {
+    /**
+     * Retry after a both-short partial re-arms a PAIR at the min shortfall,
+     * and its result REPLACED `locked`: the receipt read "300 hedged" and the
+     * perps armed at 300 against a true book of 1000/800.
+     */
+    server.use(...tradableHandlers([UNEVEN_PARTIAL, RETRY_300]), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...WIZ, notionalUsd: 1000 });
+    await confirmPair();
+    await screen.findByText(/200 USDT is unmatched/, undefined, { timeout: 4000 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    const retry = await screen.findByRole('button', { name: /Confirm — 2 Boros market orders/ }, { timeout: 4000 });
+    await waitFor(() => expect(retry).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(retry);
+
+    // The retry's own clean report shows inside the ticket (300 hedged)…
+    await screen.findByText(/300 USDT hedged/, undefined, { timeout: 4000 });
+    // …but the BOOK is 1000/800: still lopsided, still no "Rate locked ✓".
+    expect(screen.getByText(/200 USDT is unmatched/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rate locked/ })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue anyway/ }));
+    await waitFor(() => {
+      const pair = prefillsSeen.find((x) => x.kind === 'pair');
+      expect(pair?.payload.notionalUsd).toBe(800);
+    });
+  }, 20_000);
+
+  it('a single-leg lock is one-sided exposure — never "Rate locked ✓"', async () => {
+    // A one-leg result reports unhedgedSize 0, so the old gate read it as a
+    // clean pair lock and armed BOTH perp legs at the full intent size.
+    server.use(...tradableHandlers(SINGLE_LOCK), ...symbolHandlers([ETH_GATE]));
+    renderWizard(WIZ);
+    await waitFor(() => expect(screen.getByLabelText('Leg A')).toHaveValue(String(BN_M)));
+    fireEvent.click(screen.getByRole('radio', { name: 'Single' }));
+    const confirm = await screen.findByRole('button', { name: /Confirm — 1 Boros market order/ });
+    await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(confirm);
+
+    expect(
+      await screen.findByText(/Only one side of the rate pair is on/, undefined, { timeout: 4000 }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rate locked/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Continue anyway/ })).not.toBeInTheDocument();
+
+    // And leaving THIS is guarded: one leg on is exposure, whatever made it.
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(
+      await screen.findByText(/until the perp legs open you hold directional exposure/),
+    ).toBeInTheDocument();
+  }, 15_000);
+
+  it('a close through the wizard SUBTRACTS — a book closed to zero leaves silently', async () => {
+    server.use(...tradableHandlers([SINGLE_LOCK, SINGLE_CLOSE]), ...symbolHandlers([ETH_GATE]));
+    renderWizard(WIZ);
+    await waitFor(() => expect(screen.getByLabelText('Leg A')).toHaveValue(String(BN_M)));
+    fireEvent.click(screen.getByRole('radio', { name: 'Single' }));
+    const confirm = await screen.findByRole('button', { name: /Confirm — 1 Boros market order/ });
+    await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(confirm);
+    await screen.findByText(/Only one side of the rate pair is on/, undefined, { timeout: 4000 });
+
+    // Unwind it: dismiss the report (which clears the size — its point), flip
+    // the intent to Close, re-enter the size, execute.
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    fireEvent.click(screen.getByRole('radio', { name: /^Close/ }));
+    // Single-mode label is "Size (USDT)" — not the pair's "Size per leg".
+    fireEvent.change(screen.getByLabelText(/^Size \(/), { target: { value: '1000' } });
+    const confirm2 = await screen.findByRole('button', { name: /Confirm — 1 Boros market order/ });
+    await waitFor(() => expect(confirm2).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(confirm2);
+
+    // The book is flat again: the banner clears…
+    await waitFor(
+      () => expect(screen.queryByText(/Only one side of the rate pair is on/)).not.toBeInTheDocument(),
+      { timeout: 4000 },
+    );
+    // …and leaving needs no warning — nothing naked remains.
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByText('Open this strategy')).not.toBeInTheDocument());
+  }, 20_000);
+});
+
+describe('StrategyWizard — continue arms once per book state', () => {
+  it('Back → Continue with nothing new executed does NOT re-arm the perp ticket', async () => {
+    // Every Continue used to fire a fresh prefill, so re-reading the receipt
+    // and coming forward wiped the user's step-2 edits back to the fill size.
+    server.use(...tradableHandlers(CLEAN_FILL), ...symbolHandlers([ETH_GATE]));
+    renderWizard(WIZ);
+    await confirmPair();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Rate locked/ }, { timeout: 4000 }));
+    await waitFor(() => expect(prefillsSeen.filter((x) => x.kind === 'pair')).toHaveLength(1));
+
+    fireEvent.click(screen.getByRole('button', { name: /Back to the rate legs/ }));
+    fireEvent.click(await screen.findByRole('button', { name: /Rate locked/ }));
+    await screen.findByLabelText(/Size per leg/);
+    // Same book ⇒ same arm: still exactly one pair prefill.
+    expect(prefillsSeen.filter((x) => x.kind === 'pair')).toHaveLength(1);
+  }, 15_000);
+});
+
+describe('StrategyWizard — leaving and closing are deliberate', () => {
+  it('the leave warning cannot be walked through by a second Escape', async () => {
+    // Modal forwards Escape unfiltered, so a HELD key's auto-repeat (or a
+    // backdrop double-click) used to arm the guard and confirm it in one
+    // perceived gesture. Only the banner's explicit Leave closes now.
+    server.use(...agentHandlers(), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...INTENT, initialStep: 2 });
+    await screen.findByLabelText(/Size per leg/);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(
+      await screen.findByText(/until the perp legs open you hold directional exposure/),
+    ).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    // Still open, still warning.
+    expect(screen.getByText('Finish this strategy')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Leave' }));
+    await waitFor(() => expect(screen.queryByText('Finish this strategy')).not.toBeInTheDocument());
+  });
+
+  it('the modal cannot be closed while a Boros execution is in flight', async () => {
+    // Unmounting the executing ticket skips its onSuccess: the fill report and
+    // its remediation die unseen while the order executes at the venue anyway.
+    server.use(
+      http.post('/api/boros/pair/execute', () => new Promise<never>(() => {})),
+      ...tradableHandlers(CLEAN_FILL),
+      ...symbolHandlers([ETH_GATE]),
+    );
+    renderWizard(WIZ);
+    await waitFor(() => expect(screen.getByLabelText('Leg A')).toHaveValue(String(BN_M)));
+    expect(screen.getByRole('button', { name: 'close' })).toBeInTheDocument();
+
+    const confirm = await screen.findByRole('button', { name: /Confirm — 2 Boros market orders/ });
+    await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(confirm);
+
+    // In flight: the ✕ goes away and Escape is inert.
+    await waitFor(
+      () => expect(screen.queryByRole('button', { name: 'close' })).not.toBeInTheDocument(),
+      { timeout: 4000 },
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.getByText('Open this strategy')).toBeInTheDocument();
+  }, 15_000);
+});
+
+describe('StrategyWizard — token-collateral aggregate sizing', () => {
+  it('scales the USD notional by hedged/sizeBase and passes the coin size', async () => {
+    const ETH_FILL = {
+      ...CLEAN_FILL,
+      legA: { ...CLEAN_FILL.legA, filledSize: 2 },
+      legB: { ...CLEAN_FILL.legB, filledSize: 2 },
+      hedgedSize: 2,
+    };
+    server.use(...tradableHandlers(ETH_FILL, 'ETH'), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...WIZ, notionalUsd: 9000, sizeBase: 3 });
+    await confirmPair();
+
+    // The receipt reads the book in the executed collateral.
+    await screen.findByText(/2 ETH hedged/, undefined, { timeout: 4000 });
+    fireEvent.click(screen.getByRole('button', { name: /Rate locked/ }));
+    await waitFor(() => {
+      const pair = prefillsSeen.find((x) => x.kind === 'pair');
+      // 2 of the intended 3 ETH filled ⇒ 2/3 of the $9,000 intent.
+      expect(pair?.payload.notionalUsd).toBeCloseTo(6000);
+      expect(pair?.payload.sizeBase).toBe(2);
+    });
+  }, 15_000);
 });

--- a/web/src/trade/StrategyWizard.tsx
+++ b/web/src/trade/StrategyWizard.tsx
@@ -1,0 +1,444 @@
+/**
+ * Guided open-a-strategy wizard: one modal, two steps, one full strategy.
+ *
+ *   Step 1 — lock the rate   (both Boros legs, one atomic batch)
+ *   Step 2 — hedge the perps (both CrossEx legs)
+ *   Done   — hand off to the Positions page
+ *
+ * The four legs were always opened as exactly these two executions; the wizard
+ * exists to SAY so. Two side-by-side card buttons styled primary/secondary read
+ * as "pick one" — the universal idiom for alternatives — when the truth is
+ * "both, in this order". A numbered surface that advances is the only shape
+ * that states an ordered conjunction.
+ *
+ * The tickets themselves are the SAME components the manual drawer mounts,
+ * armed through the same TradeFlow prefill channel — the wizard owns sequence
+ * and framing, never execution. Both stay mounted once seen (TradeRail's own
+ * rule): step 1's fill report and a mid-flight execution must survive the step
+ * switch, because a buried live directional exposure is precisely the failure
+ * this surface exists to prevent.
+ *
+ * Progress is never trusted from memory alone: closing after step 1 is safe
+ * because the Positions page derives "rate locked, unhedged" from live legs
+ * (StrategyCard's boros-only cue) and re-enters here at step 2.
+ */
+import { useEffect, useState } from 'react';
+import type { BorosPairResult } from '../api/types';
+import { Modal } from '../components/Modal';
+import { isUsdCollateral } from '../lib/boros';
+import { BorosPairTicket } from './BorosPairTicket';
+import { PairResultReport } from './BorosPairBits';
+import { PairTicket } from './PairTicket';
+import { useTradeFlow, type StrategyWizardIntent, type TradeFlowApi } from './TradeFlow';
+
+export function StrategyWizard({ onViewPositions }: { onViewPositions?: () => void }) {
+  const flow = useTradeFlow();
+  const w = flow.wizard;
+  if (!w) return null;
+  // Keyed per intent: a different strategy is a different wizard, never a
+  // form-swap under the user's hands — the exact disorientation the old
+  // always-on rail produced.
+  return (
+    <WizardBody
+      // `initialStep` is part of the identity: a FRESH open and a RESUME of
+      // the same coin/venues/maturity are different flows (one mounts the
+      // Boros ticket, one must not), and sharing a key would carry one's
+      // state into the other instead of remounting.
+      key={`${w.base}|${w.borosLongVenue}|${w.borosShortVenue}|${w.maturity ?? ''}|${w.initialStep ?? 1}`}
+      w={w}
+      flow={flow}
+      onViewPositions={onViewPositions}
+    />
+  );
+}
+
+type Step = 1 | 2 | 'done';
+
+function WizardBody({
+  w,
+  flow,
+  onViewPositions,
+}: {
+  w: StrategyWizardIntent;
+  flow: TradeFlowApi;
+  onViewPositions?: () => void;
+}) {
+  const [step, setStep] = useState<Step>(w.initialStep ?? 1);
+  /** Step 1's last venue result — set on any accepted Boros execution. */
+  const [locked, setLocked] = useState<BorosPairResult | null>(null);
+  /** The unit `locked`'s sizes are in, straight from the ticket that traded. */
+  const [lockedCollateral, setLockedCollateral] = useState('');
+  /** Mirrors TradeRail's borosSeen: a visited step stays mounted, hidden. */
+  const [perpSeen, setPerpSeen] = useState(w.initialStep === 2);
+  /** Two-click close while leaving would strand a naked rate position. */
+  const [leaveArmed, setLeaveArmed] = useState(false);
+
+  const { prefillBorosOpen, prefillPair, closeWizard } = flow;
+
+  // Arm step 1 the moment the wizard opens (or step 2 when resuming a
+  // boros-only position). Deliberately once per wizard identity — the body is
+  // keyed on it — so ticket edits are never fought by a re-arm.
+  useEffect(() => {
+    if ((w.initialStep ?? 1) === 1) {
+      prefillBorosOpen({
+        base: w.base,
+        longVenue: w.borosLongVenue,
+        shortVenue: w.borosShortVenue,
+        maturity: w.maturity,
+        size: w.notionalUsd,
+        sizeBase: w.sizeBase,
+      });
+    } else {
+      armPerps(w.notionalUsd, w.sizeBase);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const armPerps = (notionalUsd: number, sizeBase?: number) =>
+    prefillPair({
+      base: w.base,
+      longVenue: w.crossexLongVenue,
+      shortVenue: w.crossexShortVenue,
+      notionalUsd,
+      ...(sizeBase !== undefined && sizeBase > 0 ? { sizeUnit: 'base' as const, sizeBase } : {}),
+      ...(w.perpMode ? { mode: w.perpMode } : {}),
+    });
+
+  const residual = locked !== null && locked.unhedgedSize > 0;
+
+  const continueToHedge = () => {
+    /**
+     * The hedge is sized from what step 1 actually FILLED, not what was asked:
+     * a short fill hedged at the intended size is a new directional position
+     * wearing a hedge's name. `hedgedSize` is the size both legs share; on a
+     * clean fill it equals the intent and this is a no-op. A completion result
+     * (`bothLegsSubmitted` false) or a zero falls back to the original intent —
+     * the report on screen is then the honest source and the field stays
+     * editable.
+     */
+    const fillSize =
+      locked && locked.bothLegsSubmitted && locked.hedgedSize > 0 ? locked.hedgedSize : null;
+    /**
+     * ⚠ What `fillSize` MEANS is a property of the market that traded, not of
+     * what this wizard was told when it opened.
+     *
+     * `hedgedSize` is denominated in the executed market's COLLATERAL, so the
+     * only safe discriminator is that collateral — captured from the ticket
+     * that traded. Branching on `w.sizeBase !== undefined` (the old test)
+     * asked "did the caller know a base quantity?", which is a different
+     * question: an ETH cohort whose collateral price was unavailable arrives
+     * with no `sizeBase`, and its ETH fill size was then armed as DOLLARS —
+     * a ~$9,000 rate leg hedged with a $2 perp pair.
+     */
+    if (fillSize === null) {
+      armPerps(w.notionalUsd, w.sizeBase);
+    } else if (isUsdCollateral(lockedCollateral)) {
+      // USD-collateral: the Boros size IS the dollar figure.
+      armPerps(fillSize);
+    } else if (w.sizeBase !== undefined && w.sizeBase > 0) {
+      // Token-collateral, and we know the intended quantity — scale the USD
+      // notional by how much of it actually filled.
+      armPerps(w.notionalUsd * (fillSize / w.sizeBase), fillSize);
+    } else {
+      /**
+       * Token-collateral with no conversion available (no `sizeBase`, so no
+       * price to scale by). `fillSize` is a COIN quantity and must never be
+       * passed as dollars, so the perps keep the intent's USD figure and the
+       * user edits before executing — an approximate hedge they can see beats
+       * an exact-looking one off by the coin price.
+       */
+      armPerps(w.notionalUsd);
+    }
+    setPerpSeen(true);
+    setStep(2);
+  };
+
+  /**
+   * Is there a rate leg on with no hedge against it?
+   *
+   * Either because this wizard just locked one (`locked`), or because it was
+   * OPENED on one — a resume starts at step 2 precisely because the Boros legs
+   * already exist and are unhedged. The second case is the same naked
+   * exposure, and it used to leave silently: the guard tested `locked`, which
+   * a resume never sets.
+   */
+  const unhedgedRateOn = locked !== null || (w.initialStep ?? 1) === 2;
+
+  const requestClose = () => {
+    // Rate locked but not hedged = naked directional exposure. Leaving is
+    // always allowed (Positions derives the resume point), but never silently.
+    if (unhedgedRateOn && step !== 'done' && !leaveArmed) {
+      setLeaveArmed(true);
+      return;
+    }
+    closeWizard();
+  };
+
+  const resuming = (w.initialStep ?? 1) === 2;
+  /**
+   * Venue pair for the subtitle, from whichever side is known.
+   *
+   * A resume is opened from a position whose venues come off its LEGS, and a
+   * lopsided book can be missing one side entirely — so neither name is
+   * assumed present, and a missing one is dropped rather than printed as an
+   * empty gap between separators.
+   */
+  const venuePair = [
+    w.borosShortVenue ? `short ${w.borosShortVenue.toLowerCase()}` : null,
+    w.borosLongVenue ? `long ${w.borosLongVenue.toLowerCase()}` : null,
+  ]
+    .filter((p): p is string => p !== null)
+    .join(' / ');
+  const title = (
+    <span className="flex items-baseline gap-2">
+      {/* A resume is FINISHING a position that already exists — calling that
+          "Open this strategy" tells the user they are starting something they
+          are half-way through. */}
+      <span>{resuming ? 'Finish this strategy' : 'Open this strategy'}</span>
+      <span className="num text-[12px] font-normal text-ink-400">
+        {w.base}
+        {venuePair && ` · ${venuePair}`}
+      </span>
+    </span>
+  );
+
+  return (
+    <Modal title={title} onClose={requestClose} widthClass="w-[480px]">
+      <div className="flex flex-col gap-4">
+        <StepStrip step={step} locked={locked !== null} />
+
+        {leaveArmed && step !== 'done' && (
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-amber-500/40 bg-amber-500/[0.08] px-3 py-2 text-[12px] leading-relaxed text-amber-100">
+            <span>
+              The rate is locked but not hedged — until the perp legs open you hold directional
+              exposure. The Positions page will show this and offer to finish the hedge.
+            </span>
+            <span className="flex shrink-0 gap-2">
+              <button type="button" className="btn !py-1 text-[11px]" onClick={closeWizard}>
+                Leave
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary !py-1 text-[11px]"
+                onClick={() => setLeaveArmed(false)}
+              >
+                Stay
+              </button>
+            </span>
+          </div>
+        )}
+
+        {/* --- Step 1: the Boros rate legs. Not mounted at all on a resume
+            (initialStep 2): those rate legs already exist as a position, and
+            an idle ticket for them would only poll a quote nobody wants. --- */}
+        {(w.initialStep ?? 1) === 1 && (
+        <div hidden={step !== 1}>
+          {/**
+           * ⚠ A SUCCEEDED step is a receipt, not a form.
+           *
+           * Once the rate is locked the ticket is replaced by its result. It
+           * used to stay mounted underneath, which put TWO live CTAs in the
+           * modal at once — the ticket's own `Confirm — 2 Boros market orders`
+           * and the wizard's `Rate locked ✓ — hedge the perps` — so the same
+           * pair could be fired a second time by a user the wizard had just
+           * told the rate was locked. (Dismissing the ticket's fill report
+           * calls `setReport(null)`, which returns it to its ordinary armed
+           * state; the wizard's own `locked` never cleared, so both showed.)
+           *
+           * A PARTIAL fill is the exception: its Complete/Retry actions arm
+           * the ticket again, so the form has to stay for that case — there
+           * the residual, not the wizard, is what still needs an order.
+           */}
+          {locked !== null && !residual ? (
+            <div className="flex flex-col gap-3">
+              <StepOneReceipt result={locked} collateral={lockedCollateral} />
+              <button type="button" className="btn btn-primary w-full" onClick={continueToHedge}>
+                Rate locked ✓ — hedge the perps ▸
+              </button>
+            </div>
+          ) : (
+            <>
+              <BorosPairTicket
+                active={step === 1}
+                onExecuted={(result, collateral) => {
+                  /**
+                   * ⚠ A COMPLETION must not replace the pair result.
+                   *
+                   * `onExecuted` fires for every accepted execution, including
+                   * the one-leg completion the report's "Complete now" arms.
+                   * A completion always reports `unhedgedSize: 0`
+                   * (orders.ts: `bothSubmitted ? … : 0`), so overwriting
+                   * `locked` with it flipped `residual` to false and made the
+                   * receipt describe the 100-unit top-up instead of the
+                   * 1,000-unit rate lock behind it — and sized the hedge off
+                   * the wrong number.
+                   *
+                   * The PAIR result is the one that describes this step, so it
+                   * is kept; a completion only clears the residual it closed.
+                   */
+                  setLockedCollateral(collateral);
+                  setLocked((prev) =>
+                    prev !== null && !result.bothLegsSubmitted
+                      ? { ...prev, unhedgedSize: 0, unhedgedLeg: null }
+                      : result,
+                  );
+                }}
+              />
+              {locked !== null && (
+                <div className="mt-3 flex flex-col gap-2">
+                  <p className="rounded-lg border border-amber-500/25 bg-amber-500/[0.04] px-2.5 py-1.5 text-[11px] leading-relaxed text-amber-200">
+                    {/* Deliberately does not say "the report above": that
+                        report can be dismissed, and copy pointing at something
+                        no longer on screen reads as a bug. The fact that
+                        survives either way is what continuing would cost. */}
+                    One leg filled short. Continuing now hedges only the size both legs share —
+                    the rest stays directional until you complete or close it.
+                  </p>
+                  <button type="button" className="btn btn-primary w-full" onClick={continueToHedge}>
+                    Continue anyway — hedge the perps ▸
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+        )}
+
+        {/* --- Step 2: the CrossEx perp hedge ----------------------------- */}
+        {(step === 2 || perpSeen) && (
+          <div hidden={step !== 2}>
+            {step === 2 && locked === null && (w.initialStep ?? 1) === 1 && (
+              // Only reachable via the back link below after arriving armed —
+              // still worth stating whose sizes the ticket is holding.
+              <p className="mb-2 text-[11px] text-ink-400">
+                Sized from the locked rate legs — edit before executing if they differ.
+              </p>
+            )}
+            <PairTicket onExecuted={() => setStep('done')} />
+            {step === 2 && (w.initialStep ?? 1) === 1 && (
+              <button
+                type="button"
+                className="mt-3 text-[11px] text-ink-400 underline decoration-dotted hover:text-ink-200"
+                onClick={() => setStep(1)}
+              >
+                ‹ Back to the rate legs
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* --- Done: hand off to Positions -------------------------------- */}
+        {step === 'done' && (
+          <div className="flex flex-col gap-3">
+            <div className="rounded-lg border border-emerald-500/25 bg-emerald-500/[0.05] px-3 py-2.5 text-[12.5px] leading-relaxed text-ink-100">
+              <span className="mr-2 font-semibold text-emerald-400">✓ Strategy submitted.</span>
+              The perp legs are executing — the deal view tracks their fills. Your position appears
+              on the Positions page, which watches all four legs from here on.
+            </div>
+            <button
+              type="button"
+              className="btn btn-primary w-full"
+              onClick={() => {
+                closeWizard();
+                onViewPositions?.();
+              }}
+            >
+              View my position →
+            </button>
+            <button
+              type="button"
+              className="self-center text-[11px] text-ink-400 underline decoration-dotted hover:text-ink-200"
+              onClick={closeWizard}
+            >
+              close
+            </button>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+/**
+ * Step 1, done: what was traded, not a form that can be traded again.
+ *
+ * Reuses the ticket's own report so the numbers and their wording are the same
+ * ones the ticket would have shown — a receipt that paraphrased the fill would
+ * be a second source of truth about money. The report's Complete/Retry actions
+ * are deliberately inert here: this renders only for a CLEAN fill, where there
+ * is nothing left to complete, and a partial keeps the live ticket instead.
+ */
+function StepOneReceipt({
+  result,
+  collateral,
+}: {
+  result: BorosPairResult;
+  collateral: string;
+}) {
+  return (
+    <PairResultReport
+      result={result}
+      collateral={collateral}
+      // A clean fill has no residual and no shortfall, so neither action is
+      // rendered; `onDismiss` is omitted because the report IS this step now,
+      // and hiding it would leave the step blank.
+      onComplete={() => {}}
+      onRetry={() => {}}
+    />
+  );
+}
+
+/** 1 ── 2 ── ✓, with the active step lit and finished steps checked. */
+function StepStrip({ step, locked }: { step: Step; locked: boolean }) {
+  const items: { n: 1 | 2; label: string; venue: string; done: boolean; active: boolean }[] = [
+    {
+      n: 1,
+      label: 'Lock the rate',
+      venue: 'Boros',
+      done: locked || step === 2 || step === 'done',
+      active: step === 1,
+    },
+    {
+      n: 2,
+      label: 'Hedge the perps',
+      venue: 'Gate CrossEx',
+      done: step === 'done',
+      active: step === 2,
+    },
+  ];
+  return (
+    /* The strip is the wizard's spine — it is what says the two executions are
+       ORDERED rather than alternatives, which is the whole reason this surface
+       exists. At 11px with 20px bullets it read as a caption and got skipped;
+       it now carries the weight of a heading, sitting on its own banded row so
+       it separates from the ticket below instead of floating above it. */
+    <ol className="flex items-center gap-3 rounded-lg border border-ink-800 bg-ink-900/40 px-3 py-2.5 text-[13px]">
+      {items.map((it, i) => (
+        <li key={it.n} className="flex min-w-0 flex-1 items-center gap-2.5">
+          {i > 0 && <span aria-hidden className="h-px w-5 shrink-0 bg-ink-700" />}
+          <span
+            className={`num flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[12px] font-semibold ${
+              it.done
+                ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-300'
+                : it.active
+                  ? 'border-cyan-400/70 bg-cyan-500/15 text-cyan-300'
+                  : 'border-ink-700 bg-ink-900 text-ink-500'
+            }`}
+          >
+            {it.done ? '✓' : it.n}
+          </span>
+          <span className="flex min-w-0 flex-col leading-tight">
+            <span
+              className={`truncate ${it.active ? 'font-semibold text-ink-100' : it.done ? 'text-ink-200' : 'text-ink-500'}`}
+            >
+              {it.label}
+            </span>
+            {/* The venue is the part that tells you WHICH book each step
+                touches; it was buried in the same 11px run as the verb. */}
+            <span className="truncate text-[10.5px] text-ink-500">{it.venue}</span>
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/web/src/trade/StrategyWizard.tsx
+++ b/web/src/trade/StrategyWizard.tsx
@@ -23,9 +23,10 @@
  * (StrategyCard's boros-only cue) and re-enters here at step 2.
  */
 import { useEffect, useState } from 'react';
-import type { BorosPairResult } from '../api/types';
+import type { BorosLegFill, BorosPairResult } from '../api/types';
 import { Modal } from '../components/Modal';
 import { isUsdCollateral } from '../lib/boros';
+import { sig } from '../lib/fmt';
 import { BorosPairTicket } from './BorosPairTicket';
 import { PairResultReport } from './BorosPairBits';
 import { PairTicket } from './PairTicket';
@@ -54,6 +55,70 @@ export function StrategyWizard({ onViewPositions }: { onViewPositions?: () => vo
 
 type Step = 1 | 2 | 'done';
 
+/**
+ * One leg slot of the wizard's step-1 book. `size` is SIGNED — +long / −short,
+ * in the executed market's collateral — so a close (which always carries the
+ * direction opposing the position) subtracts on its own, with no intent flag.
+ */
+type SlotFill = { size: number; marketId: number; execApr: number | null };
+
+/**
+ * What step 1 has actually put on, folded across EVERY accepted execution —
+ * the pair fill, its retries, its completions, single-leg orders, and closes.
+ *
+ * The old shape was a single `BorosPairResult` gated on `unhedgedSize > 0`,
+ * and every non-clean path broke it: a both-legs-zero fill reported
+ * unhedgedSize 0 and read as "Rate locked ✓"; a completion's merge kept the
+ * stale hedgedSize; a pair-shaped retry REPLACED the aggregate; a single-leg
+ * or close execution read as a pair lock. A cumulative signed book has none of
+ * those cases — every execution is the same fold.
+ *
+ * This is the wizard's session-relative view only. Account truth lives on the
+ * Positions page (see the header comment); in particular a §6A cancel-and-close
+ * fired from a ticket blocker bypasses `onExecuted` and is invisible here.
+ */
+type StepOneBook = {
+  a: SlotFill;
+  b: SlotFill;
+  /** The unit every `size` is in, from the ticket that traded. */
+  collateral: string;
+  /** Display only (spread attribution) — never a source of leg identity:
+   * a not-submitted leg's sentinel carries a HARDCODED direction (orders.ts). */
+  lastResult: BorosPairResult | null;
+  /** True when the whole book is one clean pair execution — the only case
+   * where that execution's realisedSpreadApr describes the book. */
+  soleClean: boolean;
+};
+
+const EMPTY_SLOT: SlotFill = { size: 0, marketId: 0, execApr: null };
+const EMPTY_BOOK: StepOneBook = {
+  a: EMPTY_SLOT,
+  b: EMPTY_SLOT,
+  collateral: '',
+  lastResult: null,
+  soleClean: false,
+};
+
+/** Was this leg actually sent to the venue? A not-submitted sentinel is
+ * all-zero with no failure (orders.ts `notSubmitted`); a REJECTED leg has
+ * filledSize 0 but a shortfall and a failure, and must still count. */
+const legSubmitted = (leg: BorosLegFill): boolean =>
+  leg.filledSize !== 0 || leg.shortfallSize > 0 || leg.failure !== null;
+
+const foldLeg = (slot: SlotFill, leg: BorosLegFill): SlotFill => {
+  if (!legSubmitted(leg)) return slot;
+  return {
+    // The venue's own defence: never trust the raw sign of filledSize.
+    size: slot.size + (leg.direction === 'long' ? 1 : -1) * Math.abs(leg.filledSize),
+    marketId: leg.marketId,
+    execApr: leg.execApr ?? slot.execApr,
+  };
+};
+
+/** Fills round-trip 18-decimal venue values through float64, so exact-zero
+ * comparisons on the folded book can be off by ~1e-11 forever. */
+const EPS = 1e-9;
+
 function WizardBody({
   w,
   flow,
@@ -63,15 +128,21 @@ function WizardBody({
   flow: TradeFlowApi;
   onViewPositions?: () => void;
 }) {
+  const resuming = (w.initialStep ?? 1) === 2;
   const [step, setStep] = useState<Step>(w.initialStep ?? 1);
-  /** Step 1's last venue result — set on any accepted Boros execution. */
-  const [locked, setLocked] = useState<BorosPairResult | null>(null);
-  /** The unit `locked`'s sizes are in, straight from the ticket that traded. */
-  const [lockedCollateral, setLockedCollateral] = useState('');
+  /** Everything step 1 has executed, as one signed book — see StepOneBook. */
+  const [book, setBook] = useState<StepOneBook>(EMPTY_BOOK);
+  /** The hedged size the perp ticket was last armed with. Continue re-arms
+   * ONLY when the book's hedged size differs — a Back → Continue round-trip
+   * with nothing new executed must not wipe the user's step-2 edits. */
+  const [lastArmedHedge, setLastArmedHedge] = useState<number | null>(null);
   /** Mirrors TradeRail's borosSeen: a visited step stays mounted, hidden. */
   const [perpSeen, setPerpSeen] = useState(w.initialStep === 2);
   /** Two-click close while leaving would strand a naked rate position. */
   const [leaveArmed, setLeaveArmed] = useState(false);
+  /** A Boros execution is in flight — the modal must not be closable: the
+   * response (and a partial fill's remediation) dies with the ticket. */
+  const [executing, setExecuting] = useState(false);
 
   const { prefillBorosOpen, prefillPair, closeWizard } = flow;
 
@@ -79,7 +150,7 @@ function WizardBody({
   // boros-only position). Deliberately once per wizard identity — the body is
   // keyed on it — so ticket edits are never fought by a re-arm.
   useEffect(() => {
-    if ((w.initialStep ?? 1) === 1) {
+    if (!resuming) {
       prefillBorosOpen({
         base: w.base,
         longVenue: w.borosLongVenue,
@@ -104,50 +175,82 @@ function WizardBody({
       ...(w.perpMode ? { mode: w.perpMode } : {}),
     });
 
-  const residual = locked !== null && locked.unhedgedSize > 0;
+  /** Fold one accepted execution into the book. Replays never reach this —
+   * the ticket skips `onExecuted` for them. */
+  const recordExecution = (result: BorosPairResult, collateral: string) =>
+    setBook((prev) => {
+      /**
+       * ⚠ Reset before folding when the legs stopped being the same book.
+       *
+       * The ticket's selects stay editable inside the wizard, so the user can
+       * repick both legs to a different cohort — a different market, possibly
+       * a different COLLATERAL — and execute. Summing ETH into a USDT book
+       * would produce a hedged size in no unit at all, so a submitted leg
+       * whose market differs from the slot's recorded one (or a collateral
+       * change) starts the book over from this execution alone.
+       */
+      const marketChanged =
+        (legSubmitted(result.legA) && prev.a.marketId !== 0 && prev.a.marketId !== result.legA.marketId) ||
+        (legSubmitted(result.legB) && prev.b.marketId !== 0 && prev.b.marketId !== result.legB.marketId);
+      const collateralChanged =
+        prev.collateral !== '' && collateral !== '' && prev.collateral !== collateral;
+      const base = marketChanged || collateralChanged ? EMPTY_BOOK : prev;
+      const wasEmpty = Math.abs(base.a.size) <= EPS && Math.abs(base.b.size) <= EPS;
+      return {
+        a: foldLeg(base.a, result.legA),
+        b: foldLeg(base.b, result.legB),
+        collateral: collateral || base.collateral,
+        lastResult: result,
+        soleClean: wasEmpty && result.bothLegsSubmitted && !result.partial,
+      };
+    });
+
+  // The book, read out: total exposure, the part that cancels (hedged) and
+  // the part that does not (residual). Same-signed slots — a deliberate
+  // single-leg lock, say — have hedged 0 and read as all-residual, which is
+  // exactly what they are.
+  const exposure = Math.abs(book.a.size) + Math.abs(book.b.size);
+  const residualSize = Math.abs(book.a.size + book.b.size);
+  const hedged = (exposure - residualSize) / 2;
+  const stepOneDone = hedged > EPS && residualSize <= EPS * Math.max(1, exposure);
+  const lopsided = !stepOneDone && hedged > EPS;
+  const oneSided = !stepOneDone && hedged <= EPS && exposure > EPS;
 
   const continueToHedge = () => {
     /**
-     * The hedge is sized from what step 1 actually FILLED, not what was asked:
-     * a short fill hedged at the intended size is a new directional position
-     * wearing a hedge's name. `hedgedSize` is the size both legs share; on a
-     * clean fill it equals the intent and this is a no-op. A completion result
-     * (`bothLegsSubmitted` false) or a zero falls back to the original intent —
-     * the report on screen is then the honest source and the field stays
-     * editable.
-     */
-    const fillSize =
-      locked && locked.bothLegsSubmitted && locked.hedgedSize > 0 ? locked.hedgedSize : null;
-    /**
-     * ⚠ What `fillSize` MEANS is a property of the market that traded, not of
-     * what this wizard was told when it opened.
+     * The hedge is sized from what step 1 actually FILLED — the book's hedged
+     * size — not what was asked: a short fill hedged at the intended size is a
+     * new directional position wearing a hedge's name. Both buttons that lead
+     * here are gated on `hedged > 0`, so there is always a real size.
      *
-     * `hedgedSize` is denominated in the executed market's COLLATERAL, so the
-     * only safe discriminator is that collateral — captured from the ticket
-     * that traded. Branching on `w.sizeBase !== undefined` (the old test)
-     * asked "did the caller know a base quantity?", which is a different
-     * question: an ETH cohort whose collateral price was unavailable arrives
-     * with no `sizeBase`, and its ETH fill size was then armed as DOLLARS —
-     * a ~$9,000 rate leg hedged with a $2 perp pair.
+     * ⚠ What `hedged` MEANS is a property of the market that traded, not of
+     * what this wizard was told when it opened. It is denominated in the
+     * executed market's COLLATERAL, so that collateral — captured from the
+     * ticket that traded — is the only safe discriminator. Branching on
+     * `w.sizeBase !== undefined` asked "did the caller know a base quantity?",
+     * which is a different question: an ETH cohort whose collateral price was
+     * unavailable arrives with no `sizeBase`, and its ETH fill size was then
+     * armed as DOLLARS — a ~$9,000 rate leg hedged with a $2 perp pair.
      */
-    if (fillSize === null) {
-      armPerps(w.notionalUsd, w.sizeBase);
-    } else if (isUsdCollateral(lockedCollateral)) {
-      // USD-collateral: the Boros size IS the dollar figure.
-      armPerps(fillSize);
-    } else if (w.sizeBase !== undefined && w.sizeBase > 0) {
-      // Token-collateral, and we know the intended quantity — scale the USD
-      // notional by how much of it actually filled.
-      armPerps(w.notionalUsd * (fillSize / w.sizeBase), fillSize);
-    } else {
-      /**
-       * Token-collateral with no conversion available (no `sizeBase`, so no
-       * price to scale by). `fillSize` is a COIN quantity and must never be
-       * passed as dollars, so the perps keep the intent's USD figure and the
-       * user edits before executing — an approximate hedge they can see beats
-       * an exact-looking one off by the coin price.
-       */
-      armPerps(w.notionalUsd);
+    if (lastArmedHedge === null || Math.abs(hedged - lastArmedHedge) > EPS) {
+      if (isUsdCollateral(book.collateral)) {
+        // USD-collateral: the Boros size IS the dollar figure.
+        armPerps(hedged);
+      } else if (w.sizeBase !== undefined && w.sizeBase > 0) {
+        // Token-collateral, and we know the intended quantity — scale the USD
+        // notional by how much of it actually filled.
+        armPerps(w.notionalUsd * (hedged / w.sizeBase), hedged);
+      } else {
+        /**
+         * Token-collateral with no conversion available (no `sizeBase`, so no
+         * price to scale by). `hedged` is a COIN quantity and must never be
+         * passed as dollars, so the perps keep the intent's USD figure and the
+         * user edits before executing — an approximate hedge they can see
+         * beats an exact-looking one off by the coin price.
+         */
+        armPerps(w.notionalUsd);
+      }
+      setLastArmedHedge(hedged);
     }
     setPerpSeen(true);
     setStep(2);
@@ -156,25 +259,27 @@ function WizardBody({
   /**
    * Is there a rate leg on with no hedge against it?
    *
-   * Either because this wizard just locked one (`locked`), or because it was
-   * OPENED on one — a resume starts at step 2 precisely because the Boros legs
-   * already exist and are unhedged. The second case is the same naked
-   * exposure, and it used to leave silently: the guard tested `locked`, which
-   * a resume never sets.
+   * Either because this wizard put exposure on (any nonzero side of the book —
+   * a one-sided fill counts, and a book closed back to zero through the wizard
+   * stops counting), or because it was OPENED on one — a resume starts at
+   * step 2 precisely because the Boros legs already exist and are unhedged.
    */
-  const unhedgedRateOn = locked !== null || (w.initialStep ?? 1) === 2;
+  const unhedgedRateOn = exposure > EPS || resuming;
 
   const requestClose = () => {
     // Rate locked but not hedged = naked directional exposure. Leaving is
-    // always allowed (Positions derives the resume point), but never silently.
-    if (unhedgedRateOn && step !== 'done' && !leaveArmed) {
+    // always allowed (Positions derives the resume point), but never silently
+    // — and never by momentum: once the warning is up, further Escape presses
+    // and backdrop clicks do nothing, because a held key's auto-repeat or a
+    // double-click would otherwise arm and close in one perceived gesture.
+    // Only the banner's explicit Leave button closes from here.
+    if (unhedgedRateOn && step !== 'done') {
       setLeaveArmed(true);
       return;
     }
     closeWizard();
   };
 
-  const resuming = (w.initialStep ?? 1) === 2;
   /**
    * Venue pair for the subtitle, from whichever side is known.
    *
@@ -203,9 +308,9 @@ function WizardBody({
   );
 
   return (
-    <Modal title={title} onClose={requestClose} widthClass="w-[480px]">
+    <Modal title={title} locked={executing} onClose={requestClose} widthClass="w-[480px]">
       <div className="flex flex-col gap-4">
-        <StepStrip step={step} locked={locked !== null} />
+        <StepStrip step={step} locked={stepOneDone} />
 
         {leaveArmed && step !== 'done' && (
           <div className="flex items-center justify-between gap-3 rounded-lg border border-amber-500/40 bg-amber-500/[0.08] px-3 py-2 text-[12px] leading-relaxed text-amber-100">
@@ -231,27 +336,24 @@ function WizardBody({
         {/* --- Step 1: the Boros rate legs. Not mounted at all on a resume
             (initialStep 2): those rate legs already exist as a position, and
             an idle ticket for them would only poll a quote nobody wants. --- */}
-        {(w.initialStep ?? 1) === 1 && (
+        {!resuming && (
         <div hidden={step !== 1}>
           {/**
-           * ⚠ A SUCCEEDED step is a receipt, not a form.
+           * ⚠ A SUCCEEDED step is a receipt, not a form — and "succeeded"
+           * means the BOOK is clean (hedged > 0, residual 0), never a
+           * property of the last result alone. A both-legs-zero fill reports
+           * unhedgedSize 0 and used to render this receipt for a trade where
+           * nothing filled; the book stays empty there and the live ticket —
+           * with its real failure report and working Retry — stays up.
            *
-           * Once the rate is locked the ticket is replaced by its result. It
-           * used to stay mounted underneath, which put TWO live CTAs in the
-           * modal at once — the ticket's own `Confirm — 2 Boros market orders`
-           * and the wizard's `Rate locked ✓ — hedge the perps` — so the same
-           * pair could be fired a second time by a user the wizard had just
-           * told the rate was locked. (Dismissing the ticket's fill report
-           * calls `setReport(null)`, which returns it to its ordinary armed
-           * state; the wizard's own `locked` never cleared, so both showed.)
-           *
-           * A PARTIAL fill is the exception: its Complete/Retry actions arm
-           * the ticket again, so the form has to stay for that case — there
-           * the residual, not the wizard, is what still needs an order.
+           * The ticket is replaced (not just covered) once done: leaving it
+           * mounted put TWO live CTAs in the modal at once, so the same pair
+           * could be fired a second time by a user the wizard had just told
+           * the rate was locked.
            */}
-          {locked !== null && !residual ? (
+          {stepOneDone ? (
             <div className="flex flex-col gap-3">
-              <StepOneReceipt result={locked} collateral={lockedCollateral} />
+              <StepOneReceipt book={book} hedged={hedged} />
               <button type="button" className="btn btn-primary w-full" onClick={continueToHedge}>
                 Rate locked ✓ — hedge the perps ▸
               </button>
@@ -260,44 +362,37 @@ function WizardBody({
             <>
               <BorosPairTicket
                 active={step === 1}
-                onExecuted={(result, collateral) => {
-                  /**
-                   * ⚠ A COMPLETION must not replace the pair result.
-                   *
-                   * `onExecuted` fires for every accepted execution, including
-                   * the one-leg completion the report's "Complete now" arms.
-                   * A completion always reports `unhedgedSize: 0`
-                   * (orders.ts: `bothSubmitted ? … : 0`), so overwriting
-                   * `locked` with it flipped `residual` to false and made the
-                   * receipt describe the 100-unit top-up instead of the
-                   * 1,000-unit rate lock behind it — and sized the hedge off
-                   * the wrong number.
-                   *
-                   * The PAIR result is the one that describes this step, so it
-                   * is kept; a completion only clears the residual it closed.
-                   */
-                  setLockedCollateral(collateral);
-                  setLocked((prev) =>
-                    prev !== null && !result.bothLegsSubmitted
-                      ? { ...prev, unhedgedSize: 0, unhedgedLeg: null }
-                      : result,
-                  );
-                }}
+                onBusyChange={setExecuting}
+                onExecuted={recordExecution}
               />
-              {locked !== null && (
+              {lopsided && (
                 <div className="mt-3 flex flex-col gap-2">
                   <p className="rounded-lg border border-amber-500/25 bg-amber-500/[0.04] px-2.5 py-1.5 text-[11px] leading-relaxed text-amber-200">
                     {/* Deliberately does not say "the report above": that
                         report can be dismissed, and copy pointing at something
                         no longer on screen reads as a bug. The fact that
                         survives either way is what continuing would cost. */}
-                    One leg filled short. Continuing now hedges only the size both legs share —
-                    the rest stays directional until you complete or close it.
+                    The rate legs are lopsided — {sig(residualSize)}
+                    {book.collateral ? ` ${book.collateral}` : ''} is unmatched. Continuing hedges
+                    only the size both legs share; the rest stays directional until you complete or
+                    close it.
                   </p>
                   <button type="button" className="btn btn-primary w-full" onClick={continueToHedge}>
                     Continue anyway — hedge the perps ▸
                   </button>
                 </div>
+              )}
+              {oneSided && (
+                /* Sometimes deliberate (the ticket's Single mode), so this
+                   describes the position, not a failure — and offers no
+                   Continue: with no shared size there is nothing to hedge,
+                   and arming the intent size here was exactly the bug where
+                   a one-leg book got a full-size "hedge". */
+                <p className="mt-3 rounded-lg border border-amber-500/25 bg-amber-500/[0.04] px-2.5 py-1.5 text-[11px] leading-relaxed text-amber-200">
+                  Only one side of the rate pair is on — that is directional exposure, not a locked
+                  spread. There is no shared size to hedge yet; complete the other leg, or close
+                  this one.
+                </p>
               )}
             </>
           )}
@@ -307,15 +402,21 @@ function WizardBody({
         {/* --- Step 2: the CrossEx perp hedge ----------------------------- */}
         {(step === 2 || perpSeen) && (
           <div hidden={step !== 2}>
-            {step === 2 && locked === null && (w.initialStep ?? 1) === 1 && (
-              // Only reachable via the back link below after arriving armed —
-              // still worth stating whose sizes the ticket is holding.
-              <p className="mb-2 text-[11px] text-ink-400">
-                Sized from the locked rate legs — edit before executing if they differ.
-              </p>
-            )}
+            {step === 2 &&
+              !resuming &&
+              lastArmedHedge !== null &&
+              Math.abs(hedged - lastArmedHedge) > EPS && (
+                // An execution that was still in flight when Continue was
+                // clicked has landed and moved the book. Re-arming here would
+                // wipe the user's edits — the exact bug the lastArmedHedge
+                // gate fixes — so say it instead and let them re-continue.
+                <p className="mb-2 rounded-lg border border-amber-500/25 bg-amber-500/[0.04] px-2.5 py-1.5 text-[11px] leading-relaxed text-amber-200">
+                  The rate legs changed since this hedge was sized — go back to the rate legs and
+                  continue again to re-size it.
+                </p>
+              )}
             <PairTicket onExecuted={() => setStep('done')} />
-            {step === 2 && (w.initialStep ?? 1) === 1 && (
+            {step === 2 && !resuming && (
               <button
                 type="button"
                 className="mt-3 text-[11px] text-ink-400 underline decoration-dotted hover:text-ink-200"
@@ -364,24 +465,41 @@ function WizardBody({
  *
  * Reuses the ticket's own report so the numbers and their wording are the same
  * ones the ticket would have shown — a receipt that paraphrased the fill would
- * be a second source of truth about money. The report's Complete/Retry actions
- * are deliberately inert here: this renders only for a CLEAN fill, where there
- * is nothing left to complete, and a partial keeps the live ticket instead.
+ * be a second source of truth about money. It renders the BOOK (the fold of
+ * every execution), synthesized as a clean result: only reachable when the
+ * book is clean, so the report shows no Complete/Retry, and `onDismiss` is
+ * omitted because the report IS this step now.
+ *
+ * ⚠ Leg identity comes from the book's slots, never from any raw result: a
+ * not-submitted leg's sentinel carries a HARDCODED direction (orders.ts), and
+ * after a completion the "last result" describes only the top-up.
  */
-function StepOneReceipt({
-  result,
-  collateral,
-}: {
-  result: BorosPairResult;
-  collateral: string;
-}) {
+function StepOneReceipt({ book, hedged }: { book: StepOneBook; hedged: number }) {
+  const synthLeg = (slot: SlotFill): BorosLegFill => ({
+    marketId: slot.marketId,
+    direction: slot.size > 0 ? 'long' : 'short',
+    filledSize: Math.abs(slot.size),
+    shortfallSize: 0,
+    execApr: slot.execApr,
+    feeSize: null,
+    failure: null,
+  });
+  const result: BorosPairResult = {
+    legA: synthLeg(book.a),
+    legB: synthLeg(book.b),
+    bothLegsSubmitted: true,
+    hedgedSize: hedged,
+    unhedgedSize: 0,
+    unhedgedLeg: null,
+    // Attributable only when the whole book is one clean execution; a spread
+    // stitched across a partial and its top-up would mislabel money.
+    realisedSpreadApr: book.soleClean ? (book.lastResult?.realisedSpreadApr ?? null) : null,
+    partial: false,
+  };
   return (
     <PairResultReport
       result={result}
-      collateral={collateral}
-      // A clean fill has no residual and no shortfall, so neither action is
-      // rendered; `onDismiss` is omitted because the report IS this step now,
-      // and hiding it would leave the step blank.
+      collateral={book.collateral}
       onComplete={() => {}}
       onRetry={() => {}}
     />

--- a/web/src/trade/TradeFlow.tsx
+++ b/web/src/trade/TradeFlow.tsx
@@ -109,10 +109,73 @@ export interface SinglePerpPrefill {
   nonce: number;
 }
 
+/**
+ * Everything the guided 2-step wizard needs to open one full strategy: the
+ * Boros rate legs (step 1) and the CrossEx perp hedge (step 2).
+ *
+ * Venues travel TWICE because the two halves are addressed differently: a
+ * card's Boros leg and its perp leg sit at the same venue but under different
+ * keys, and crossing them arms tickets with markets that do not exist.
+ */
+export interface StrategyWizardIntent {
+  base: string;
+  /** Boros venue keys for the rate legs, long side first. */
+  borosLongVenue: string;
+  borosShortVenue: string;
+  /** Maturity of the Boros legs, unix seconds — see BorosOpenPrefill.maturity. */
+  maturity?: number;
+  /** CrossEx venue keys for the perp legs; null = no mapped symbol there. */
+  crossexLongVenue: string | null;
+  crossexShortVenue: string | null;
+  /** USD notional per leg. */
+  notionalUsd: number;
+  /**
+   * The same size in the base coin, for token-margined cohorts.
+   *
+   * ⚠ Set ONLY when the Boros collateral IS the base coin — that is the case
+   * where the Boros size and the perp quantity are the same number, needing no
+   * conversion. Every caller guards on it (the Opportunities card compares the
+   * collateral symbol to the base; the Positions cue uses `baseSized`), and
+   * the wizard turns its presence straight into `sizeUnit: 'base'`. Setting it
+   * for a USDT-collateral coin would arm the perp box with a dollar figure
+   * labelled as coins.
+   */
+  sizeBase?: number;
+  /** Perp execution mode to arm step 2 with. */
+  perpMode?: ExecMode;
+  /**
+   * Step to open at. 2 = the rate legs already exist (a boros-only position
+   * resuming its hedge); default 1.
+   */
+  initialStep?: 1 | 2;
+}
+
 export interface TradeFlowApi {
   modalOpen: boolean;
   /** Show the live deal view (post-202, or the recovery banner). */
   openDeal: (dealId: string) => void;
+  /** The guided open-a-strategy wizard; null = closed. */
+  wizard: StrategyWizardIntent | null;
+  openWizard: (w: StrategyWizardIntent) => void;
+  closeWizard: () => void;
+  /**
+   * Bumped when a strategy is requested that cannot be executed yet because
+   * credentials are unconfigured. The wizard deliberately does NOT open — a
+   * two-step execution modal with no keys behind it is a dead end — so this
+   * counter is the click's only trace, and the setup guide answers it by
+   * scrolling to and flashing the API-key form.
+   */
+  setupNonce: number;
+  /** Ask for setup instead of opening the wizard (first-run cards). */
+  requestSetup: () => void;
+  /**
+   * The manual order ticket, now an on-demand drawer rather than a permanent
+   * column. Any prefill fired while the wizard is closed opens it — a form
+   * must never be populated out of sight.
+   */
+  railOpen: boolean;
+  openRail: () => void;
+  closeRail: () => void;
   pairPrefill: PairPrefill | null;
   /** Prefill the pair ticket (strategy-box "Open the perp legs" cue). */
   prefillPair: (p: Omit<PairPrefill, 'nonce'>) => void;
@@ -142,18 +205,37 @@ export function TradeFlowProvider({ children }: { children: ReactNode }) {
   const [pairPrefill, setPairPrefill] = useState<PairPrefill | null>(null);
   const [borosOpenPrefill, setBorosOpenPrefill] = useState<BorosOpenPrefill | null>(null);
   const [singlePerpPrefill, setSinglePerpPrefill] = useState<SinglePerpPrefill | null>(null);
+  const [wizard, setWizard] = useState<StrategyWizardIntent | null>(null);
+  const [railOpen, setRailOpen] = useState(false);
+  const [setupNonce, setSetupNonce] = useState(0);
   const prefillNonce = useRef(0);
+  // Read by the prefill callbacks, which must stay referentially stable: a
+  // wizard-fired prefill arms the wizard's own tickets and must NOT pop the
+  // manual drawer over it.
+  const wizardRef = useRef<StrategyWizardIntent | null>(null);
+  wizardRef.current = wizard;
 
   const openDeal = useCallback((id: string) => setDealId(id), []);
+  /**
+   * A prefill is a promise that the armed form is on screen. The rail is a
+   * drawer now, so any prefill fired outside the wizard has to open it — and a
+   * prefill fired BY the wizard must not, or the drawer would cover the wizard
+   * and mount a second ticket consuming the same prefill.
+   */
+  const revealRail = () => {
+    if (wizardRef.current === null) setRailOpen(true);
+  };
   const prefillPair = useCallback((p: Omit<PairPrefill, 'nonce'>) => {
     prefillNonce.current += 1;
     setPairPrefill({ ...p, nonce: prefillNonce.current });
+    revealRail();
   }, []);
   // Shares the nonce counter with prefillPair: both arm the same rail, so one
   // monotonic source means a stale prefill can never be applied.
   const prefillBorosOpen = useCallback((p: Omit<BorosOpenPrefill, 'nonce'>) => {
     prefillNonce.current += 1;
     setBorosOpenPrefill({ ...p, nonce: prefillNonce.current });
+    revealRail();
   }, []);
 
   // Shares the one monotonic counter with the other prefills: they all arm the
@@ -161,12 +243,50 @@ export function TradeFlowProvider({ children }: { children: ReactNode }) {
   const prefillSinglePerp = useCallback((p: Omit<SinglePerpPrefill, 'nonce'>) => {
     prefillNonce.current += 1;
     setSinglePerpPrefill({ ...p, nonce: prefillNonce.current });
+    revealRail();
+  }, []);
+
+  /**
+   * Closing an execution surface retires its prefills. Without this, a ticket
+   * mounted LATER (the drawer re-opened by hand) would find the old nonce
+   * ahead of its own state and re-arm a form for a trade the user walked away
+   * from — a loaded order whose subject matches nothing on screen.
+   */
+  const clearPrefills = () => {
+    setPairPrefill(null);
+    setBorosOpenPrefill(null);
+    setSinglePerpPrefill(null);
+  };
+  const openWizard = useCallback((w: StrategyWizardIntent) => {
+    setWizard(w);
+    // One execution surface at a time: the wizard replaces whatever the
+    // drawer was staging.
+    setRailOpen(false);
+    clearPrefills();
+  }, []);
+  const closeWizard = useCallback(() => {
+    setWizard(null);
+    clearPrefills();
+  }, []);
+  const requestSetup = useCallback(() => setSetupNonce((n) => n + 1), []);
+  const openRail = useCallback(() => setRailOpen(true), []);
+  const closeRail = useCallback(() => {
+    setRailOpen(false);
+    clearPrefills();
   }, []);
 
   const api = useMemo<TradeFlowApi>(
     () => ({
       modalOpen: dealId !== null,
       openDeal,
+      wizard,
+      openWizard,
+      closeWizard,
+      setupNonce,
+      requestSetup,
+      railOpen,
+      openRail,
+      closeRail,
       pairPrefill,
       prefillPair,
       borosOpenPrefill,
@@ -174,7 +294,7 @@ export function TradeFlowProvider({ children }: { children: ReactNode }) {
       singlePerpPrefill,
       prefillSinglePerp,
     }),
-    [dealId, openDeal, pairPrefill, prefillPair, borosOpenPrefill, prefillBorosOpen, singlePerpPrefill, prefillSinglePerp],
+    [dealId, openDeal, wizard, openWizard, closeWizard, setupNonce, requestSetup, railOpen, openRail, closeRail, pairPrefill, prefillPair, borosOpenPrefill, prefillBorosOpen, singlePerpPrefill, prefillSinglePerp],
   );
 
   return (

--- a/web/src/trade/TradeRail.tsx
+++ b/web/src/trade/TradeRail.tsx
@@ -1,5 +1,8 @@
 /**
- * Right rail: the order ticket.
+ * The manual order ticket — now the CONTENT of an on-demand drawer rather
+ * than a permanent right rail. The guided path is the StrategyWizard; this
+ * surface is for free-form trades, and mounts only while its drawer is open,
+ * so it can never sit armed beside content it has nothing to do with.
  *
  * The top-level choice is the VENUE, not the execution style:
  *
@@ -22,7 +25,7 @@
  * header names it, and the Boros confirm names the venue and both markets
  * before anything is sent.
  */
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { UnderlineTabs } from '../components/UnderlineTabs';
 import { BorosPairTicket } from './BorosPairTicket';
 import { PairTicket } from './PairTicket';
@@ -51,7 +54,6 @@ export function TradeRail() {
   // execution's result entirely.
   const [borosSeen, setBorosSeen] = useState(false);
   const flow = useTradeFlowOptional();
-  const asideRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     if (venue === 'boros') setBorosSeen(true);
@@ -60,13 +62,13 @@ export function TradeRail() {
   // A strategy-box "Open the perp legs" prefill lands here: make sure the perp
   // pair ticket is visible (PairTicket itself consumes the field values). The
   // venue is set explicitly — a prefill that arrived while the Boros ticket was
-  // open must not silently fill a form the user cannot see.
+  // open must not silently fill a form the user cannot see. No scrolling any
+  // more: the drawer opens over the page, so the armed form is always in view.
   const prefillNonce = flow?.pairPrefill?.nonce ?? 0;
   useEffect(() => {
     if (!prefillNonce) return;
     setVenue('perp');
     setPerpMode('pair');
-    asideRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, [prefillNonce]);
 
   // A missing-perp ROW asks for one leg, so the rail shows the single ticket
@@ -86,18 +88,15 @@ export function TradeRail() {
   useEffect(() => {
     if (!borosOpenNonce) return;
     setVenue('boros');
-    asideRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, [borosOpenNonce]);
 
   return (
-    // The 340px is mirrored by TabBar's right slot so the active tab's cyan
-    // shelf ends exactly where this rail begins — change both together.
-    <aside ref={asideRef} className="flex w-[340px] shrink-0 flex-col gap-4" aria-label="Order ticket">
-      <div className="card px-4 py-4">
-        {/* No "Order ticket" heading: the rail is the only thing in this column
-            and the tabs below name what it is. The venue and mode switches are
-            NAVIGATION — which ticket am I on — so they read as underline tabs,
-            while the settings inside each ticket keep their boxed toggles. */}
+    // The drawer supplies width, heading and scroll; this is just the tickets.
+    <div className="flex flex-col gap-4" aria-label="Order ticket">
+      <div>
+        {/* The venue and mode switches are NAVIGATION — which ticket am I on —
+            so they read as underline tabs, while the settings inside each
+            ticket keep their boxed toggles. */}
         <UnderlineTabs<Venue>
           ariaLabel="Venue"
           value={venue}
@@ -132,6 +131,6 @@ export function TradeRail() {
           </div>
         )}
       </div>
-    </aside>
+    </div>
   );
 }

--- a/web/src/trade/TradeRail.tsx
+++ b/web/src/trade/TradeRail.tsx
@@ -42,7 +42,13 @@ const VENUE_BLURB: Record<Venue, string> = {
   boros: 'Opens fixed-rate positions on Boros.',
 };
 
-export function TradeRail() {
+export function TradeRail({
+  onBusyChange,
+}: {
+  /** True while a Boros execution is in flight — the drawer hosting this rail
+   * locks its close controls off it (see BorosPairTicket.onBusyChange). */
+  onBusyChange?: (busy: boolean) => void;
+} = {}) {
   const [venue, setVenue] = useState<Venue>('perp');
   // Pair is the default within perps: the terminal exists for delta-neutral
   // pair entries.
@@ -127,7 +133,7 @@ export function TradeRail() {
         )}
         {(venue === 'boros' || borosSeen) && (
           <div hidden={venue !== 'boros'}>
-            <BorosPairTicket active={venue === 'boros'} />
+            <BorosPairTicket active={venue === 'boros'} onBusyChange={onBusyChange} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Open a strategy as one guided flow, and make every size say what it means

Opening a 4-leg position was two side-by-side buttons on an Opportunities card.
Styled primary/secondary, they read as *alternatives* — "pick one" — when the
truth is "both, in this order". This replaces them with a single CTA that opens
a two-step wizard, and fixes a family of unit bugs found while building it.

### The flow

- **One CTA per opportunity** → a 2-step modal: **lock the rate on Boros**, then
  **hedge the perps on CrossEx**. Numbered steps state the order the old layout
  contradicted.
- **The hedge is sized from what step 1 actually filled**, not what was asked. A
  short fill hedged at the intended size is a new directional position wearing a
  hedge's name.
- **Leaving with a rate locked but unhedged is guarded** — that state is naked
  directional exposure, and it now says so before you close the modal.
- **Resuming works.** A position with Boros legs and no perps re-enters the
  wizard at step 2 ("Finish this strategy"). This path existed in code but
  nothing reached it.
- The manual order ticket becomes an on-demand drawer rather than a permanent
  column that stayed armed while you looked at unrelated screens.

### Sizing units

One rule, one place (`lib/boros.ts`): **ETH/BTC size in the coin, everything else
in USDT/USDC** — following the Boros collateral, so both halves of a strategy
share a unit and no leg needs an eyeballed FX conversion. Applied to the pair
ticket, the single ticket, the Boros ticket and the close dialog. The close
dialog can now be sized in dollars, converting at the mark.

### Correctness fixes

Found by three review passes over the diff and the execution path:

- **Prefilled Boros legs could land on different maturities.** The cue that
  opens a card's missing legs carries no maturity, so each venue resolved to its
  own first match — Gate lists one ETH market, Hyperliquid lists a later one
  first, and the ticket armed an untradeable pair. Legs now resolve together on
  the soonest **shared** maturity, or not at all.
- **A close could send dollars as a coin quantity** when a position's mark price
  was missing or zero: the unit default didn't consult the mark, only the toggle
  did.
- **Changing coins relabelled the number already in the box** — "2000" typed as
  dollars became 2000 ETH, flipping the wire field from `notional` to `qty`.
- **The wizard sized the hedge off the caller's assumption rather than the
  executed market's collateral**, so an ETH fill could arm the perps in dollars.
- **`sizeUnit` wasn't part of the ticket's idempotency key**, so a lost response
  followed by a unit flip resent the same deal id and the server deduped it —
  the screen said one thing, the venue had done another.
- Pair closes now carry a slippage control (they silently used the default), and
  the Boros ticket surfaces an out-of-range value instead of quietly clamping it.
- Closing one leg of a hedged pair now warns that the other side is left naked.
- The Boros close preview labels its PnL "before fees" and quotes the fee drag.

### Positions

- Perp-only positions render in the same card grammar as tracked ones, instead
  of a second visual language for the same object.
- With no address tracked, a position shows as a full card that makes **no claim
  about Boros legs it never looked for** — the missing-leg rows and cues are
  suppressed, and the "Add Boros address" CTA takes their place.
- A leg shared across maturities states its share on its own row; the duplicated
  card-level banner is gone (the Manual Adjustment column already says it).
- Dropped the `boros.finance` link-out: the app opens Boros legs itself now.

### Also

- **README**: renamed to *Arbitrage with CrossEx*, and corrected stale content —
  a caveat claiming the funding scanner was "not built yet" (it ships as
  `src/core/boros/`), CLI flags that no longer exist, a feature list predating
  the pairing rework, and the SDK version.

### Testing

`web` 634 passing (47 files) · server 828 passing (55 files) · both typechecks
clean. New coverage for the wizard, the unit rule, maturity agreement, the close
dialog's USD path, and the idempotency-key regression — the last three were
mutation-checked (reverting the fix fails the test).