### PR TITLE
Track step 1 as a running book, and lock the surfaces that can drop a live fill

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -237,12 +237,17 @@ function OrderTicketButton() {
 }
 
 /** The manual ticket, mounted ONLY while its drawer is open — a closed drawer
- * cannot sit armed with a stale order. Closing also clears any prefills. */
+ * cannot sit armed with a stale order. Closing also clears any prefills.
+ * `locked` while a Boros execution is in flight: closing would unmount the
+ * ticket, and its fill report — a partial fill's remediation included — and
+ * replay-protection order ids are component state that die with it while the
+ * order executes at the venue regardless. */
 function OrderTicketDrawer() {
   const flow = useTradeFlow();
+  const [busy, setBusy] = useState(false);
   return (
-    <Drawer open={flow.railOpen} title="Order ticket" onClose={flow.closeRail}>
-      <TradeRail />
+    <Drawer open={flow.railOpen} title="Order ticket" locked={busy} onClose={flow.closeRail}>
+      <TradeRail onBusyChange={setBusy} />
     </Drawer>
   );
 }

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -3,36 +3,44 @@ import { useEffect, type ReactNode } from 'react';
 interface Props {
   open: boolean;
   title: string;
+  /** While locked (execution in flight) the ✕ is hidden and Escape/backdrop
+   * are ignored — closing unmounts the children, and an executing ticket's
+   * result would die with them. Mirrors Modal's prop of the same name. */
+  locked?: boolean;
   onClose: () => void;
   children: ReactNode;
 }
 
 /** Right-side overlay drawer (Settings). Escape or backdrop click closes. */
-export function Drawer({ open, title, onClose, children }: Props) {
+export function Drawer({ open, title, locked = false, onClose, children }: Props) {
   useEffect(() => {
-    if (!open) return;
+    if (!open || locked) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      // e.repeat: a HELD Escape auto-repeats, and surfaces with an arm-then-
+      // confirm close guard would see the repeat as the confirming second call.
+      if (e.key === 'Escape' && !e.repeat) onClose();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [open, onClose]);
+  }, [open, locked, onClose]);
 
   if (!open) return null;
   return (
     <div className="fixed inset-0 z-50" role="dialog" aria-modal="true" aria-label={title}>
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-[2px]" onClick={onClose} />
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-[2px]" onClick={locked ? undefined : onClose} />
       <div className="absolute inset-y-0 right-0 flex w-[380px] max-w-[92vw] flex-col border-l border-ink-700 bg-ink-900 shadow-2xl">
         <div className="flex items-center justify-between border-b border-ink-800 px-5 py-4">
           <h2 className="text-sm font-semibold text-ink-100">{title}</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="close"
-            className="rounded-md px-2 py-0.5 text-ink-400 transition-colors hover:bg-ink-800 hover:text-ink-100"
-          >
-            ✕
-          </button>
+          {!locked && (
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="close"
+              className="rounded-md px-2 py-0.5 text-ink-400 transition-colors hover:bg-ink-800 hover:text-ink-100"
+            >
+              ✕
+            </button>
+          )}
         </div>
         <div className="flex-1 overflow-y-auto px-5 py-4">{children}</div>
       </div>

--- a/web/src/components/Modal.tsx
+++ b/web/src/components/Modal.tsx
@@ -18,7 +18,10 @@ export function Modal({ title, locked = false, onClose, widthClass = 'w-[700px]'
   useEffect(() => {
     if (locked) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+      // e.repeat: a HELD Escape auto-repeats, and surfaces with an arm-then-
+      // confirm close guard (the wizard's leave warning) would see the repeat
+      // as the confirming second call.
+      if (e.key === 'Escape' && !e.repeat) onClose();
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);

--- a/web/src/panels/ClosePairForm.test.tsx
+++ b/web/src/panels/ClosePairForm.test.tsx
@@ -6,11 +6,11 @@
  * "respected" because it could not be expressed. The single-leg ClosePopover
  * always had the control; this is the two-leg surface catching up.
  */
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
-import type { ActionInput, PreviewResponse } from '../api/types';
+import type { ActionInput, DealRequest, PreviewResponse } from '../api/types';
 import { baseHandlers, previewFor } from '../test/fixtures';
 import { env, server } from '../test/server';
 import { renderWithClient } from '../test/utils';
@@ -95,4 +95,47 @@ describe('ClosePairForm — the slippage the user sets is the slippage sent', ()
       expect.stringContaining("the hedge leg is sent at market, inside the venue's own price band"),
     );
   });
+});
+
+describe('ClosePairForm — slippage is part of the close intent', () => {
+  it('mints a NEW deal id when slippage changes after a lost response', async () => {
+    /**
+     * Mirrors PairTicket's size-unit regression: `slippagePct` rides the wire
+     * and sets the close's price band, so it must be in the intentKey. Without
+     * it, a lost-response confirm at 0.5% followed by an edit to 2% produced a
+     * byte-identical key — the persisted deal id was resent, the server
+     * deduped it into the ORIGINAL band, and the form showed the new one.
+     */
+    const dealCalls: DealRequest[] = [];
+    server.use(
+      ...baseHandlers(),
+      previewSpy([]),
+      http.post('/api/deals', async ({ request }) => {
+        dealCalls.push((await request.json()) as DealRequest);
+        return HttpResponse.json(
+          { ok: false, error: { category: 'network', message: 'socket hang up', retryable: true } },
+          { status: 500 },
+        );
+      }),
+    );
+    renderWithClient(<ClosePairForm base="HYPE" legs={LEGS} />);
+
+    const btn = await screen.findByRole('button', { name: /Close both/ });
+    await waitFor(() => expect(btn).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(btn);
+    await waitFor(() => expect(dealCalls).toHaveLength(1), { timeout: 2_000 });
+
+    const slip = screen.getByLabelText('Slippage %');
+    await userEvent.clear(slip);
+    await userEvent.type(slip, '2');
+
+    const btn2 = screen.getByRole('button', { name: /Close both/ });
+    await waitFor(() => expect(btn2).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(btn2);
+    await waitFor(() => expect(dealCalls).toHaveLength(2), { timeout: 2_000 });
+
+    // A different band is a different order ⇒ a different id, so the server
+    // cannot dedupe the 2% close into the 0.5% one.
+    expect(dealCalls[1].id).not.toBe(dealCalls[0].id);
+  }, 15_000);
 });

--- a/web/src/panels/PerpOnlyBox.tsx
+++ b/web/src/panels/PerpOnlyBox.tsx
@@ -342,7 +342,13 @@ export function ClosePairForm({
         label="Close both ▸"
         // See CloseBoth: the per-mount pairGroupId would otherwise change the
         // intent identity on every remount and break idempotent recovery.
-        intentKey={['closeBoth', ...legs.map((l) => `${l.symbol}:${l.qty}`)].join('|')}
+        // ⚠ `slip` is part of the intent — it rides the wire as `slippagePct`
+        // and sets the close's price band. Without it here, a lost-response
+        // confirm followed by a slippage edit produced a byte-identical key,
+        // so the persisted deal id was resent and the server deduped it into
+        // the ORIGINAL band while the form showed the new one — the same bug
+        // class PairTicket's intentKey fixes by carrying `sizeUnit`.
+        intentKey={['closeBoth', String(slip), ...legs.map((l) => `${l.symbol}:${l.qty}`)].join('|')}
         buttonClassName="w-full"
         // The panel above already reviews this close; the hover card would
         // repeat it on top of the dialog. Errors still surface.

--- a/web/src/trade/BorosPairTicket.test.tsx
+++ b/web/src/trade/BorosPairTicket.test.tsx
@@ -1107,9 +1107,35 @@ describe('BorosPairTicket — slippage is stated, not silently clamped', () => {
     await user.clear(slip);
     await user.type(slip, '50');
 
-    expect(await screen.findByText(/Max slippage cannot exceed/)).toBeInTheDocument();
+    expect(await screen.findByText(/Max slippage must be greater than 0/)).toBeInTheDocument();
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /Confirm/ })).toBeDisabled(),
     );
+  });
+
+  it('blocks confirm on a typed ZERO — the seeded default must not go out silently', async () => {
+    /**
+     * The check used to be one-sided: only `> MAX_SLIP_PCT` was flagged, while
+     * a typed 0 (or a cleared box, or a negative) fell through to `pctToApr`'s
+     * fallback — the order went out carrying the SEEDED default as its rate
+     * bound, a bound the user explicitly did not choose, with "0" on screen.
+     */
+    server.use(...handlers());
+    const user = userEvent.setup();
+    renderWithClient(<BorosPairTicket />);
+    await fillTicket(user);
+
+    const slip = screen.getByLabelText(/Max slippage/);
+    await user.clear(slip);
+    await user.type(slip, '0');
+
+    expect(await screen.findByText(/Max slippage must be greater than 0/)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Confirm/ })).toBeDisabled(),
+    );
+
+    // A cleared box is the same dishonesty — empty on screen, seed on the wire.
+    await user.clear(slip);
+    expect(await screen.findByText(/Max slippage must be greater than 0/)).toBeInTheDocument();
   });
 });

