### PR TITLE
Never margin-block a close, and charge an unwinding open only for what it opens

### DIFF
--- a/src/core/preflight.ts
+++ b/src/core/preflight.ts
@@ -9,6 +9,13 @@
  *  - **Reduce-only legs consume no margin** (a close FREES it). They contribute 0 to
  *    the requirement, so a close (or close-pair) is never blocked — including for an
  *    underwater account, which is exactly the account that most needs to close.
+ *  - **An open leg is netted against the live opposite position.** `reduceOnly` is a
+ *    flag on the ORDER, not a description of its effect: in one-way mode a plain BUY
+ *    against a short shrinks the position and releases IM. The pair ticket unwinds a
+ *    hedged book exactly this way (BUY the short venue, SELL the long venue) with two
+ *    ordinary opens. Only the excess PAST flat is charged. ONE-WAY MODE ONLY: in hedge
+ *    mode that BUY opens a separate long at full IM, so netting would UNDER-require —
+ *    the one direction this file must never move in. Gated on positionMode.
  *  - **Fail-open on any READ failure.** If the account / reference-price / leverage
  *    read throws (endpoint down, 429, unreachable), the preflight SKIPS rather than
  *    blocks: fail-closed would turn a flaky Gate endpoint into a trading outage that
@@ -49,6 +56,9 @@ export interface PreflightDeps {
   /** Current effective per-symbol leverage (test seam); defaults to Gate CrossEx.
    * Values may be numbers or strings (the SDK returns strings) — coerced below. */
   getPositionLeverage?: (symbols: string[]) => Promise<Record<string, string | number>>;
+  /** Live positions, for netting an unwinding leg (test seam). A failure charges every
+   * leg in full — over-requiring, not under. */
+  getPositions?: () => Promise<Array<{ symbol?: string; positionQty?: string | number }>>;
 }
 
 interface LegRequirement {
@@ -85,7 +95,7 @@ export async function preflightMargin(
   // already resolved so resolveActions skips the ref lookup), so we must price them
   // ourselves. A per-leg pricing failure EXEMPTS that leg (fail-open), not the basket.
   const refCache = new Map<string, number | null>();
-  const priced: Array<{ index: number; symbol: string; notional: number; leverage?: number }> = [];
+  const priced: Array<{ leg: ResolvedAction; index: number; symbol: string; notional: number; leverage?: number }> = [];
   for (const leg of openLegs) {
     let notional = leg.estNotional > 0 ? leg.estNotional : 0;
     if (notional <= 0) {
@@ -102,14 +112,50 @@ export async function preflightMargin(
       notional = Number(leg.qty) * px;
     }
     if (!(notional > 0)) continue;
-    priced.push({ index: leg.index, symbol: leg.symbol, notional, leverage: leg.leverage?.requested });
+    priced.push({ leg, index: leg.index, symbol: leg.symbol, notional, leverage: leg.leverage?.requested });
   }
-  if (priced.length === 0) return;
+  if (priced.length === 0) return; // nothing priceable — no account read needed
+
+  // Read once, after pricing: gives both the comparison and the netting mode. Fail-open.
+  let account: CrossexAccount;
+  try {
+    account = deps.getAccount ? await deps.getAccount() : (await clients.crossEx.getCrossexAccount()).body;
+  } catch (err) {
+    console.warn(`[preflight] account read failed — skipping margin check (fail-open): ${(err as Error).message}`);
+    return;
+  }
+  const available = Number(account.availableMargin);
+  if (!Number.isFinite(available)) {
+    console.warn('[preflight] account.availableMargin not a number — skipping margin check (fail-open)');
+    return;
+  }
+
+  // Net off the share of each leg that only unwinds. Symbols uppercased both sides (as
+  // create.ts/actions.ts do): a casing miss silently charges in full, i.e. the bug back.
+  if (isOneWayMode(account.positionMode)) {
+    const posQty = new Map<string, number>();
+    try {
+      const rows = deps.getPositions
+        ? await deps.getPositions()
+        : (await clients.crossEx.listCrossexPositions()).body ?? [];
+      for (const r of rows) {
+        const q = Number(r?.positionQty);
+        if (r?.symbol && Number.isFinite(q) && q !== 0) posQty.set(r.symbol.toUpperCase(), q);
+      }
+    } catch (err) {
+      console.warn(`[preflight] positions read failed — charging every leg in full: ${(err as Error).message}`);
+    }
+    for (const p of priced) p.notional *= 1 - offsetFraction(p.leg, posQty.get(p.symbol.toUpperCase()));
+  } else {
+    console.warn(`[preflight] positionMode '${account.positionMode}' is not one-way — charging every leg in full`);
+  }
+  const opening = priced.filter((p) => p.notional > 0);
+  if (opening.length === 0) return;
 
   // Fill in leverage for legs that don't carry a requested value (remediation
   // completeLeg, hand-built baskets) from the account's CURRENT effective leverage —
   // one batched read. A failure exempts those legs (fail-open).
-  const needLev = priced.filter((p) => !(p.leverage && p.leverage > 0));
+  const needLev = opening.filter((p) => !(p.leverage && p.leverage > 0));
   if (needLev.length > 0) {
     const symbols = [...new Set(needLev.map((p) => p.symbol))];
     let levMap: Record<string, string | number> = {};
@@ -127,7 +173,7 @@ export async function preflightMargin(
     }
   }
 
-  const legs: LegRequirement[] = priced
+  const legs: LegRequirement[] = opening
     .filter((p) => !!p.leverage && p.leverage > 0)
     .map((p) => ({ index: p.index, symbol: p.symbol, notional: p.notional, leverage: p.leverage as number }));
   if (legs.length === 0) return; // nothing we can size confidently → fail-open
@@ -135,19 +181,6 @@ export async function preflightMargin(
   const required =
     legs.reduce((s, l) => s + l.notional / l.leverage, 0) * PREFLIGHT_MARGIN_BUFFER +
     legs.reduce((s, l) => s + l.notional, 0) * TAKER_FEE_RESERVE;
-
-  let account: CrossexAccount;
-  try {
-    account = deps.getAccount ? await deps.getAccount() : (await clients.crossEx.getCrossexAccount()).body;
-  } catch (err) {
-    console.warn(`[preflight] account read failed — skipping margin check (fail-open): ${(err as Error).message}`);
-    return;
-  }
-  const available = Number(account.availableMargin);
-  if (!Number.isFinite(available)) {
-    console.warn('[preflight] account.availableMargin not a number — skipping margin check (fail-open)');
-    return;
-  }
 
   if (required > available) {
     throw new CoreError(
@@ -158,4 +191,21 @@ export async function preflightMargin(
       { required, available, legs },
     );
   }
+}
+
+/** Fraction of an open leg that only nets down an opposite position (1 = fully
+ * offsetting). Unknown/aligned ⇒ 0 (charge in full). Mirrors web/src/trade/previewBits.tsx. */
+function offsetFraction(leg: ResolvedAction, positionQty: number | undefined): number {
+  const qty = Number(leg.qty);
+  if (positionQty === undefined || !Number.isFinite(qty) || qty <= 0) return 0;
+  const opposes = leg.side === 'BUY' ? positionQty < 0 : positionQty > 0;
+  if (!opposes) return 0;
+  return Math.min(qty, Math.abs(positionQty)) / qty;
+}
+
+/** One-way (netting) mode? Gate reports 'SINGLE'. Anything else — hedge mode, or an
+ * unrecognised value — answers NO and charges in full: a wrong YES can half-fill a pair. */
+function isOneWayMode(mode: string | undefined): boolean {
+  const m = (mode ?? '').toUpperCase();
+  return m === 'SINGLE' || m === 'ONE_WAY' || m === 'ONEWAY';
 }

--- a/src/server/routes/deals.ts
+++ b/src/server/routes/deals.ts
@@ -53,12 +53,16 @@ export function dealsRoutes(deps: AppDeps) {
       const clients = deps.getClients();
       const getAccount = async () =>
         (await deps.cache.get('account', TTL.live, async () => (await clients.crossEx.getCrossexAccount()).body)).value;
+      // Shares the `positions` cache key with GET /positions (the UI polls it every 4s),
+      // so the preflight's netting read is normally already warm.
+      const getPositions = async () =>
+        (await deps.cache.get('positions', TTL.live, async () => (await clients.crossEx.listCrossexPositions()).body)).value ?? [];
       const refPriceA =
         body.execution === 'taker' && body.a?.symbol
           ? await deps.engine!.venue.refPrice(body.a.symbol.toUpperCase()).catch(() => null)
           : null;
       const row = await resolveDeal(clients, body, deps.engine!.clock.now(), {
-        preflight: { getAccount },
+        preflight: { getAccount, getPositions },
         refPriceA,
       });
 

--- a/tests/unit/preflight.test.ts
+++ b/tests/unit/preflight.test.ts
@@ -30,7 +30,7 @@ function leg(over: Partial<ResolvedAction>): ResolvedAction {
   };
 }
 
-const acct = (availableMargin: string) => ({ availableMargin }) as Awaited<ReturnType<NonNullable<Parameters<typeof preflightMargin>[2]>['getAccount'] & object>>;
+const acct = (availableMargin: string, positionMode = 'SINGLE') => ({ availableMargin, positionMode }) as Awaited<ReturnType<NonNullable<Parameters<typeof preflightMargin>[2]>['getAccount'] & object>>;
 
 /** required for a single leg, per the documented formula, so tests read as intent. */
 const requiredFor = (notional: number, lev: number) =>
@@ -49,6 +49,72 @@ describe('preflightMargin', () => {
     await expect(
       preflightMargin(clients, legs, { getAccount: async () => acct(String(need + 1)) }),
     ).resolves.toBeUndefined();
+  });
+
+  describe('netting an open leg against the live opposite position', () => {
+    // The pair ticket unwinds with two ORDINARY opens: no reduceOnly, but no new IM.
+    const unwind = [
+      leg({ index: 0, symbol: 'HYPERLIQUID_FUTURE_ETH_USDC', side: 'BUY', qty: '1', estNotional: 2457.8, leverage: { requested: 25, max: 25 } }),
+      leg({ index: 1, symbol: 'BINANCE_FUTURE_ETH_USDT', side: 'SELL', qty: '1', estNotional: 2457.26, leverage: { requested: 25, max: 25 } }),
+    ];
+    const book = async () => [
+      { symbol: 'HYPERLIQUID_FUTURE_ETH_USDC', positionQty: '-25.25' }, // short → a BUY nets down
+      { symbol: 'BINANCE_FUTURE_ETH_USDT', positionQty: '10.579' }, // long → a SELL nets down
+    ];
+
+    it('does not block a fully offsetting pair on a NEGATIVE available margin', async () => {
+      await expect(
+        preflightMargin(clients, unwind, { getAccount: async () => acct('-3824.76'), getPositions: book }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('charges only the excess PAST flat', async () => {
+      // BUY 30 against a 25.25 short: 4.75 of it opens a new long.
+      const over = [leg({ index: 0, symbol: 'HYPERLIQUID_FUTURE_ETH_USDC', side: 'BUY', qty: '30', estNotional: 30 * 2457.8, leverage: { requested: 25, max: 25 } })];
+      const need = requiredFor(4.75 * 2457.8, 25);
+      await expect(
+        preflightMargin(clients, over, { getAccount: async () => acct(String(need - 1)), getPositions: book }),
+      ).rejects.toMatchObject({ category: 'insufficient-margin' });
+      await expect(
+        preflightMargin(clients, over, { getAccount: async () => acct(String(need + 1)), getPositions: book }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('charges an ALIGNED leg in full (adding to a position is a real open)', async () => {
+      const add = [leg({ index: 0, symbol: 'BINANCE_FUTURE_ETH_USDT', side: 'BUY', qty: '1', estNotional: 2457.26, leverage: { requested: 25, max: 25 } })];
+      await expect(
+        preflightMargin(clients, add, { getAccount: async () => acct('50'), getPositions: book }),
+      ).rejects.toMatchObject({ category: 'insufficient-margin' });
+    });
+
+    // In hedge mode that BUY opens a SEPARATE long at full IM, so netting would
+    // under-require and leave leg B rejected with leg A filled. Unknown modes too.
+    it.each(['DUAL_SIDE', 'SOMETHING_NEW', ''])('does NOT net when positionMode is %j', async (mode) => {
+      await expect(
+        preflightMargin(clients, unwind, { getAccount: async () => acct('-3824.76', mode), getPositions: book }),
+      ).rejects.toMatchObject({ category: 'insufficient-margin' });
+    });
+
+    it('matches the position regardless of the venue symbol casing', async () => {
+      const lower = async () => [
+        { symbol: 'hyperliquid_future_eth_usdc', positionQty: '-25.25' },
+        { symbol: 'binance_future_eth_usdt', positionQty: '10.579' },
+      ];
+      await expect(
+        preflightMargin(clients, unwind, { getAccount: async () => acct('-3824.76'), getPositions: lower }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('charges every leg in full when the positions read fails (safe direction)', async () => {
+      await expect(
+        preflightMargin(clients, unwind, {
+          getAccount: async () => acct('-3824.76'),
+          getPositions: async () => {
+            throw new Error('boom');
+          },
+        }),
+      ).rejects.toMatchObject({ category: 'insufficient-margin' });
+    });
   });
 
   it('prices a MARKET open leg (estNotional 0 at execute) via the ref-price seam', async () => {

--- a/version.json
+++ b/version.json
@@ -1,12 +1,8 @@
 {
-  "version": "1.4.0",
+  "version": "1.4.1",
   "highlights": [
-    "Share links are far shorter — the same snapshot, in a URL that survives a paste into X or Telegram",
-    "Open and close Boros legs directly in the app, without a detour to the Boros front end",
-    "A four-leg arb now goes up in two steps: pick the pair, confirm the size — the legs are placed for you",
-    "When automatic grouping cannot tell shared legs apart, adjust a composite position by hand and the app keeps your split",
-    "Composite positions track more faithfully as legs fill, close, and settle",
-    "Position tracking and cost settings are streamlined into one place, so what you paid and what you hold read together",
-    "App renamed to Arbitrage with CrossEx"
+    "Closing a position is no longer blocked when your available margin has gone negative — the one state where closing matters most",
+    "Unwinding a hedged pair from the order ticket no longer asks for margin it does not need: an order that only reduces an open position is charged for the part that actually opens, if any",
+    "The ticket's margin figure reflects the same thing, so what it quotes and what it lets you do now agree"
   ]
 }

--- a/web/src/panels/ClosePairForm.test.tsx
+++ b/web/src/panels/ClosePairForm.test.tsx
@@ -11,7 +11,7 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
 import type { ActionInput, DealRequest, PreviewResponse } from '../api/types';
-import { baseHandlers, previewFor } from '../test/fixtures';
+import { account, baseHandlers, previewFor } from '../test/fixtures';
 import { env, server } from '../test/server';
 import { renderWithClient } from '../test/utils';
 import { ClosePairForm } from './PerpOnlyBox';
@@ -63,6 +63,37 @@ describe('ClosePairForm — the slippage the user sets is the slippage sent', ()
 
     // Both legs, not just the one that carries the band.
     await waitFor(() => expect(slipOf(seen.at(-1)!)).toEqual([2, 2]), { timeout: 4000 });
+  });
+
+  it('stays executable when availableMargin is NEGATIVE', async () => {
+    // Both legs are reduce-only and require 0; 0 must not "exceed" a negative available.
+    const seen: ActionInput[][] = [];
+    const posted: DealRequest[] = [];
+    server.use(
+      http.get('/api/account', () => HttpResponse.json(env({ ...account, availableMargin: '-3824.76' }))),
+      ...baseHandlers(),
+      previewSpy(seen),
+      http.post('/api/deals', async ({ request }) => {
+        posted.push((await request.json()) as DealRequest);
+        return HttpResponse.json(env({ id: 'd-neg' }), { status: 202 });
+      }),
+    );
+    renderWithClient(<ClosePairForm base="HYPE" legs={LEGS} />);
+
+    await waitFor(() => expect(seen.length).toBeGreaterThan(0), { timeout: 4000 });
+    const btn = screen.getByRole('button', { name: /Close both/ });
+    await waitFor(() => expect(btn).toBeEnabled(), { timeout: 4000 });
+    expect(screen.queryByText(/exceeds available/)).toBeNull();
+
+    // Enabled is not enough — asserting the payload proves it also clears `!mappable`.
+    fireEvent.pointerDown(btn);
+    await waitFor(() => expect(posted).toHaveLength(1), { timeout: 4000 });
+    expect(posted[0]).toMatchObject({
+      a: { symbol: 'BYBIT_FUTURE_HYPE_USDT', reduceOnly: true },
+      b: { symbol: 'HYPERLIQUID_FUTURE_HYPE_USDC', reduceOnly: true },
+      qty: '1.89',
+      execution: 'taker',
+    });
   });
 
   it('refuses an out-of-range slippage instead of silently defaulting', async () => {

--- a/web/src/trade/ExecuteControl.test.tsx
+++ b/web/src/trade/ExecuteControl.test.tsx
@@ -3,7 +3,7 @@ import { http, HttpResponse } from 'msw';
 import { useState } from 'react';
 import { describe, expect, it } from 'vitest';
 import type { ActionInput, DealRequest } from '../api/types';
-import { baseHandlers, echoPreviewHandler, previewFor } from '../test/fixtures';
+import { account, baseHandlers, echoPreviewHandler, ethPosition, previewFor } from '../test/fixtures';
 import { env, server } from '../test/server';
 import { renderWithClient } from '../test/utils';
 import { ExecuteControl } from './ExecuteControl';
@@ -398,6 +398,85 @@ describe('ExecuteControl', () => {
         execution: 'taker',
         clipBandPct: 0.5,
       });
+    });
+
+    it('never blocks a close when availableMargin is NEGATIVE (borrowing sub-account)', async () => {
+      // A close requires 0, and 0 > -3870 is true — that disabled the one control that
+      // could fix the account.
+      const calls: DealRequest[] = [];
+      const closeAction: ActionInput = { kind: 'close-position', symbol: 'GATE_FUTURE_ETH_USDT' };
+      server.use(
+        // FIRST match wins within one server.use — the override must precede baseHandlers'
+        // own /api/account or the fixture's positive balance silently stands.
+        http.get('/api/account', () =>
+          HttpResponse.json(env({ ...account, availableMargin: '-3870.72', marginBalance: '4040.86', initialMargin: '7857.62' })),
+        ),
+        ...baseHandlers(),
+        echoPreviewHandler({ overrides: { estNotional: 36_080 } }),
+        dealHandler(calls),
+      );
+      renderWithClient(<ExecuteControl scope="mn" actions={[closeAction]} label="Close now" holdMs={50} />);
+
+      const btn = await screen.findByRole('button', { name: 'Close now' });
+      await waitFor(() => expect(btn).toBeEnabled());
+      expect(screen.queryByText(/exceeds available/)).toBeNull();
+      fireEvent.pointerDown(btn);
+      await waitFor(() => expect(calls).toHaveLength(1));
+      expect(calls[0]).toMatchObject({ a: { reduceOnly: true }, execution: 'taker' });
+    });
+
+    // Two ORDINARY open-market legs (the pair ticket has no reduce-only mode), each
+    // opposing a live position — together they open nothing.
+    const UNWIND: ActionInput[] = [
+      { kind: 'open-market', symbol: 'HYPERLIQUID_FUTURE_ETH_USDC', side: 'BUY', qty: '1', leverage: 25 },
+      { kind: 'open-market', symbol: 'BINANCE_FUTURE_ETH_USDT', side: 'SELL', qty: '1', leverage: 25 },
+    ];
+    const BOOK = [
+      { ...ethPosition, symbol: 'HYPERLIQUID_FUTURE_ETH_USDC', positionQty: '-25.25', leverage: '25' },
+      { ...ethPosition, symbol: 'BINANCE_FUTURE_ETH_USDT', positionQty: '10.579', leverage: '25' },
+    ];
+    /** Underwater account + a live book; `positions: null` leaves the read failing. */
+    const underwater = (positions: unknown[] | null, positionMode = 'ONE_WAY') => [
+      http.get('/api/account', () =>
+        HttpResponse.json(env({ ...account, availableMargin: '-3824.76', positionMode })),
+      ),
+      http.get('/api/positions', () =>
+        positions ? HttpResponse.json(env({ positions, exposure: [] })) : HttpResponse.error(),
+      ),
+      ...baseHandlers(),
+      echoPreviewHandler({ overrides: { qty: '1', estNotional: 2457.8, leverage: { requested: 25, max: 25 } } }),
+    ];
+
+    it('nets an OPEN leg against the live opposite position (pair-ticket unwind)', async () => {
+      server.use(...underwater(BOOK));
+      renderWithClient(<ExecuteControl scope="mo" actions={UNWIND} label="Execute pair" holdMs={50} />);
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Execute pair' })).toBeEnabled());
+      expect(screen.queryByText(/exceeds available/)).toBeNull();
+    });
+
+    it('does not block while positions are still loading', async () => {
+      // The legs carry a requested leverage, so without the guard the estimate is
+      // "confident" and full-priced — a false block until the 4s poll lands.
+      server.use(...underwater(null));
+      renderWithClient(<ExecuteControl scope="ml" actions={UNWIND} label="Execute pair" holdMs={50} />);
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Execute pair' })).toBeEnabled());
+      expect(screen.queryByText(/exceeds available/)).toBeNull();
+    });
+
+    it('does NOT net in dual-side (hedge) mode — the same unwind stays blocked', async () => {
+      // There a BUY against a short opens a SEPARATE long at full IM.
+      server.use(...underwater(BOOK, 'DUAL_SIDE'));
+      renderWithClient(<ExecuteControl scope="mh" actions={UNWIND} label="Execute pair" holdMs={50} />);
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Execute pair' })).toBeDisabled());
+      expect(await screen.findByRole('alert')).toHaveTextContent(/exceeds available/);
+    });
+
+    it('still blocks an ALIGNED open that adds to an existing position', async () => {
+      const add: ActionInput[] = [{ kind: 'open-market', symbol: 'BINANCE_FUTURE_ETH_USDT', side: 'BUY', qty: '1', leverage: 25 }];
+      server.use(...underwater(BOOK));
+      renderWithClient(<ExecuteControl scope="mp" actions={add} label="Add" holdMs={50} />);
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled());
+      expect(await screen.findByRole('alert')).toHaveTextContent(/exceeds available/);
     });
 
     it('does not block a low-confidence estimate (no known leverage) — display only', async () => {

--- a/web/src/trade/ExecuteControl.tsx
+++ b/web/src/trade/ExecuteControl.tsx
@@ -173,11 +173,17 @@ export function ExecuteControl({
   // Money-safety: block confirm when the basket's estimated margin exceeds available
   // (the same shortfall the server preflight rejects — this just spares the round-trip
   // and explains why). Only when the estimate is CONFIDENT (every open leg has a known
-  // leverage), so a fallback-to-1x guess can't false-block; closes are already exempt
-  // inside estimateMargin.
+  // leverage), so a fallback-to-1x guess can't false-block.
+  //
+  // `required > 0` is load-bearing: an all-close basket requires 0, and 0 still "exceeds"
+  // a NEGATIVE availableMargin (which CrossEx reports when a sub-account borrows against
+  // the others) — that blocked every close on the account that most needs to close.
   const available = Number(account.data?.availableMargin ?? NaN);
-  const margin = previews ? estimateMargin(previews, positions.data?.positions) : { required: 0, confident: false };
-  const marginBlocked = Boolean(previews) && margin.confident && Number.isFinite(available) && margin.required > available;
+  const margin = previews
+    ? estimateMargin(previews, positions.data?.positions, account.data?.positionMode)
+    : { required: 0, confident: false };
+  const marginBlocked =
+    Boolean(previews) && margin.confident && Number.isFinite(available) && margin.required > 0 && margin.required > available;
   // The confirmed intent must map onto a deal shape the engine models (probe
   // with a placeholder id) — an unmappable shape must disable, not no-op.
   const mappable =

--- a/web/src/trade/PairTicket.tsx
+++ b/web/src/trade/PairTicket.tsx
@@ -10,7 +10,7 @@
  * confirm — no review modal — so the maker price stays live until t=submit.
  */
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useSymbolDetail, useSymbolsByBase } from '../api/queries';
+import { useAccount, usePositions, useSymbolDetail, useSymbolsByBase } from '../api/queries';
 import type { ActionInput, PreviewResult, RestEstimate } from '../api/types';
 import { SegmentedToggle } from '../components/SegmentedToggle';
 import { amountError } from '../lib/amount';
@@ -94,6 +94,8 @@ export function PairTicket({ onExecuted }: { onExecuted?: () => void } = {}) {
   }, [base, unitPinned]);
 
   const venues = useSymbolsByBase(base);
+  const positions = usePositions();
+  const account = useAccount();
   const longDetail = useSymbolDetail(longSym);
   const shortDetail = useSymbolDetail(shortSym);
 
@@ -309,9 +311,12 @@ export function PairTicket({ onExecuted }: { onExecuted?: () => void } = {}) {
     onExecuted?.();
   };
 
-  // Total initial margin the pair posts — Σ notional/leverage over the open
-  // legs, from the same estimator the execute gate uses.
-  const marginRequired = preview.previews ? estimateMargin(preview.previews, undefined).required : null;
+  // Total initial margin the pair posts — Σ notional/leverage over the open legs, from
+  // the same estimator (and the same live positions/mode) the execute gate uses, or an
+  // unwind reads as $197 of IM on a ticket that opens nothing.
+  const marginRequired = preview.previews
+    ? estimateMargin(preview.previews, positions.data?.positions, account.data?.positionMode).required
+    : null;
 
   return (
     <div className="flex flex-col gap-3">

--- a/web/src/trade/previewBits.tsx
+++ b/web/src/trade/previewBits.tsx
@@ -108,21 +108,52 @@ export function describeAction(a: ActionInput): string {
  * leverage, else 1x (worst case). `confident` is false when any counted leg had to
  * fall back to 1x (no requested and no live position leverage) — the number is still
  * shown, but blocking on it would risk a false block, so callers must not gate on it.
+ *
+ * CALLER CONTRACT: excluding closes from the SUM is not the same as exempting them from
+ * a comparison. An all-close basket returns 0, and `availableMargin` can be NEGATIVE, so
+ * any gate must also require `required > 0` — otherwise 0 > -3870 blocks the close.
  */
 export function estimateMargin(
   previews: PreviewResult[],
   positions: CrossexPosition[] | undefined,
+  positionMode?: string,
 ): { required: number; confident: boolean } {
+  const canNet = isOneWayMode(positionMode);
   let required = 0;
-  let confident = true;
+  // Positions unknown while netting is live: an unwind is indistinguishable from an open
+  // and would false-block. `[]` is an answer, `undefined` is not. Not-confident fails open.
+  let confident = !(canNet && positions === undefined);
   for (const p of previews) {
     if (p.reduceOnly) continue; // a close consumes no margin
-    const posLev = Number(positions?.find((x) => x.symbol === p.symbol)?.leverage);
+    // Case-normalized like every other position lookup here (core/actions.ts, create.ts).
+    const pos = positions?.find((x) => (x.symbol ?? '').toUpperCase() === p.symbol.toUpperCase());
+    const notional = p.estNotional * (canNet ? 1 - offsetFraction(p, pos) : 1);
+    if (!(notional > 0)) continue; // fully offsetting — opens no new exposure
+    const posLev = Number(pos?.leverage);
     const known = p.leverage?.requested || (Number.isFinite(posLev) && posLev > 0 ? posLev : 0);
     if (!known) confident = false; // fell back to 1x worst case
-    required += p.estNotional / (known || 1);
+    required += notional / (known || 1);
   }
   return { required, confident };
+}
+
+/** One-way (netting) mode? In hedge mode a BUY against a short opens a SEPARATE long at
+ * full IM. Anything unrecognised answers NO and charges in full. Mirrors core/preflight.ts. */
+function isOneWayMode(mode: string | undefined): boolean {
+  const m = (mode ?? '').toUpperCase();
+  return m === 'SINGLE' || m === 'ONE_WAY' || m === 'ONEWAY';
+}
+
+/** Fraction of an OPEN leg that only nets down an opposite position (1 = fully
+ * offsetting). A BUY against a short releases IM rather than locking it, so only the
+ * excess past flat opens. Unknown/aligned ⇒ 0 (charge in full). One-way mode only. */
+function offsetFraction(p: PreviewResult, pos: CrossexPosition | undefined): number {
+  const posQty = Number(pos?.positionQty);
+  const qty = Number(p.qty);
+  if (!Number.isFinite(posQty) || posQty === 0 || !Number.isFinite(qty) || qty <= 0) return 0;
+  const opposes = p.side === 'BUY' ? posQty < 0 : posQty > 0;
+  if (!opposes) return 0;
+  return Math.min(qty, Math.abs(posQty)) / qty;
 }
 
 /**


### PR DESCRIPTION
## The problem

An account whose **available margin has gone negative cannot close anything.** Every close surface — the row `Close`, `Close both`, and the card's `Close perp pair` — renders disabled with *"margin ≈ $0.00 exceeds available −$3,870.72"*. That is the one account state where closing matters most.

Two independent bugs, both on the client.

## 1. A close was blocked by a negative available margin

`estimateMargin` excludes reduce-only legs from the **sum**, but the gate compared that sum against `availableMargin`:

```ts
const marginBlocked = … && margin.required > available;
```

CrossEx reports `availableMargin` negative once one venue sub-account is underwater enough to borrow against the others — its borrowing IM is charged to the unified account. An all-close basket requires `0`, and `0 > -3870` is **true**.

Excluding closes from the sum is not the same as exempting them from the comparison.

The client was the **sole** blocker: `create.ts:308` never calls the preflight when every leg is reduce-only, and `preflightMargin` returns early on zero open legs. The request was never even attempted.

**Fix:** require `required > 0` before comparing.

## 2. An open leg that only unwinds a position was charged full IM

`reduceOnly` is a flag on the **order**, not a description of its **effect**. In one-way mode a plain `BUY` against a short shrinks the position and *releases* IM.

The pair ticket unwinds a hedged book exactly that way — BUY the short venue, SELL the long venue — with two ordinary `open-market` legs (`PairTicket.tsx:218`). So it quoted **~$197** of margin for a ticket that opens nothing, and refused to execute.

**Fix:** both the client estimator and the server preflight net an open leg against the live opposite position, charging only the excess past flat. Without the server half the button would enable and the POST would then 400.

**Netting is gated on `positionMode`, and that gate is load-bearing.** It is sound only in one-way mode. In dual-side (hedge) mode a `BUY` against a short opens a **separate long** at full IM — netting there would under-require, wave a pair through, and leave leg A filled with leg B rejected on margin: a naked leg, the exact failure this file exists to prevent, and a violation of its own invariant that the preflight *"can only ever REMOVE a failure mode, never add one."*

`SINGLE` / `ONE_WAY` net; anything else — including an unrecognised or absent mode — charges every leg in full. The SDK's `CrossexOrderRequest.PositionSide` enum (`LONG | SHORT | NONE`) is what establishes hedge mode exists; nothing else in the app models it, and `positionMode` was previously read only to be displayed in `AccountHealthStrip`.

Deliberately conservative:
- An **aligned** leg (adding to a position) is still charged in full.
- A failed positions read charges every leg in full — over-requiring, not under.
- The server's positions read is **skipped entirely** outside one-way mode, and otherwise shares the `positions` cache key the UI already polls at 4s, so it is normally warm.
- **Positions still loading** while netting is live makes the estimate *not confident* rather than full-priced. An unwind and a fresh open are indistinguishable without positions, and the unwind would false-block for the seconds before the 4s poll lands. `[]` is a real answer; only `undefined` is "don't know". Not-confident fails open on the client, and the server preflight does its own read and still blocks for real.
- The account is still read **once**, and still only after at least one leg prices — a basket with nothing priceable touches no account endpoint (a pre-existing test asserts this, and caught an earlier revision of this patch that broke it).
- Both lookups **uppercase the symbol**, as every other position lookup in the repo does (`core/actions.ts:464`, `engine/create.ts:240`). A casing miss doesn't error — it silently charges the unwind in full, which is exactly the bug being fixed. On the client that same lookup also feeds the leverage fallback, where a miss fell back to 1x and set `confident: false` (a fail-**open** path), so normalizing can only tighten a gate that wasn't gating.

Also: `PairTicket`'s *"Margin required"* row passed `undefined` for positions, which would have left it quoting $197 beside a now-enabled button. It takes the live positions so the display and the gate cannot disagree.

## Verified against a live account at **−3,839** available

Every close surface — reduce-only, zero violations, `required = 0`:

| surface | required | blocked |
|---|---|---|
| Close full GATE / HYPERLIQUID / BINANCE | 0.00 | **False** (before: True) |
| Close partial | 0.00 | **False** |
| Close perp pair (2 legs) | 0.00 | **False** |
| Single ticket, reduce-only (market + maker) | 0.00 | **False** |

The netting does not over-fire:

| case | gross | netted | blocked |
|---|---|---|---|
| unwind BUY HL 1 / SELL BN 1 | 196.91 | **0.00** | False |
| overshoot BUY HL 30 vs 25.25 short | 2953.32 | **467.61** | True ✅ |
| aligned add BUY BN 1 | 98.47 | 98.47 | True ✅ |
| fresh open BUY SOL 1 | 3.88 | 3.88 | True ✅ |

## Scope

Nine regression tests, **each confirmed to fail against the unfixed code**:
- a close with negative available margin (`ExecuteControl`)
- `Close perp pair` with negative available margin, asserting the **posted deal** — which proves it clears `!mappable` too, not just the margin gate
- a fully offsetting unwind pair on the server preflight
- **dual-side (hedge) mode does not net**, on both client and server
- **an unrecognised / absent `positionMode` does not net**
- a lowercase-symbol positions payload, so a casing miss can't silently reinstate the bug
- **positions still loading does not block** an unwind that carries a requested leverage
- excess-past-flat, aligned, and read-failure cases on the server

`835` server / `654` web tests passing; both typechecks clean.

## End-to-end, driving the real functions against the live account

Not a transcription of the logic — `preflightMargin` and `estimateMargin` imported and called directly, fed the live `/account` and `/positions` (`positionMode: SINGLE`, available **−3,816**):

| basket | server preflight |
|---|---|
| **both legs closing** (BUY HL 1 / SELL BN 1) | **ALLOWED** |
| **both legs closing, full size** (10.579 each) | **ALLOWED** |
| one closing, one opening fresh | BLOCKED — needs ≈ $105.65 |
| both opening (aligned adds) | BLOCKED — needs ≈ $211.30 |
| overshoot past flat (BUY HL 30 vs 25.25 short) | BLOCKED — needs ≈ $501.84 |

Client and server were then swept across the overshoot boundary and **agree at every point**, so there is no band where the button enables and the POST 400s:

| qty on a BN SELL (long 10.579) | client required | client blocks | server |
|---|---|---|---|
| 10.579 (exact) | 0.000000 | false | ALLOWED |
| 10.5789 (under) | 0.000000 | false | ALLOWED |
| 10.58 (0.001 over) | 0.098280 | true | BLOCKED |
| 11 | 41.375880 | true | BLOCKED |

The 0.001-ETH overshoot blocking is correct, not a residue of the original bug: that basket genuinely opens new exposure and the requirement is really non-zero, unlike the `required = 0` case that started this.

## Not fixed here

A two-leg close requires **equal leg sizes** (`deal.ts:61`). A book where one short is hedged by *two* longs has no balanced pair, so `Close perp pair` clears the margin gate and then disables on `!mappable`. Per-row `Close` with partial qty is the working path in that state. Left alone deliberately — sizing both legs to `min(qtyA, qtyB)` changes what a labelled money button does and needs its own copy.

The client estimator also under-states the venue's IM by a flat **7.5bps** of notional — measured across six data points, `IM = notional × (1/leverage + 0.00075)`, with the same additive term on maintenance margin over three distinct venue MMR bases (GATE 1.00%, HYPERLIQUID 2.00%, BINANCE 0.50%). Not a safety hole: the server preflight's `1.05× + 10bps` is strictly stricter than the venue at every leverage, so anything it approves the venue can fund. It does leave a narrow band where the button enables and the POST 400s. Worth closing separately by having the client mirror the server's formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jre11CHKeg95uQFpGTmfKQ