--- a/web/src/trade/BorosPairTicket.tsx
+++ b/web/src/trade/BorosPairTicket.tsx
@@ -92,6 +92,7 @@ const newOrderIds = () => ({ a: `a-${uuid()}`, b: `b-${uuid()}` });
 export function BorosPairTicket({
   active = true,
   onExecuted,
+  onBusyChange,
 }: {
   active?: boolean;
   /**
@@ -100,6 +101,15 @@ export function BorosPairTicket({
    * these. Re-deriving it there could disagree with the ticket that traded.
    */
   onExecuted?: (result: BorosPairResult, collateral: string) => void;
+  /**
+   * True while an execution is in flight. The surface hosting this ticket
+   * (wizard modal, order-ticket drawer) locks its close controls off it:
+   * unmounting mid-execution skips the mutate-level onSuccess, so the fill
+   * report — including a partial fill's Complete/Unwind remediation — and the
+   * replay-protection order ids would die with the component while the order
+   * executes at the venue regardless.
+   */
+  onBusyChange?: (busy: boolean) => void;
 } = {}) {
   const tracked = useTrackedAddressOptional();
   const agent = useBorosAgent();
@@ -372,8 +382,14 @@ export function BorosPairTicket({
    * disagreement visible instead of silent.
    */
   const slipOutOfRange = (raw: string): boolean => {
+    // ⚠ Two-sided on purpose. Flagging only the too-large direction left the
+    // other half of the same dishonesty in place: a typed zero, negative, or
+    // cleared value fell through to `pctToApr`'s fallback and the order went
+    // out carrying the SEEDED default as its rate bound — a bound the user
+    // explicitly did not choose, with nothing on screen saying so. (The boxes
+    // are seeded, so an empty value only exists after a deliberate clear.)
     const n = Number(raw);
-    return raw.trim() !== '' && Number.isFinite(n) && n > MAX_SLIP_PCT;
+    return raw.trim() === '' || !Number.isFinite(n) || n <= 0 || n > MAX_SLIP_PCT;
   };
   const slipInvalid = perLeg
     ? slipOutOfRange(slipStrA) || slipOutOfRange(slipStrB)
@@ -444,6 +460,20 @@ export function BorosPairTicket({
   const execute = useExecuteBorosPair();
   const cancelClose = useBorosCancelAndClose();
 
+  // Tell the host surface an execution is in flight, so it can lock its close
+  // controls (see the prop doc). Cleared on unmount so a host never stays
+  // locked by a ticket that is gone. A follow-up could make an interrupted
+  // execution genuinely recoverable — persist the in-flight order ids the way
+  // pendingBasket.ts does and re-POST on remount to hit the server's replay
+  // memo — but while the report lives only in this component, blocking the
+  // close is what keeps a live fill visible.
+  const busy = execute.isPending;
+  useEffect(() => {
+    onBusyChange?.(busy);
+    return () => onBusyChange?.(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [busy]);
+
   /**
    * Freshness is judged HERE, not by the server's gate.
    *
@@ -472,7 +502,7 @@ export function BorosPairTicket({
       ? [
           {
             code: 'slippage-out-of-range',
-            message: `Max slippage cannot exceed ${MAX_SLIP_PCT}% APR — lower it, or the order would carry a rate bound you did not choose.`,
+            message: `Max slippage must be greater than 0 and at most ${MAX_SLIP_PCT}% APR — the order would otherwise carry a rate bound you did not choose.`,
           },
         ]
       : []),

--- a/web/src/trade/ClosePopover.test.tsx
+++ b/web/src/trade/ClosePopover.test.tsx
@@ -1,8 +1,10 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
+import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { ActionInput, DealRequest, PreviewResponse } from '../api/types';
+import type { ActionInput, CrossexPosition, DealRequest, PreviewResponse } from '../api/types';
+import { sig } from '../lib/fmt';
 import { baseHandlers, ethPosition, makeCrossexPosition, previewFor } from '../test/fixtures';
 import { env, server } from '../test/server';
 import { renderWithClient } from '../test/utils';
@@ -357,5 +359,72 @@ describe('ClosePopover — closing one side of a hedge', () => {
     renderWithClient(<ClosePopover position={ethPosition} onDismiss={() => {}} />);
     await screen.findByText(/marketable limit px/);
     expect(screen.queryByText(/leaves that one unhedged/)).not.toBeInTheDocument();
+  });
+});
+
+describe('ClosePopover — the conversion mark is latched at open', () => {
+  const hype = makeCrossexPosition({
+    symbol: 'BYBIT_FUTURE_HYPE_USDT',
+    positionQty: '1.89',
+    markPrice: '80',
+    entryPrice: '78',
+  });
+
+  /** Simulates the 4s positions poll delivering a refreshed position whose
+   * mark has turned unusable while the dialog is up. */
+  function MarkFlipHarness() {
+    const [pos, setPos] = useState<CrossexPosition>(hype);
+    return (
+      <>
+        <button type="button" onClick={() => setPos(makeCrossexPosition({ ...hype, markPrice: '0' }))}>
+          break-mark
+        </button>
+        <ClosePopover position={pos} onDismiss={() => {}} />
+      </>
+    );
+  }
+
+  it('a mark that breaks mid-dialog does NOT relabel the typed USD figure', async () => {
+    /**
+     * `effUnit` used to re-derive from the LIVE markPrice each render while
+     * the typed digits persisted — a mark arriving as ''/'0' mid-edit flipped
+     * the unit to 'base' and re-read "$50" as 50 HYPE (~40× the close), with
+     * only the label quietly changing. The mark is latched at open now.
+     */
+    server.use(...baseHandlers(), closePreviewHandler());
+    renderWithClient(<MarkFlipHarness />);
+    await screen.findByText(/marketable limit px/);
+
+    await userEvent.click(screen.getByRole('radio', { name: 'partial' }));
+    await userEvent.type(screen.getByLabelText('Close value'), '50');
+    await userEvent.click(screen.getByRole('button', { name: 'break-mark' }));
+
+    // Still a DOLLAR box, still converting at the mark the dialog opened with.
+    expect(screen.getByLabelText('Close value')).toHaveValue('50');
+    expect(screen.queryByLabelText('Close qty')).not.toBeInTheDocument();
+    expect(await screen.findByText(/0\.625/)).toBeInTheDocument();
+  });
+
+  it('accepts the USD maximum the dialog itself displays', async () => {
+    /**
+     * The max is DISPLAYED via sig() (round-to-nearest) but was validated by
+     * exact conversion: whenever sig rounded up, typing the placeholder's own
+     * figure converted to a hair above posQty and was refused by an error
+     * naming the very number it rejected. Within rounding distance the entry
+     * is accepted and the wire qty is clamped to the position.
+     */
+    server.use(...baseHandlers(), closePreviewHandler());
+    renderWithClient(
+      <ClosePopover position={makeCrossexPosition({ ...hype, markPrice: '80.001' })} onDismiss={() => {}} />,
+    );
+    await screen.findByText(/marketable limit px/);
+    await userEvent.click(screen.getByRole('radio', { name: 'partial' }));
+
+    // The placeholder's own stated max: sig(1.89 × 80.001) rounds UP.
+    const max = sig(1.89 * 80.001);
+    await userEvent.type(screen.getByLabelText('Close value'), max);
+
+    expect(screen.queryByText(/close size exceeds position/)).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Close now ▸' })).toBeEnabled());
   });
 });

--- a/web/src/trade/ClosePopover.tsx
+++ b/web/src/trade/ClosePopover.tsx
@@ -95,7 +95,17 @@ export function ClosePopover({
   const [unit, setUnit] = useState<'base' | 'usd'>(() =>
     shared ? 'base' : sizeUnitForBase(base),
   );
-  const mark = Number(position.markPrice);
+  /**
+   * ⚠ LATCHED at dialog open, not read live. The `position` prop refreshes
+   * from the 4s positions poll while the dialog is up, and `effUnit` below is
+   * derived from the mark — so a mark that turned empty/zero mid-dialog would
+   * silently re-read a typed "$300" as 300 COINS (and a recovering mark would
+   * divide typed coins by it), with only the label quietly changing. The
+   * conversion price the user was shown when they started typing is the one
+   * every read uses until the dialog closes; the preview below still quotes
+   * live prices server-side.
+   */
+  const [mark] = useState(() => Number(position.markPrice));
   const markOk = Number.isFinite(mark) && mark > 0;
   /**
    * ⚠ USD is only a legal unit while there is a mark to convert AT.
@@ -129,12 +139,24 @@ export function ClosePopover({
    * option is not offered at all, so this cannot silently divide by a stale or
    * zero price.
    */
-  const qtyNum = effUnit === 'usd' ? entered / mark : entered;
+  const rawQty = effUnit === 'usd' ? entered / mark : entered;
+  /**
+   * The displayed maximum is `sig()`-rounded to-nearest, so typing the
+   * dialog's OWN stated limit ("≤ 151.2019") can convert to a hair above
+   * `posQty` — refusing it would reject the very figure the placeholder and
+   * the error message name. Sizes within rounding distance are accepted and
+   * clamped to the position, so nothing can over-close.
+   */
+  const qtyNum = Math.min(rawQty, posQty);
   const partialMissing = mode === 'partial' && qtyStr.trim() === '';
   const partialInvalid =
     mode === 'partial' &&
     qtyStr.trim() !== '' &&
-    (!Number.isFinite(entered) || entered <= 0 || !Number.isFinite(qtyNum) || qtyNum <= 0 || qtyNum > posQty);
+    (!Number.isFinite(entered) ||
+      entered <= 0 ||
+      !Number.isFinite(rawQty) ||
+      rawQty <= 0 ||
+      rawQty > posQty * (1 + 1e-6));
 
   const action = useMemo<ActionInput | null>(() => {
     if (slipInvalid || partialMissing || partialInvalid) return null;

--- a/web/src/trade/StrategyWizard.test.tsx
+++ b/web/src/trade/StrategyWizard.test.tsx
@@ -145,7 +145,16 @@ const market = (over: Record<string, unknown> = {}) => ({
 });
 
 /** A wizard whose Boros step can actually be filled and executed. */
-const tradableHandlers = (result: Record<string, unknown>, collateral = 'USDT') => [
+/** Pass an ARRAY of results to script SEQUENTIAL executions (a partial then
+ * its completion, a retry, a close): call N answers with results[N], and the
+ * last one repeats. A single result behaves as before. */
+const tradableHandlers = (result: Record<string, unknown> | Record<string, unknown>[], collateral = 'USDT') => {
+  const sequence = Array.isArray(result) ? result : [result];
+  let call = 0;
+  return tradableHandlersSeq(() => sequence[Math.min(call++, sequence.length - 1)], collateral);
+};
+
+const tradableHandlersSeq = (next: () => Record<string, unknown>, collateral: string) => [
   http.get('/api/boros/agent', () =>
     HttpResponse.json(
       env({
@@ -197,7 +206,7 @@ const tradableHandlers = (result: Record<string, unknown>, collateral = 'USDT') 
     ),
   ),
   http.post('/api/boros/pair/execute', () =>
-    HttpResponse.json(env({ result, estimate: null, warnings: [] })),
+    HttpResponse.json(env({ result: next(), estimate: null, warnings: [] })),
   ),
 ];
 
@@ -295,4 +304,375 @@ describe('StrategyWizard — step 1 becomes a receipt once the rate is locked', 
     // And no Dismiss — the receipt IS the step; hiding it would blank it.
     expect(screen.queryByRole('button', { name: 'Dismiss' })).not.toBeInTheDocument();
   });
+});
+
+// ---------------------------------------------------------------------------
+// The step-1 BOOK: every execution folds; "locked" means the book is clean
+// ---------------------------------------------------------------------------
+
+/** The sentinel a not-submitted leg comes back as (orders.ts `notSubmitted`). */
+const NOT_SUBMITTED = {
+  marketId: 0,
+  direction: 'short',
+  filledSize: 0,
+  shortfallSize: 0,
+  execApr: null,
+  feeSize: null,
+  failure: null,
+};
+
+/** Both legs venue-rejected: fills 0 under a 200. The old receipt gate read
+ * `unhedgedSize > 0`, which is 0 here — and showed "Rate locked ✓". */
+const ZERO_FILL = {
+  legA: { marketId: HL_M, direction: 'short', filledSize: 0, shortfallSize: 1000, execApr: null, feeSize: null, failure: { code: 'rate-deviation', message: 'rate moved beyond the band' } },
+  legB: { marketId: BN_M, direction: 'long', filledSize: 0, shortfallSize: 1000, execApr: null, feeSize: null, failure: { code: 'rate-deviation', message: 'rate moved beyond the band' } },
+  hedgedSize: 0,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: null,
+  partial: true,
+  bothLegsSubmitted: true,
+};
+
+/** Leg A fills whole, leg B falls 400 short: 600 hedged, 400 directional. */
+const PARTIAL_600 = {
+  legA: { marketId: HL_M, direction: 'short', filledSize: 1000, shortfallSize: 0, execApr: 0.09, feeSize: 4, failure: null },
+  legB: { marketId: BN_M, direction: 'long', filledSize: 600, shortfallSize: 400, execApr: 0.042, feeSize: 3, failure: null },
+  hedgedSize: 600,
+  unhedgedSize: 400,
+  unhedgedLeg: 'A',
+  realisedSpreadApr: null,
+  partial: true,
+  bothLegsSubmitted: true,
+};
+
+/** The 400-unit one-leg completion of PARTIAL_600's deficient leg B. */
+const COMPLETION_400 = {
+  legA: NOT_SUBMITTED,
+  legB: { marketId: BN_M, direction: 'long', filledSize: 400, shortfallSize: 0, execApr: 0.041, feeSize: 2, failure: null },
+  hedgedSize: 0,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: null,
+  partial: false,
+  bothLegsSubmitted: false,
+};
+
+/** The same completion, FAILED at the venue — still a 200. */
+const COMPLETION_FAIL = {
+  legA: NOT_SUBMITTED,
+  legB: { marketId: BN_M, direction: 'long', filledSize: 0, shortfallSize: 400, execApr: null, feeSize: null, failure: { code: 'insufficient-depth', message: 'not enough depth inside the band' } },
+  hedgedSize: 0,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: null,
+  partial: true,
+  bothLegsSubmitted: false,
+};
+
+/** Both legs short by DIFFERENT amounts: 500 hedged, 200 directional. */
+const UNEVEN_PARTIAL = {
+  legA: { marketId: HL_M, direction: 'short', filledSize: 700, shortfallSize: 300, execApr: 0.09, feeSize: 3, failure: null },
+  legB: { marketId: BN_M, direction: 'long', filledSize: 500, shortfallSize: 500, execApr: 0.042, feeSize: 2, failure: null },
+  hedgedSize: 500,
+  unhedgedSize: 200,
+  unhedgedLeg: 'A',
+  realisedSpreadApr: null,
+  partial: true,
+  bothLegsSubmitted: true,
+};
+
+/** The pair-shaped retry Retry arms for UNEVEN_PARTIAL (min shortfall 300),
+ * filling clean. The book is then 1000/800 — still 200 directional. */
+const RETRY_300 = {
+  legA: { marketId: HL_M, direction: 'short', filledSize: 300, shortfallSize: 0, execApr: 0.088, feeSize: 1, failure: null },
+  legB: { marketId: BN_M, direction: 'long', filledSize: 300, shortfallSize: 0, execApr: 0.043, feeSize: 1, failure: null },
+  hedgedSize: 300,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: 0.045,
+  partial: false,
+  bothLegsSubmitted: true,
+};
+
+/** A deliberate one-leg lock (the ticket's Single mode). */
+const SINGLE_LOCK = {
+  legA: { marketId: HL_M, direction: 'short', filledSize: 1000, shortfallSize: 0, execApr: 0.09, feeSize: 4, failure: null },
+  legB: NOT_SUBMITTED,
+  hedgedSize: 0,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: null,
+  partial: false,
+  bothLegsSubmitted: false,
+};
+
+/** The close that unwinds SINGLE_LOCK — opposite direction, same market. */
+const SINGLE_CLOSE = {
+  legA: { marketId: HL_M, direction: 'long', filledSize: 1000, shortfallSize: 0, execApr: 0.091, feeSize: 4, failure: null },
+  legB: NOT_SUBMITTED,
+  hedgedSize: 0,
+  unhedgedSize: 0,
+  unhedgedLeg: null,
+  realisedSpreadApr: null,
+  partial: false,
+  bothLegsSubmitted: false,
+};
+
+const WIZ = { ...INTENT, maturity: MAT, borosLongVenue: 'BINANCE', borosShortVenue: 'HYPERLIQUID' };
+
+/** Arm, wait for the tradable state, hold-to-confirm the pair. */
+const confirmPair = async () => {
+  await waitFor(() => expect(screen.getByLabelText('Leg A')).toHaveValue(String(BN_M)));
+  const confirm = await screen.findByRole('button', { name: /Confirm — 2 Boros market orders/ });
+  await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 4000 });
+  fireEvent.pointerDown(confirm);
+};
+
+describe('StrategyWizard — the book decides, not the last result', () => {
+  it('a ZERO fill keeps the live ticket: no receipt, no Continue, Retry works', async () => {
+    /**
+     * The receipt gate used to read `unhedgedSize > 0`, and a both-legs-zero
+     * rejection reports unhedgedSize 0 — so nothing filled, the ticket
+     * unmounted, and "Rate locked ✓ — hedge the perps" armed a FULL-SIZE perp
+     * pair against a rate position that does not exist, over dead
+     * Complete/Retry buttons.
+     */
+    server.use(...tradableHandlers(ZERO_FILL), ...symbolHandlers([ETH_GATE]));
+    renderWizard(WIZ);
+    await confirmPair();
+
+    // The ticket's own failure report, with its REAL remediation…
+    expect(await screen.findByRole('button', { name: 'Retry' }, { timeout: 4000 })).toBeEnabled();
+    // …and nothing claiming a rate was locked.
+    expect(screen.queryByRole('button', { name: /Rate locked/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Continue anyway/ })).not.toBeInTheDocument();
+  }, 15_000);
+
+  it('a partial and its completion make ONE aggregate receipt, sizing the hedge', async () => {
+    /**
+     * The old merge kept the PRE-completion hedgedSize (600) and the receipt
+     * described whichever result came last — the book is what actually traded:
+     * 1000/1000 after the top-up.
+     */
+    server.use(...tradableHandlers([PARTIAL_600, COMPLETION_400]), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...WIZ, notionalUsd: 1000 });
+    await confirmPair();
+
+    // Partial: the wizard names the unmatched size and the ticket stays live.
+    expect(await screen.findByText(/400 USDT is unmatched/, undefined, { timeout: 4000 })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rate locked/ })).not.toBeInTheDocument();
+
+    // Complete the deficient leg through the ticket's own report.
+    fireEvent.click(screen.getByRole('button', { name: 'Complete now at market' }));
+    const complete = await screen.findByRole('button', { name: /^Confirm — complete leg/ }, { timeout: 4000 });
+    await waitFor(() => expect(complete).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(complete);
+
+    // ONE receipt, reading the AGGREGATE — not the 400 top-up, not the stale 600.
+    await screen.findByText(/1,000 USDT hedged/, undefined, { timeout: 4000 });
+    fireEvent.click(screen.getByRole('button', { name: /Rate locked/ }));
+    await waitFor(() => {
+      const pair = prefillsSeen.find((x) => x.kind === 'pair');
+      expect(pair?.payload.notionalUsd).toBe(1000);
+    });
+  }, 20_000);
+
+  it('a FAILED completion leaves the residual standing', async () => {
+    // The old merge zeroed unhedgedSize on ANY completion result — including
+    // one whose leg filled nothing — erasing a residual that still exists.
+    server.use(...tradableHandlers([PARTIAL_600, COMPLETION_FAIL]), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...WIZ, notionalUsd: 1000 });
+    await confirmPair();
+    await screen.findByText(/400 USDT is unmatched/, undefined, { timeout: 4000 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Complete now at market' }));
+    const complete = await screen.findByRole('button', { name: /^Confirm — complete leg/ }, { timeout: 4000 });
+    await waitFor(() => expect(complete).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(complete);
+
+    // The completion failed at the venue: the round-trip settles back into a
+    // live one-leg report with remediation (clicking Complete cleared the
+    // pair report, so this button is the failed completion's own)…
+    expect(
+      await screen.findByRole('button', { name: /Retry the rest/ }, { timeout: 4000 }),
+    ).toBeInTheDocument();
+    // …and the 400 stays flagged; nothing claims the rate is locked. (The old
+    // merge zeroed the residual here and rendered the receipt.)
+    expect(screen.getByText(/400 USDT is unmatched/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rate locked/ })).not.toBeInTheDocument();
+  }, 20_000);
+
+  it('a pair-shaped Retry ADDS to the book — the hedge is the aggregate', async () => {
+    /**
+     * Retry after a both-short partial re-arms a PAIR at the min shortfall,
+     * and its result REPLACED `locked`: the receipt read "300 hedged" and the
+     * perps armed at 300 against a true book of 1000/800.
+     */
+    server.use(...tradableHandlers([UNEVEN_PARTIAL, RETRY_300]), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...WIZ, notionalUsd: 1000 });
+    await confirmPair();
+    await screen.findByText(/200 USDT is unmatched/, undefined, { timeout: 4000 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    const retry = await screen.findByRole('button', { name: /Confirm — 2 Boros market orders/ }, { timeout: 4000 });
+    await waitFor(() => expect(retry).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(retry);
+
+    // The retry's own clean report shows inside the ticket (300 hedged)…
+    await screen.findByText(/300 USDT hedged/, undefined, { timeout: 4000 });
+    // …but the BOOK is 1000/800: still lopsided, still no "Rate locked ✓".
+    expect(screen.getByText(/200 USDT is unmatched/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rate locked/ })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Continue anyway/ }));
+    await waitFor(() => {
+      const pair = prefillsSeen.find((x) => x.kind === 'pair');
+      expect(pair?.payload.notionalUsd).toBe(800);
+    });
+  }, 20_000);
+
+  it('a single-leg lock is one-sided exposure — never "Rate locked ✓"', async () => {
+    // A one-leg result reports unhedgedSize 0, so the old gate read it as a
+    // clean pair lock and armed BOTH perp legs at the full intent size.
+    server.use(...tradableHandlers(SINGLE_LOCK), ...symbolHandlers([ETH_GATE]));
+    renderWizard(WIZ);
+    await waitFor(() => expect(screen.getByLabelText('Leg A')).toHaveValue(String(BN_M)));
+    fireEvent.click(screen.getByRole('radio', { name: 'Single' }));
+    const confirm = await screen.findByRole('button', { name: /Confirm — 1 Boros market order/ });
+    await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(confirm);
+
+    expect(
+      await screen.findByText(/Only one side of the rate pair is on/, undefined, { timeout: 4000 }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rate locked/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Continue anyway/ })).not.toBeInTheDocument();
+
+    // And leaving THIS is guarded: one leg on is exposure, whatever made it.
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(
+      await screen.findByText(/until the perp legs open you hold directional exposure/),
+    ).toBeInTheDocument();
+  }, 15_000);
+
+  it('a close through the wizard SUBTRACTS — a book closed to zero leaves silently', async () => {
+    server.use(...tradableHandlers([SINGLE_LOCK, SINGLE_CLOSE]), ...symbolHandlers([ETH_GATE]));
+    renderWizard(WIZ);
+    await waitFor(() => expect(screen.getByLabelText('Leg A')).toHaveValue(String(BN_M)));
+    fireEvent.click(screen.getByRole('radio', { name: 'Single' }));
+    const confirm = await screen.findByRole('button', { name: /Confirm — 1 Boros market order/ });
+    await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(confirm);
+    await screen.findByText(/Only one side of the rate pair is on/, undefined, { timeout: 4000 });
+
+    // Unwind it: dismiss the report (which clears the size — its point), flip
+    // the intent to Close, re-enter the size, execute.
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    fireEvent.click(screen.getByRole('radio', { name: /^Close/ }));
+    // Single-mode label is "Size (USDT)" — not the pair's "Size per leg".
+    fireEvent.change(screen.getByLabelText(/^Size \(/), { target: { value: '1000' } });
+    const confirm2 = await screen.findByRole('button', { name: /Confirm — 1 Boros market order/ });
+    await waitFor(() => expect(confirm2).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(confirm2);
+
+    // The book is flat again: the banner clears…
+    await waitFor(
+      () => expect(screen.queryByText(/Only one side of the rate pair is on/)).not.toBeInTheDocument(),
+      { timeout: 4000 },
+    );
+    // …and leaving needs no warning — nothing naked remains.
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByText('Open this strategy')).not.toBeInTheDocument());
+  }, 20_000);
+});
+
+describe('StrategyWizard — continue arms once per book state', () => {
+  it('Back → Continue with nothing new executed does NOT re-arm the perp ticket', async () => {
+    // Every Continue used to fire a fresh prefill, so re-reading the receipt
+    // and coming forward wiped the user's step-2 edits back to the fill size.
+    server.use(...tradableHandlers(CLEAN_FILL), ...symbolHandlers([ETH_GATE]));
+    renderWizard(WIZ);
+    await confirmPair();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Rate locked/ }, { timeout: 4000 }));
+    await waitFor(() => expect(prefillsSeen.filter((x) => x.kind === 'pair')).toHaveLength(1));
+
+    fireEvent.click(screen.getByRole('button', { name: /Back to the rate legs/ }));
+    fireEvent.click(await screen.findByRole('button', { name: /Rate locked/ }));
+    await screen.findByLabelText(/Size per leg/);
+    // Same book ⇒ same arm: still exactly one pair prefill.
+    expect(prefillsSeen.filter((x) => x.kind === 'pair')).toHaveLength(1);
+  }, 15_000);
+});
+
+describe('StrategyWizard — leaving and closing are deliberate', () => {
+  it('the leave warning cannot be walked through by a second Escape', async () => {
+    // Modal forwards Escape unfiltered, so a HELD key's auto-repeat (or a
+    // backdrop double-click) used to arm the guard and confirm it in one
+    // perceived gesture. Only the banner's explicit Leave closes now.
+    server.use(...agentHandlers(), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...INTENT, initialStep: 2 });
+    await screen.findByLabelText(/Size per leg/);
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(
+      await screen.findByText(/until the perp legs open you hold directional exposure/),
+    ).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    // Still open, still warning.
+    expect(screen.getByText('Finish this strategy')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Leave' }));
+    await waitFor(() => expect(screen.queryByText('Finish this strategy')).not.toBeInTheDocument());
+  });
+
+  it('the modal cannot be closed while a Boros execution is in flight', async () => {
+    // Unmounting the executing ticket skips its onSuccess: the fill report and
+    // its remediation die unseen while the order executes at the venue anyway.
+    server.use(
+      http.post('/api/boros/pair/execute', () => new Promise<never>(() => {})),
+      ...tradableHandlers(CLEAN_FILL),
+      ...symbolHandlers([ETH_GATE]),
+    );
+    renderWizard(WIZ);
+    await waitFor(() => expect(screen.getByLabelText('Leg A')).toHaveValue(String(BN_M)));
+    expect(screen.getByRole('button', { name: 'close' })).toBeInTheDocument();
+
+    const confirm = await screen.findByRole('button', { name: /Confirm — 2 Boros market orders/ });
+    await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(confirm);
+
+    // In flight: the ✕ goes away and Escape is inert.
+    await waitFor(
+      () => expect(screen.queryByRole('button', { name: 'close' })).not.toBeInTheDocument(),
+      { timeout: 4000 },
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.getByText('Open this strategy')).toBeInTheDocument();
+  }, 15_000);
+});
+
+describe('StrategyWizard — token-collateral aggregate sizing', () => {
+  it('scales the USD notional by hedged/sizeBase and passes the coin size', async () => {
+    const ETH_FILL = {
+      ...CLEAN_FILL,
+      legA: { ...CLEAN_FILL.legA, filledSize: 2 },
+      legB: { ...CLEAN_FILL.legB, filledSize: 2 },
+      hedgedSize: 2,
+    };
+    server.use(...tradableHandlers(ETH_FILL, 'ETH'), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...WIZ, notionalUsd: 9000, sizeBase: 3 });
+    await confirmPair();
+
+    // The receipt reads the book in the executed collateral.
+    await screen.findByText(/2 ETH hedged/, undefined, { timeout: 4000 });
+    fireEvent.click(screen.getByRole('button', { name: /Rate locked/ }));
+    await waitFor(() => {
+      const pair = prefillsSeen.find((x) => x.kind === 'pair');
+      // 2 of the intended 3 ETH filled ⇒ 2/3 of the $9,000 intent.
+      expect(pair?.payload.notionalUsd).toBeCloseTo(6000);
+      expect(pair?.payload.sizeBase).toBe(2);
+    });
+  }, 15_000);
 });

--- a/web/src/trade/StrategyWizard.tsx
+++ b/web/src/trade/StrategyWizard.tsx
@@ -23,9 +23,10 @@
  * (StrategyCard's boros-only cue) and re-enters here at step 2.
  */
 import { useEffect, useState } from 'react';
-import type { BorosPairResult } from '../api/types';
+import type { BorosLegFill, BorosPairResult } from '../api/types';
 import { Modal } from '../components/Modal';
 import { isUsdCollateral } from '../lib/boros';
+import { sig } from '../lib/fmt';
 import { BorosPairTicket } from './BorosPairTicket';
 import { PairResultReport } from './BorosPairBits';
 import { PairTicket } from './PairTicket';
@@ -54,6 +55,70 @@ export function StrategyWizard({ onViewPositions }: { onViewPositions?: () => vo
 
 type Step = 1 | 2 | 'done';
 
+/**
+ * One leg slot of the wizard's step-1 book. `size` is SIGNED — +long / −short,
+ * in the executed market's collateral — so a close (which always carries the
+ * direction opposing the position) subtracts on its own, with no intent flag.
+ */
+type SlotFill = { size: number; marketId: number; execApr: number | null };
+
+/**
+ * What step 1 has actually put on, folded across EVERY accepted execution —
+ * the pair fill, its retries, its completions, single-leg orders, and closes.
+ *
+ * The old shape was a single `BorosPairResult` gated on `unhedgedSize > 0`,
+ * and every non-clean path broke it: a both-legs-zero fill reported
+ * unhedgedSize 0 and read as "Rate locked ✓"; a completion's merge kept the
+ * stale hedgedSize; a pair-shaped retry REPLACED the aggregate; a single-leg
+ * or close execution read as a pair lock. A cumulative signed book has none of
+ * those cases — every execution is the same fold.
+ *
+ * This is the wizard's session-relative view only. Account truth lives on the
+ * Positions page (see the header comment); in particular a §6A cancel-and-close
+ * fired from a ticket blocker bypasses `onExecuted` and is invisible here.
+ */
+type StepOneBook = {
+  a: SlotFill;
+  b: SlotFill;
+  /** The unit every `size` is in, from the ticket that traded. */
+  collateral: string;
+  /** Display only (spread attribution) — never a source of leg identity:
+   * a not-submitted leg's sentinel carries a HARDCODED direction (orders.ts). */
+  lastResult: BorosPairResult | null;
+  /** True when the whole book is one clean pair execution — the only case
+   * where that execution's realisedSpreadApr describes the book. */
+  soleClean: boolean;
+};
+
+const EMPTY_SLOT: SlotFill = { size: 0, marketId: 0, execApr: null };
+const EMPTY_BOOK: StepOneBook = {
+  a: EMPTY_SLOT,
+  b: EMPTY_SLOT,
+  collateral: '',
+  lastResult: null,
+  soleClean: false,
+};
+
+/** Was this leg actually sent to the venue? A not-submitted sentinel is
+ * all-zero with no failure (orders.ts `notSubmitted`); a REJECTED leg has
+ * filledSize 0 but a shortfall and a failure, and must still count. */
+const legSubmitted = (leg: BorosLegFill): boolean =>
+  leg.filledSize !== 0 || leg.shortfallSize > 0 || leg.failure !== null;
+
+const foldLeg = (slot: SlotFill, leg: BorosLegFill): SlotFill => {
+  if (!legSubmitted(leg)) return slot;
+  return {
+    // The venue's own defence: never trust the raw sign of filledSize.
+    size: slot.size + (leg.direction === 'long' ? 1 : -1) * Math.abs(leg.filledSize),
+    marketId: leg.marketId,
+    execApr: leg.execApr ?? slot.execApr,
+  };
+};
+
+/** Fills round-trip 18-decimal venue values through float64, so exact-zero
+ * comparisons on the folded book can be off by ~1e-11 forever. */
+const EPS = 1e-9;
+
 function WizardBody({
   w,
   flow,
@@ -63,15 +128,21 @@ function WizardBody({
   flow: TradeFlowApi;
   onViewPositions?: () => void;
 }) {
+  const resuming = (w.initialStep ?? 1) === 2;
   const [step, setStep] = useState<Step>(w.initialStep ?? 1);
-  /** Step 1's last venue result — set on any accepted Boros execution. */
-  const [locked, setLocked] = useState<BorosPairResult | null>(null);
-  /** The unit `locked`'s sizes are in, straight from the ticket that traded. */
-  const [lockedCollateral, setLockedCollateral] = useState('');
+  /** Everything step 1 has executed, as one signed book — see StepOneBook. */
+  const [book, setBook] = useState<StepOneBook>(EMPTY_BOOK);
+  /** The hedged size the perp ticket was last armed with. Continue re-arms
+   * ONLY when the book's hedged size differs — a Back → Continue round-trip
+   * with nothing new executed must not wipe the user's step-2 edits. */
+  const [lastArmedHedge, setLastArmedHedge] = useState<number | null>(null);
   /** Mirrors TradeRail's borosSeen: a visited step stays mounted, hidden. */
   const [perpSeen, setPerpSeen] = useState(w.initialStep === 2);
   /** Two-click close while leaving would strand a naked rate position. */
   const [leaveArmed, setLeaveArmed] = useState(false);
+  /** A Boros execution is in flight — the modal must not be closable: the
+   * response (and a partial fill's remediation) dies with the ticket. */
+  const [executing, setExecuting] = useState(false);
 
   const { prefillBorosOpen, prefillPair, closeWizard } = flow;
 
@@ -79,7 +150,7 @@ function WizardBody({
   // boros-only position). Deliberately once per wizard identity — the body is
   // keyed on it — so ticket edits are never fought by a re-arm.
   useEffect(() => {
-    if ((w.initialStep ?? 1) === 1) {
+    if (!resuming) {
       prefillBorosOpen({
         base: w.base,
         longVenue: w.borosLongVenue,
@@ -104,50 +175,82 @@ function WizardBody({
       ...(w.perpMode ? { mode: w.perpMode } : {}),
     });
 
-  const residual = locked !== null && locked.unhedgedSize > 0;
+  /** Fold one accepted execution into the book. Replays never reach this —
+   * the ticket skips `onExecuted` for them. */
+  const recordExecution = (result: BorosPairResult, collateral: string) =>
+    setBook((prev) => {
+      /**
+       * ⚠ Reset before folding when the legs stopped being the same book.
+       *
+       * The ticket's selects stay editable inside the wizard, so the user can
+       * repick both legs to a different cohort — a different market, possibly
+       * a different COLLATERAL — and execute. Summing ETH into a USDT book
+       * would produce a hedged size in no unit at all, so a submitted leg
+       * whose market differs from the slot's recorded one (or a collateral
+       * change) starts the book over from this execution alone.
+       */
+      const marketChanged =
+        (legSubmitted(result.legA) && prev.a.marketId !== 0 && prev.a.marketId !== result.legA.marketId) ||
+        (legSubmitted(result.legB) && prev.b.marketId !== 0 && prev.b.marketId !== result.legB.marketId);
+      const collateralChanged =
+        prev.collateral !== '' && collateral !== '' && prev.collateral !== collateral;
+      const base = marketChanged || collateralChanged ? EMPTY_BOOK : prev;
+      const wasEmpty = Math.abs(base.a.size) <= EPS && Math.abs(base.b.size) <= EPS;
+      return {
+        a: foldLeg(base.a, result.legA),
+        b: foldLeg(base.b, result.legB),
+        collateral: collateral || base.collateral,
+        lastResult: result,
+        soleClean: wasEmpty && result.bothLegsSubmitted && !result.partial,
+      };
+    });
+
+  // The book, read out: total exposure, the part that cancels (hedged) and
+  // the part that does not (residual). Same-signed slots — a deliberate
+  // single-leg lock, say — have hedged 0 and read as all-residual, which is
+  // exactly what they are.
+  const exposure = Math.abs(book.a.size) + Math.abs(book.b.size);
+  const residualSize = Math.abs(book.a.size + book.b.size);
+  const hedged = (exposure - residualSize) / 2;
+  const stepOneDone = hedged > EPS && residualSize <= EPS * Math.max(1, exposure);
+  const lopsided = !stepOneDone && hedged > EPS;
+  const oneSided = !stepOneDone && hedged <= EPS && exposure > EPS;
 
   const continueToHedge = () => {
     /**
-     * The hedge is sized from what step 1 actually FILLED, not what was asked:
-     * a short fill hedged at the intended size is a new directional position
-     * wearing a hedge's name. `hedgedSize` is the size both legs share; on a
-     * clean fill it equals the intent and this is a no-op. A completion result
-     * (`bothLegsSubmitted` false) or a zero falls back to the original intent —
-     * the report on screen is then the honest source and the field stays
-     * editable.
-     */
-    const fillSize =
-      locked && locked.bothLegsSubmitted && locked.hedgedSize > 0 ? locked.hedgedSize : null;
-    /**
-     * ⚠ What `fillSize` MEANS is a property of the market that traded, not of
-     * what this wizard was told when it opened.
+     * The hedge is sized from what step 1 actually FILLED — the book's hedged
+     * size — not what was asked: a short fill hedged at the intended size is a
+     * new directional position wearing a hedge's name. Both buttons that lead
+     * here are gated on `hedged > 0`, so there is always a real size.
      *
-     * `hedgedSize` is denominated in the executed market's COLLATERAL, so the
-     * only safe discriminator is that collateral — captured from the ticket
-     * that traded. Branching on `w.sizeBase !== undefined` (the old test)
-     * asked "did the caller know a base quantity?", which is a different
-     * question: an ETH cohort whose collateral price was unavailable arrives
-     * with no `sizeBase`, and its ETH fill size was then armed as DOLLARS —
-     * a ~$9,000 rate leg hedged with a $2 perp pair.
+     * ⚠ What `hedged` MEANS is a property of the market that traded, not of
+     * what this wizard was told when it opened. It is denominated in the
+     * executed market's COLLATERAL, so that collateral — captured from the
+     * ticket that traded — is the only safe discriminator. Branching on
+     * `w.sizeBase !== undefined` asked "did the caller know a base quantity?",
+     * which is a different question: an ETH cohort whose collateral price was
+     * unavailable arrives with no `sizeBase`, and its ETH fill size was then
+     * armed as DOLLARS — a ~$9,000 rate leg hedged with a $2 perp pair.
      */
-    if (fillSize === null) {
-      armPerps(w.notionalUsd, w.sizeBase);
-    } else if (isUsdCollateral(lockedCollateral)) {
-      // USD-collateral: the Boros size IS the dollar figure.
-      armPerps(fillSize);
-    } else if (w.sizeBase !== undefined && w.sizeBase > 0) {
-      // Token-collateral, and we know the intended quantity — scale the USD
-      // notional by how much of it actually filled.
-      armPerps(w.notionalUsd * (fillSize / w.sizeBase), fillSize);
-    } else {
-      /**
-       * Token-collateral with no conversion available (no `sizeBase`, so no
-       * price to scale by). `fillSize` is a COIN quantity and must never be
-       * passed as dollars, so the perps keep the intent's USD figure and the
-       * user edits before executing — an approximate hedge they can see beats
-       * an exact-looking one off by the coin price.
-       */
-      armPerps(w.notionalUsd);
+    if (lastArmedHedge === null || Math.abs(hedged - lastArmedHedge) > EPS) {
+      if (isUsdCollateral(book.collateral)) {
+        // USD-collateral: the Boros size IS the dollar figure.
+        armPerps(hedged);
+      } else if (w.sizeBase !== undefined && w.sizeBase > 0) {
+        // Token-collateral, and we know the intended quantity — scale the USD
+        // notional by how much of it actually filled.
+        armPerps(w.notionalUsd * (hedged / w.sizeBase), hedged);
+      } else {
+        /**
+         * Token-collateral with no conversion available (no `sizeBase`, so no
+         * price to scale by). `hedged` is a COIN quantity and must never be
+         * passed as dollars, so the perps keep the intent's USD figure and the
+         * user edits before executing — an approximate hedge they can see
+         * beats an exact-looking one off by the coin price.
+         */
+        armPerps(w.notionalUsd);
+      }
+      setLastArmedHedge(hedged);
     }
     setPerpSeen(true);
     setStep(2);
@@ -156,25 +259,27 @@ function WizardBody({
   /**
    * Is there a rate leg on with no hedge against it?
    *
-   * Either because this wizard just locked one (`locked`), or because it was
-   * OPENED on one — a resume starts at step 2 precisely because the Boros legs
-   * already exist and are unhedged. The second case is the same naked
-   * exposure, and it used to leave silently: the guard tested `locked`, which
-   * a resume never sets.
+   * Either because this wizard put exposure on (any nonzero side of the book —
+   * a one-sided fill counts, and a book closed back to zero through the wizard
+   * stops counting), or because it was OPENED on one — a resume starts at
+   * step 2 precisely because the Boros legs already exist and are unhedged.
    */
-  const unhedgedRateOn = locked !== null || (w.initialStep ?? 1) === 2;
+  const unhedgedRateOn = exposure > EPS || resuming;
 
   const requestClose = () => {
     // Rate locked but not hedged = naked directional exposure. Leaving is
-    // always allowed (Positions derives the resume point), but never silently.
-    if (unhedgedRateOn && step !== 'done' && !leaveArmed) {
+    // always allowed (Positions derives the resume point), but never silently
+    // — and never by momentum: once the warning is up, further Escape presses
+    // and backdrop clicks do nothing, because a held key's auto-repeat or a
+    // double-click would otherwise arm and close in one perceived gesture.
+    // Only the banner's explicit Leave button closes from here.
+    if (unhedgedRateOn && step !== 'done') {
       setLeaveArmed(true);
       return;
     }
     closeWizard();
   };
 
-  const resuming = (w.initialStep ?? 1) === 2;
   /**
    * Venue pair for the subtitle, from whichever side is known.
    *
@@ -203,9 +308,9 @@ function WizardBody({
   );
 
   return (
-    <Modal title={title} onClose={requestClose} widthClass="w-[480px]">
+    <Modal title={title} locked={executing} onClose={requestClose} widthClass="w-[480px]">
       <div className="flex flex-col gap-4">
-        <StepStrip step={step} locked={locked !== null} />
+        <StepStrip step={step} locked={stepOneDone} />
 
         {leaveArmed && step !== 'done' && (
           <div className="flex items-center justify-between gap-3 rounded-lg border border-amber-500/40 bg-amber-500/[0.08] px-3 py-2 text-[12px] leading-relaxed text-amber-100">
@@ -231,27 +336,24 @@ function WizardBody({
         {/* --- Step 1: the Boros rate legs. Not mounted at all on a resume
             (initialStep 2): those rate legs already exist as a position, and
             an idle ticket for them would only poll a quote nobody wants. --- */}
-        {(w.initialStep ?? 1) === 1 && (
+        {!resuming && (
         <div hidden={step !== 1}>
           {/**
-           * ⚠ A SUCCEEDED step is a receipt, not a form.
+           * ⚠ A SUCCEEDED step is a receipt, not a form — and "succeeded"
+           * means the BOOK is clean (hedged > 0, residual 0), never a
+           * property of the last result alone. A both-legs-zero fill reports
+           * unhedgedSize 0 and used to render this receipt for a trade where
+           * nothing filled; the book stays empty there and the live ticket —
+           * with its real failure report and working Retry — stays up.
            *
-           * Once the rate is locked the ticket is replaced by its result. It
-           * used to stay mounted underneath, which put TWO live CTAs in the
-           * modal at once — the ticket's own `Confirm — 2 Boros market orders`
-           * and the wizard's `Rate locked ✓ — hedge the perps` — so the same
-           * pair could be fired a second time by a user the wizard had just
-           * told the rate was locked. (Dismissing the ticket's fill report
-           * calls `setReport(null)`, which returns it to its ordinary armed
-           * state; the wizard's own `locked` never cleared, so both showed.)
-           *
-           * A PARTIAL fill is the exception: its Complete/Retry actions arm
-           * the ticket again, so the form has to stay for that case — there
-           * the residual, not the wizard, is what still needs an order.
+           * The ticket is replaced (not just covered) once done: leaving it
+           * mounted put TWO live CTAs in the modal at once, so the same pair
+           * could be fired a second time by a user the wizard had just told
+           * the rate was locked.
            */}
-          {locked !== null && !residual ? (
+          {stepOneDone ? (
             <div className="flex flex-col gap-3">
-              <StepOneReceipt result={locked} collateral={lockedCollateral} />
+              <StepOneReceipt book={book} hedged={hedged} />
               <button type="button" className="btn btn-primary w-full" onClick={continueToHedge}>
                 Rate locked ✓ — hedge the perps ▸
               </button>
@@ -260,44 +362,37 @@ function WizardBody({
             <>
               <BorosPairTicket
                 active={step === 1}
-                onExecuted={(result, collateral) => {
-                  /**
-                   * ⚠ A COMPLETION must not replace the pair result.
-                   *
-                   * `onExecuted` fires for every accepted execution, including
-                   * the one-leg completion the report's "Complete now" arms.
-                   * A completion always reports `unhedgedSize: 0`
-                   * (orders.ts: `bothSubmitted ? … : 0`), so overwriting
-                   * `locked` with it flipped `residual` to false and made the
-                   * receipt describe the 100-unit top-up instead of the
-                   * 1,000-unit rate lock behind it — and sized the hedge off
-                   * the wrong number.
-                   *
-                   * The PAIR result is the one that describes this step, so it
-                   * is kept; a completion only clears the residual it closed.
-                   */
-                  setLockedCollateral(collateral);
-                  setLocked((prev) =>
-                    prev !== null && !result.bothLegsSubmitted
-                      ? { ...prev, unhedgedSize: 0, unhedgedLeg: null }
-                      : result,
-                  );
-                }}
+                onBusyChange={setExecuting}
+                onExecuted={recordExecution}
               />
-              {locked !== null && (
+              {lopsided && (
                 <div className="mt-3 flex flex-col gap-2">
                   <p className="rounded-lg border border-amber-500/25 bg-amber-500/[0.04] px-2.5 py-1.5 text-[11px] leading-relaxed text-amber-200">
                     {/* Deliberately does not say "the report above": that
                         report can be dismissed, and copy pointing at something
                         no longer on screen reads as a bug. The fact that
                         survives either way is what continuing would cost. */}
-                    One leg filled short. Continuing now hedges only the size both legs share —
-                    the rest stays directional until you complete or close it.
+                    The rate legs are lopsided — {sig(residualSize)}
+                    {book.collateral ? ` ${book.collateral}` : ''} is unmatched. Continuing hedges
+                    only the size both legs share; the rest stays directional until you complete or
+                    close it.
                   </p>
                   <button type="button" className="btn btn-primary w-full" onClick={continueToHedge}>
                     Continue anyway — hedge the perps ▸
                   </button>
                 </div>
+              )}
+              {oneSided && (
+                /* Sometimes deliberate (the ticket's Single mode), so this
+                   describes the position, not a failure — and offers no
+                   Continue: with no shared size there is nothing to hedge,
+                   and arming the intent size here was exactly the bug where
+                   a one-leg book got a full-size "hedge". */
+                <p className="mt-3 rounded-lg border border-amber-500/25 bg-amber-500/[0.04] px-2.5 py-1.5 text-[11px] leading-relaxed text-amber-200">
+                  Only one side of the rate pair is on — that is directional exposure, not a locked
+                  spread. There is no shared size to hedge yet; complete the other leg, or close
+                  this one.
+                </p>
               )}
             </>
           )}
@@ -307,15 +402,21 @@ function WizardBody({
         {/* --- Step 2: the CrossEx perp hedge ----------------------------- */}
         {(step === 2 || perpSeen) && (
           <div hidden={step !== 2}>
-            {step === 2 && locked === null && (w.initialStep ?? 1) === 1 && (
-              // Only reachable via the back link below after arriving armed —
-              // still worth stating whose sizes the ticket is holding.
-              <p className="mb-2 text-[11px] text-ink-400">
-                Sized from the locked rate legs — edit before executing if they differ.
-              </p>
-            )}
+            {step === 2 &&
+              !resuming &&
+              lastArmedHedge !== null &&
+              Math.abs(hedged - lastArmedHedge) > EPS && (
+                // An execution that was still in flight when Continue was
+                // clicked has landed and moved the book. Re-arming here would
+                // wipe the user's edits — the exact bug the lastArmedHedge
+                // gate fixes — so say it instead and let them re-continue.
+                <p className="mb-2 rounded-lg border border-amber-500/25 bg-amber-500/[0.04] px-2.5 py-1.5 text-[11px] leading-relaxed text-amber-200">
+                  The rate legs changed since this hedge was sized — go back to the rate legs and
+                  continue again to re-size it.
+                </p>
+              )}
             <PairTicket onExecuted={() => setStep('done')} />
-            {step === 2 && (w.initialStep ?? 1) === 1 && (
+            {step === 2 && !resuming && (
               <button
                 type="button"
                 className="mt-3 text-[11px] text-ink-400 underline decoration-dotted hover:text-ink-200"
@@ -364,24 +465,41 @@ function WizardBody({
  *
  * Reuses the ticket's own report so the numbers and their wording are the same
  * ones the ticket would have shown — a receipt that paraphrased the fill would
- * be a second source of truth about money. The report's Complete/Retry actions
- * are deliberately inert here: this renders only for a CLEAN fill, where there
- * is nothing left to complete, and a partial keeps the live ticket instead.
+ * be a second source of truth about money. It renders the BOOK (the fold of
+ * every execution), synthesized as a clean result: only reachable when the
+ * book is clean, so the report shows no Complete/Retry, and `onDismiss` is
+ * omitted because the report IS this step now.
+ *
+ * ⚠ Leg identity comes from the book's slots, never from any raw result: a
+ * not-submitted leg's sentinel carries a HARDCODED direction (orders.ts), and
+ * after a completion the "last result" describes only the top-up.
  */
-function StepOneReceipt({
-  result,
-  collateral,
-}: {
-  result: BorosPairResult;
-  collateral: string;
-}) {
+function StepOneReceipt({ book, hedged }: { book: StepOneBook; hedged: number }) {
+  const synthLeg = (slot: SlotFill): BorosLegFill => ({
+    marketId: slot.marketId,
+    direction: slot.size > 0 ? 'long' : 'short',
+    filledSize: Math.abs(slot.size),
+    shortfallSize: 0,
+    execApr: slot.execApr,
+    feeSize: null,
+    failure: null,
+  });
+  const result: BorosPairResult = {
+    legA: synthLeg(book.a),
+    legB: synthLeg(book.b),
+    bothLegsSubmitted: true,
+    hedgedSize: hedged,
+    unhedgedSize: 0,
+    unhedgedLeg: null,
+    // Attributable only when the whole book is one clean execution; a spread
+    // stitched across a partial and its top-up would mislabel money.
+    realisedSpreadApr: book.soleClean ? (book.lastResult?.realisedSpreadApr ?? null) : null,
+    partial: false,
+  };
   return (
     <PairResultReport
       result={result}
-      collateral={collateral}
-      // A clean fill has no residual and no shortfall, so neither action is
-      // rendered; `onDismiss` is omitted because the report IS this step now,
-      // and hiding it would leave the step blank.
+      collateral={book.collateral}
       onComplete={() => {}}
       onRetry={() => {}}
     />

--- a/web/src/trade/TradeRail.tsx
+++ b/web/src/trade/TradeRail.tsx
@@ -42,7 +42,13 @@ const VENUE_BLURB: Record<Venue, string> = {
   boros: 'Opens fixed-rate positions on Boros.',
 };
 
-export function TradeRail() {
+export function TradeRail({
+  onBusyChange,
+}: {
+  /** True while a Boros execution is in flight — the drawer hosting this rail
+   * locks its close controls off it (see BorosPairTicket.onBusyChange). */
+  onBusyChange?: (busy: boolean) => void;
+} = {}) {
   const [venue, setVenue] = useState<Venue>('perp');
   // Pair is the default within perps: the terminal exists for delta-neutral
   // pair entries.
@@ -127,7 +133,7 @@ export function TradeRail() {
         )}
         {(venue === 'boros' || borosSeen) && (
           <div hidden={venue !== 'boros'}>
-            <BorosPairTicket active={venue === 'boros'} />
+            <BorosPairTicket active={venue === 'boros'} onBusyChange={onBusyChange} />
           </div>
         )}
       </div>


### PR DESCRIPTION
Review fixes for #29. Every finding here was verified against the code and the
server-side result semantics in `src/core/boros/orders.ts`, and each one ships
with a test that fails when the fix is reverted.

## The wizard's step-1 state

`StrategyWizard` modelled step 1 as one `BorosPairResult` and branched on
`unhedgedSize > 0` / `bothLegsSubmitted`. That shape is right for a clean pair
fill and wrong for everything else — and each break sized or labelled a hedge
against a rate position that was not there:

- **A both-legs-zero fill read as success.** Venue rejections fold into
  `filledSize: 0` legs and still return 200, reporting `unhedgedSize: 0` — so a
  trade where NOTHING filled rendered "Rate locked ✓" with step 1 checked, over
  Complete/Retry buttons wired to `() => {}`, and continuing armed a **full-size
  perp pair** against nothing.
- **A completion kept the stale hedge size.** "Complete now at market" tops up
  the deficient leg, so a 1000/900 book becomes 1000/1000 — but the merge kept
  `hedgedSize: 900` and hedged 100 short per side. It also zeroed the residual
  unconditionally, erasing a real one when the completion itself failed or
  filled short.
- **A pair-shaped Retry replaced the aggregate.** After 700/500, Retry re-arms
  a pair at the 300 shortfall; its result overwrote the book, so the receipt
  read "300 hedged" and the perps armed at 300 against a true 1000/800.
- **A single-leg or CLOSE execution read as a pair lock.** Both report
  `unhedgedSize: 0`, so the wizard showed "Rate locked ✓" and armed both perp
  legs at the full intent size — the venue whose rate leg was never opened
  carrying full-size floating exposure labelled as hedged.

Step 1 now keeps a **direction-signed book**: `+long / −short` per leg slot, in
the executed market's collateral, folded across every accepted execution.
Closes subtract on their own — a close always carries the direction opposing
the position — so retries, completions, single-leg orders and closes are all
the same fold, with no intent flag threaded through the callback.

"Rate locked ✓" now means the *book* is clean (`hedged > 0`, residual ≈ 0
against a float-dust epsilon, since 18-decimal fills round-trip through
float64). A lopsided book names its unmatched size and offers Continue; a
one-sided book says so and offers **no** Continue, because there is no shared
size to hedge; an empty book keeps the live ticket with its own working Retry.
The hedge is sized from the book's hedged size, and Continue re-arms only when
that size changed — a **Back → Continue round-trip no longer wipes step-2
edits**. The book resets if the legs are repicked mid-wizard, so two collaterals
can never sum into a hedged size in no unit at all.

## Surfaces that could drop a live fill

- **Closing mid-execution.** The wizard's guard read state set only *after* the
  response, and the ticket drawer had no guard at all — so one Escape during
  the round-trip unmounted `BorosPairTicket`, and react-query skips a
  mutate-level `onSuccess` with no listeners. The fill report, a partial fill's
  remediation and the replay-protection order ids all died while the order
  executed at the venue regardless (`RecoveryBanner` covers CrossEx deals
  only). Both surfaces now lock while an execution is in flight — `Modal`
  already had the prop and never received it; `Drawer` gains it.
- **One-sided slippage validation.** The ticket flagged only `> MAX_SLIP_PCT`.
  A typed `0`, a negative, or a cleared box fell through to `pctToApr`'s
  fallback, so the order carried the *seeded default* as its rate bound — one
  the user explicitly did not choose — with their own number on screen.
- **The close dialog's unit could flip mid-edit.** `effUnit` re-derived from
  the live `markPrice` each render while the typed digits persisted, so a mark
  arriving empty/zero from the 4s poll re-read "$300" as 300 coins and stayed
  armed. The conversion price is latched at dialog open.
- **The close dialog refused its own maximum.** The limit is displayed
  `sig()`-rounded but was validated exactly, so typing the figure the
  placeholder and the error message both name was rejected. Entries within
  rounding distance are accepted and clamped to the position.
- **The pair-close intent key omitted `slippagePct`.** After a lost response,
  an edited-slippage retry resent the same deal id and the server deduped it
  into the original band — the class `PairTicket`'s key already fixes by
  carrying `sizeUnit`.

## Not in scope

Three confirmed display bugs from the same review are left for a follow-up:
the degraded box's unconditional "no rate locked" header, the untracked card's
false `unhedged`/`unverified` chips and lost imbalance cue, and stacked
overlays sharing one Escape. All are misleading rather than mis-executing —
every order still goes through its own preview and confirm.

## Testing

`web` 648 passing (47 files) · server 828 passing (55 files) · both typechecks
clean. 14 new tests, one per defect, including sequential-execution coverage
(partial → completion, retry, close) the fixtures could not express before. The
fold, the intent key and the mark latch were mutation-checked.

## Note for review

The leave guard is now stricter than a fix strictly required: once the
"rate locked but not hedged" warning is up, Escape and backdrop clicks do
nothing and only the banner's **Leave** button closes. A held key's auto-repeat
would otherwise arm and confirm the guard in one perceived gesture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)