### PR TITLE
Show the spread leg by leg, and show the installer working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ to do instead of naming a flag.
   Boros order may still be settling, and says which. A "Read the code changes →" link opens the
   exact GitHub comparison between the version you are running and the one that will install — and
   it installs *that* commit, not whatever `main` holds by the time the download starts.
+- **The update pop-up shows what the installer is doing.** It used to say the install takes a few
+  minutes and then show the same screen for those minutes, which is indistinguishable from a stuck
+  update. It now names the step the installer is on, ticks off the five steps it goes through, and
+  runs a clock. An update that fails and rolls back says so, with the installer's own output to
+  read. The dialog asks one question first — let the app do it, or copy the command and run it
+  yourself — and puts a single button under the answer.
 - **⚠ Windows users must re-run the install command once.** Every Windows install so far reported
   itself as a source checkout, so the button refused it. The fix cannot install itself: run the
   install command from the pop-up one more time, and every update after this one is a button
@@ -30,8 +36,9 @@ to do instead of naming a flag.
   ten dollars or less is now caught while you type the size, instead of failing after you confirm.
 - **Profit is counted from the day the position opened.** A position's Fixed APY spread the whole
   term's income over the days remaining rather than the days held, which overstated the headline
-  and the ROI beside it. The hover now shows the arithmetic one line per leg, and a leg with no
-  known open date says so instead of quietly guessing.
+  and the ROI beside it. The locked spread beside it now opens a breakdown — one row per Boros
+  leg with its rate, its size, the window it accrues over and what it is worth by maturity — and a
+  leg with no known open date is marked rather than quietly guessed.
 - **An update that installs but will not start puts the previous version back.** Both installers
   keep the old copy, and restore it if the new one does not answer. A machine can no longer be left
   with no server at all.

--- a/src/server/routes/version.ts
+++ b/src/server/routes/version.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import type { FetchLike } from '../../core/boros/client';
 import type { AppDeps } from '../app';
 import { TTL } from '../cache';
-import { startUpdate } from '../updater';
+import { startUpdate, updateProgress } from '../updater';
 import { compareVersions, fetchLatestVersion, type RemoteVersion } from '../version';
 import { borosExecutionsPending } from './borosPair';
 
@@ -38,6 +38,15 @@ export function versionRoutes(deps: AppDeps) {
         highlights: updateAvailable && remote ? remote.highlights : [],
       });
     });
+
+    /**
+     * GET /api/version/update/log — what the installer has printed so far.
+     *
+     * The dialog used to say "this takes a few minutes" and then show nothing
+     * for those minutes, which is indistinguishable from a stuck update. The
+     * installer names each step it starts, so the panel can name it too.
+     */
+    app.get('/version/update/log', async (_req, reply) => reply.ok(updateProgress()));
 
     app.post('/version/update', async (_req, reply) => {
       const refuse = (message: string, retryable: boolean) =>

--- a/src/server/updater.ts
+++ b/src/server/updater.ts
@@ -28,9 +28,48 @@ function updateLogPath(): string {
 const UPDATE_WINDOW_MS = 10 * 60_000;
 
 let updating = false;
+let startedAtMs: number | null = null;
 let windowTimer: ReturnType<typeof setTimeout> | null = null;
 
 export const isUpdating = (): boolean => updating;
+
+/** Tail of the running installer's output, for the progress panel.
+ *
+ * The installer stops this server partway through, so the panel loses the feed
+ * and picks it back up from the NEW server — which is why the log has to be the
+ * source of truth rather than anything held in memory here. Both installers
+ * print their steps as `==> …`, and both print the rollback banner on a
+ * failure, so the text alone says where the update got to. */
+export function updateProgress(): { startedAt: number | null; running: boolean; text: string } {
+  const main = tail(updateLogPath());
+  // Windows keeps native stderr in its own file; a failure that never reached
+  // a `Say` line leaves its only explanation there.
+  const err = process.platform === 'win32' ? tail(updateLogPath().replace(/\.log$/, '.err.log')) : '';
+  return {
+    startedAt: startedAtMs,
+    running: updating,
+    text: err.trim() ? `${main}\n${err}` : main,
+  };
+}
+
+const TAIL_BYTES = 16_384;
+
+function tail(file: string): string {
+  try {
+    const fd = fs.openSync(file, 'r');
+    try {
+      const { size } = fs.fstatSync(fd);
+      const take = Math.min(size, TAIL_BYTES);
+      const buf = Buffer.alloc(take);
+      fs.readSync(fd, buf, 0, take, size - take);
+      return buf.toString('utf8');
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return '';
+  }
+}
 
 export function endUpdateWindow(): void {
   updating = false;
@@ -40,6 +79,7 @@ export function endUpdateWindow(): void {
 
 function beginUpdateWindow(): void {
   updating = true;
+  startedAtMs = Date.now();
   if (windowTimer) clearTimeout(windowTimer);
   windowTimer = setTimeout(endUpdateWindow, UPDATE_WINDOW_MS);
   windowTimer.unref?.();
@@ -83,6 +123,12 @@ async function stageWindowsInstaller(logPath: string, pin: string | null): Promi
   }
   fs.mkdirSync(root, { recursive: true });
   fs.writeFileSync(installer, script, 'utf8');
+
+  // Start-Process truncates both files, but only once the task actually fires.
+  // Until then the progress panel would be reading the LAST update's output —
+  // and calling this one finished on the previous run's "Done!".
+  fs.writeFileSync(logPath, '');
+  fs.writeFileSync(logPath.replace(/\.log$/, '.err.log'), '');
 
   // BOROS_REF can no longer travel on the command line, so the runner sets it.
   // `pin` is a validated 40-char sha and '' doubles PowerShell's quote escape.
@@ -141,7 +187,7 @@ export async function startUpdate(ref?: string | null): Promise<string> {
     return logPath;
   }
 
-  const log = fs.openSync(logPath, 'a');
+  const log = fs.openSync(logPath, 'w');
   /**
    * ⚠ NODE_ENV MUST NOT REACH THE INSTALLER.
    *

--- a/version.json
+++ b/version.json
@@ -2,9 +2,9 @@
   "version": "1.5.0",
   "highlights": [
     "Windows only, one time: run the install command below once more. After that, updating is a button press",
-    "Updating is now one button — it installs the new version, restarts, and reloads this page. If it cannot start, your old version comes back",
+    "Updating is now one button — it installs the new version, restarts, and reloads this page. You can watch it work, and if it cannot start, your old version comes back",
     "Boros gas takes care of itself. An empty gas pot no longer stops an order, and there is nothing to top up by hand",
     "Orders that cannot go through now say what to change, and which venue is the problem",
-    "A position's Fixed APY is counted from the day you opened it. The old figure was too high"
+    "A position's Fixed APY is counted from the day you opened it. The old figure was too high — and the spread beside it now shows what each leg contributes"
   ]
 }

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -41,6 +41,7 @@ import type {
   UpdateStatus,
   TopUpGasResponse,
   RunUpdateResponse,
+  UpdateProgress,
 } from './types';
 
 export const qk = {
@@ -485,6 +486,26 @@ export function useTopUpGas() {
 export function useRunUpdate() {
   return useMutation({
     mutationFn: () => postJson<RunUpdateResponse>('/version/update', {}),
+  });
+}
+
+/**
+ * The installer's output while an update runs.
+ *
+ * Errors are the normal case for part of it — the installer stops this server
+ * before it swaps the new copy in — so this never retries and never treats a
+ * failure as final. Background refetch for the same reason `useInstallWatch`
+ * needs it: nobody keeps the tab in front of them for a whole install.
+ */
+export function useUpdateLog(enabled: boolean) {
+  return useQuery({
+    queryKey: [...qk.version, 'log'] as const,
+    queryFn: () => fetchJson<UpdateProgress>('/version/update/log'),
+    enabled,
+    refetchInterval: 1_500,
+    refetchIntervalInBackground: true,
+    staleTime: 0,
+    retry: false,
   });
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1130,6 +1130,16 @@ export interface RunUpdateResponse {
   ref: string | null;
 }
 
+/** What the running installer has printed so far — drives the progress panel. */
+export interface UpdateProgress {
+  /** ms epoch, from the server that STARTED the update. Null once the NEW copy
+   * is the one answering: a fresh process has no memory of the install that
+   * replaced it. The dialog keeps its own start time for the clock. */
+  startedAt: number | null;
+  running: boolean;
+  text: string;
+}
+
 export interface BorosLegFill {
   marketId: number;
   direction: BorosLegDirection;

--- a/web/src/components/HoverCard.tsx
+++ b/web/src/components/HoverCard.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * A figure that shows its working when you point at it.
+ *
+ * `title` could not do this job. It is one unstyled paragraph, and nothing on
+ * the page says it is there — a reader who never happens to rest the pointer
+ * on the number never learns the breakdown exists. The trigger here carries a
+ * dotted rule and a marker, so it looks like something to point at.
+ *
+ * Portaled and fixed, for the same reason Modal is: these cards sit inside
+ * `overflow-hidden` boxes, and the header they can open near is blurred with
+ * backdrop-filter, which would otherwise trap an absolutely-positioned panel.
+ */
+
+interface Box {
+  left: number;
+  top?: number;
+  bottom?: number;
+}
+
+/** The marker. Nothing else on a card carries it, so it reads as "more here"
+ * rather than decoration. */
+function InfoMark() {
+  return (
+    <span
+      aria-hidden
+      className="inline-flex h-[11px] w-[11px] items-center justify-center rounded-full border border-current text-[8px] font-bold leading-none opacity-70"
+    >
+      i
+    </span>
+  );
+}
+
+export function HoverCard({
+  label,
+  widthPx = 460,
+  children,
+}: {
+  /** The figure itself — it keeps its own styling. */
+  label: ReactNode;
+  widthPx?: number;
+  children: ReactNode;
+}) {
+  const anchor = useRef<HTMLSpanElement>(null);
+  const closing = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [box, setBox] = useState<Box | null>(null);
+
+  const stopClosing = () => {
+    if (closing.current) clearTimeout(closing.current);
+    closing.current = null;
+  };
+
+  /**
+   * Measured once, on open. The card shuts on scroll and resize, so the one
+   * measurement can never go stale — and opening upward is anchored by
+   * `bottom`, which needs no height from a panel that has not rendered yet.
+   */
+  const open = () => {
+    const r = anchor.current?.getBoundingClientRect();
+    if (!r) return;
+    stopClosing();
+    const left = Math.max(8, Math.min(r.left, window.innerWidth - widthPx - 8));
+    setBox(
+      window.innerHeight - r.bottom < 260
+        ? { left, bottom: window.innerHeight - r.top + 6 }
+        : { left, top: r.bottom + 6 },
+    );
+  };
+
+  /** Leaving the trigger waits, so the pointer can cross the gap into the
+   * card; leaving the card itself does not. */
+  const close = (delayed: boolean) => {
+    stopClosing();
+    if (delayed) closing.current = setTimeout(() => setBox(null), 120);
+    else setBox(null);
+  };
+
+  useEffect(() => {
+    if (!box) return;
+    const shut = () => setBox(null);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setBox(null);
+    };
+    window.addEventListener('scroll', shut, true);
+    window.addEventListener('resize', shut);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('scroll', shut, true);
+      window.removeEventListener('resize', shut);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [box]);
+
+  useEffect(() => stopClosing, []);
+
+  return (
+    <span
+      ref={anchor}
+      onMouseEnter={open}
+      onMouseLeave={() => close(true)}
+      /* These triggers sit inside larger buttons (the card hero toggles its
+         own charts). Reading the breakdown must not also fire that. */
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (box) setBox(null);
+        else open();
+      }}
+      className="inline-flex cursor-help items-center gap-1 border-b border-dotted border-ink-600 text-ink-400 transition-colors hover:border-cyan-400/70 hover:text-cyan-200"
+    >
+      {label}
+      <InfoMark />
+      {box &&
+        createPortal(
+          <div
+            role="tooltip"
+            style={{ left: box.left, top: box.top, bottom: box.bottom, width: widthPx }}
+            onMouseEnter={stopClosing}
+            onMouseLeave={() => close(false)}
+            className="fixed z-50 rounded-lg border border-ink-700 bg-ink-950 px-3 py-2.5 text-ink-200 shadow-xl shadow-black/60"
+          >
+            {children}
+          </div>,
+          document.body,
+        )}
+    </span>
+  );
+}

--- a/web/src/components/UpdateIndicator.test.tsx
+++ b/web/src/components/UpdateIndicator.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { RunUpdateResponse, UpdateStatus } from '../api/types';
+import type { RunUpdateResponse, UpdateProgress, UpdateStatus } from '../api/types';
 import { INSTALL_CMD, INSTALL_CMD_WINDOWS } from '../lib/app';
 import { versionHandler } from '../test/fixtures';
 import { env, server } from '../test/server';
@@ -27,6 +27,18 @@ function updateHandler(calls: unknown[], refusal?: string) {
   });
 }
 
+
+/** The installer's output. Polled the moment an update starts, so every test
+ * that presses the button needs one — msw is set to error on a stray request. */
+function logHandler(text = '') {
+  return http.get('/api/version/update/log', () =>
+    HttpResponse.json(env<UpdateProgress>({ startedAt: Date.now(), running: true, text })),
+  );
+}
+
+/** The install command lives behind the second route now — the dialog opens on
+ * the one-click one. */
+const manualRoute = () => fireEvent.click(screen.getByRole('radio', { name: 'Run it in my terminal' }));
 
 /** An install-info block, so a test can say which commit is being served. */
 function installedAt(commit: string): UpdateStatus['install'] {
@@ -69,30 +81,34 @@ describe('UpdateIndicator', () => {
     expect(screen.queryByRole('button', { name: /Update v/ })).toBeNull();
   });
 
-  it('shows the pill for a newer version; the modal carries highlights and ONE OS command', async () => {
+  it('shows the pill for a newer version; the modal carries highlights and ONE button', async () => {
     await openModal({ current: '1.0.0', highlights: ['A brand new thing', 'Another improvement'] });
 
     expect(screen.getByText('Update available — v1.2.0')).toBeInTheDocument();
-    expect(screen.getByText(/You're on/)).toHaveTextContent('v1.0.0');
+    expect(screen.getByText(/You’re on/)).toHaveTextContent('v1.0.0');
     expect(screen.getByText('A brand new thing')).toBeInTheDocument();
     expect(screen.getByText('Another improvement')).toBeInTheDocument();
-    const shown = [INSTALL_CMD, INSTALL_CMD_WINDOWS].filter((c) => screen.queryByText(c) !== null);
-    expect(shown).toHaveLength(1);
+    // The one-click route is what opens, so the only thing to press is the
+    // update itself — no command block competing with it for the eye.
+    expect(screen.getByRole('button', { name: 'Update to v1.2.0' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Copy command/ })).toBeNull();
+    expect([INSTALL_CMD, INSTALL_CMD_WINDOWS].filter((c) => screen.queryByText(c))).toHaveLength(0);
     expect(screen.getByRole('link', { name: /Full changelog/ })).toHaveAttribute(
       'href',
       'https://github.com/pendle-finance/arbitrage-with-crossex/blob/main/CHANGELOG.md',
     );
   });
 
-  it('offers the other OS behind a toggle, this machine first', async () => {
-    // jsdom's UA is not Windows, so macOS is the default and leads the toggle.
+  it('puts the command behind the second route, this machine selected', async () => {
+    // jsdom's UA is not Windows, so macOS is the one already chosen.
     await openModal();
-    const [first, second] = screen.getAllByRole('tab');
-    expect(first).toHaveTextContent('macOS');
-    expect(first).toHaveAttribute('aria-selected', 'true');
+    manualRoute();
+    expect(screen.getByRole('radio', { name: 'macOS' })).toHaveAttribute('aria-checked', 'true');
     expect(screen.getByText(INSTALL_CMD)).toBeInTheDocument();
+    // One thing to press on this route too.
+    expect(screen.queryByRole('button', { name: /^Update to/ })).toBeNull();
 
-    fireEvent.click(second);
+    fireEvent.click(screen.getByRole('radio', { name: 'Windows' }));
     expect(screen.getByText(INSTALL_CMD_WINDOWS)).toBeInTheDocument();
     expect(screen.queryByText(INSTALL_CMD)).toBeNull();
   });
@@ -121,7 +137,7 @@ describe('UpdateIndicator', () => {
     );
   });
 
-  it('pins the command and the diff to the advertised commit', async () => {
+  it('pins the diff link to the advertised commit, and keeps shas out of the dialog', async () => {
     const sha = '3f7c1b9e2d4a6058cbe1740f9a2d5b83c6e0f1a4';
     await openModal({
       latestCommit: sha,
@@ -138,32 +154,60 @@ describe('UpdateIndicator', () => {
       'href',
       `https://github.com/pendle-finance/arbitrage-with-crossex/compare/abc1234...${sha}`,
     );
-    expect(screen.getByText(`BOROS_REF=${sha} ${INSTALL_CMD}`)).toBeInTheDocument();
-    expect(screen.getByText(/It installs commit/)).toHaveTextContent('3f7c1b9');
-  });
-
-  it('says nothing about a commit when the sha is unknown', async () => {
-    await openModal();
-    expect(screen.queryByText(/It installs commit/)).toBeNull();
+    // The command the user pastes is the one on the landing page and in the
+    // README. A 40-character ref in front of it is a sha to check against a
+    // link that already shows the same thing — and the server pins the
+    // one-click install to that commit either way.
+    manualRoute();
     expect(screen.getByText(INSTALL_CMD)).toBeInTheDocument();
+    expect(screen.queryByText(new RegExp(sha))).toBeNull();
   });
 
-  it('the button runs the update once and names the log file', async () => {
+  it('the button runs the update once, then shows what the installer is doing', async () => {
     const calls: unknown[] = [];
-    server.use(updateHandler(calls));
+    server.use(updateHandler(calls), logHandler('==> Installing dependencies (this takes a minute)…'));
     await openModal();
 
     fireEvent.click(screen.getByRole('button', { name: 'Update to v1.2.0' }));
-    const note = await screen.findByRole('status');
-    expect(note).toHaveTextContent('/Users/x/.boros-crossex/logs/update.log');
-    expect(note).toHaveTextContent(/comes back on its own/);
+    const panel = await screen.findByRole('status');
+    expect(panel).toHaveTextContent('Installation running in the background.');
     expect(calls).toHaveLength(1);
     expect(screen.queryByRole('button', { name: /^Update to/ })).toBeNull();
+
+    // The step the installer named, and the checklist caught up to it.
+    await waitFor(() => expect(panel).toHaveTextContent('Installing dependencies'));
+    expect(panel).toHaveTextContent('/Users/x/.boros-crossex/logs/update.log');
+    expect(within(panel).getAllByRole('listitem')[1]).toHaveTextContent('✓Download');
+    expect(within(panel).getAllByRole('listitem')[2]).toHaveTextContent('●Dependencies');
+    expect(within(panel).getAllByRole('listitem')[3]).toHaveTextContent('○Build');
+  });
+
+  it('says an update failed rather than spinning, and offers another go', async () => {
+    const calls: unknown[] = [];
+    server.use(
+      updateHandler(calls),
+      logHandler(
+        ['==> Building the web interface…', 'Error: build failed',
+         '      the previous version is running again at http://localhost:6688'].join('\n'),
+      ),
+    );
+    await openModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Update to v1.2.0' }));
+
+    const panel = await screen.findByRole('status');
+    await waitFor(() => expect(panel).toHaveTextContent('The update failed'));
+    expect(panel).toHaveTextContent('Your keys and trade history are untouched');
+
+    fireEvent.click(within(panel).getByRole('button', { name: 'Try again' }));
+    expect(screen.getByRole('button', { name: 'Update to v1.2.0' })).toBeEnabled();
   });
 
   it('a refusal shows the server’s own reason and leaves the button usable', async () => {
     const calls: unknown[] = [];
-    server.use(updateHandler(calls, 'a deal is still working — wait for it to finish before updating'));
+    server.use(
+      updateHandler(calls, 'a deal is still working — wait for it to finish before updating'),
+      logHandler(),
+    );
     await openModal();
 
     fireEvent.click(screen.getByRole('button', { name: 'Update to v1.2.0' }));
@@ -198,6 +242,7 @@ describe('UpdateIndicator', () => {
       server.use(
         versionHandler({ latest: '1.2.0', updateAvailable: true, install: installedAt('a'.repeat(40)) }),
         updateHandler(calls),
+        logHandler(),
       );
       renderWithClient(<UpdateIndicator />);
       fireEvent.click(await screen.findByRole('button', { name: 'Update v1.2.0' }));
@@ -236,6 +281,7 @@ describe('UpdateIndicator', () => {
           );
         }),
         updateHandler(calls),
+        logHandler(),
       );
       renderWithClient(<UpdateIndicator />);
       fireEvent.click(await screen.findByRole('button', { name: 'Update v1.2.0' }));
@@ -250,6 +296,7 @@ describe('UpdateIndicator', () => {
       server.use(
         versionHandler({ latest: '1.2.0', updateAvailable: true, install: installedAt('a'.repeat(40)) }),
         updateHandler(calls),
+        logHandler(),
       );
       renderWithClient(<UpdateIndicator />);
       fireEvent.click(await screen.findByRole('button', { name: 'Update v1.2.0' }));

--- a/web/src/components/UpdateIndicator.tsx
+++ b/web/src/components/UpdateIndicator.tsx
@@ -1,33 +1,172 @@
 import { useEffect, useState } from 'react';
 import { ApiError } from '../api/client';
-import { useInstallWatch, useRunUpdate, useVersion } from '../api/queries';
+import { useInstallWatch, useRunUpdate, useUpdateLog, useVersion } from '../api/queries';
 import { INSTALL_CMD, INSTALL_CMD_WINDOWS, REPO_URL } from '../lib/app';
+import { readUpdateLog, UPDATE_PHASES } from '../lib/updateProgress';
 import { CopyBlock } from './CopyBlock';
 import { Modal } from './Modal';
+import { SegmentedToggle } from './SegmentedToggle';
 
 const CHANGELOG_URL = `${REPO_URL}/blob/main/CHANGELOG.md`;
 
 type Os = 'macos' | 'windows';
-const OS_LABEL: Record<Os, string> = { macos: 'macOS', windows: 'Windows (PowerShell)' };
-/** The machine reading this. Only the default — the other OS stays one click
- * away, because a user copying the command for a second machine is common. */
+/** Let the app do it, or do it yourself. One choice, one button under it. */
+type Route = 'auto' | 'manual';
+
+const OS_LABEL: Record<Os, string> = { macos: 'macOS', windows: 'Windows' };
+const INSTALL_BY_OS: Record<Os, string> = { macos: INSTALL_CMD, windows: INSTALL_CMD_WINDOWS };
 const thisMachine = (): Os => (navigator.userAgent.includes('Windows') ? 'windows' : 'macos');
-const installCmd = (os: Os, pin: string | null): string =>
-  os === 'windows'
-    ? pin
-      ? `$env:BOROS_REF='${pin}'; ${INSTALL_CMD_WINDOWS}`
-      : INSTALL_CMD_WINDOWS
-    : pin
-      ? `BOROS_REF=${pin} ${INSTALL_CMD}`
-      : INSTALL_CMD;
+
 const LINK_CLASS =
   'text-xs text-cyan-300 underline decoration-cyan-500/40 underline-offset-2 hover:text-cyan-200';
+
+/** Longer than any install anyone has timed. Past it the panel stops implying
+ * that waiting is still the right thing to do, and puts the log in reach. */
+const SLOW_MS = 4 * 60_000;
+
+const clock = (ms: number): string => {
+  const s = Math.max(0, Math.round(ms / 1000));
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`;
+};
+
+/**
+ * What the installer is doing, while it does it.
+ *
+ * The old dialog said "this takes a few minutes" and then showed the same
+ * screen for those minutes, which looks exactly like a stuck update — one
+ * trader waited five. Three things fix that and all three come from the log:
+ * the step it is on, a clock that moves, and a checklist that fills in.
+ */
+function UpdateProgress({
+  startedAt,
+  text,
+  offline,
+  logPath,
+  onRetry,
+}: {
+  startedAt: number;
+  text: string;
+  /** The server stopped answering — normal, and expected near the end. */
+  offline: boolean;
+  logPath: string;
+  onRetry: () => void;
+}) {
+  const { step, phase, done, failed, plain } = readUpdateLog(text);
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (done || failed) return;
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [done, failed]);
+
+  const elapsed = now - startedAt;
+  const slow = !done && !failed && elapsed > SLOW_MS;
+  const pct = done ? 100 : Math.round(((phase + 1) / (UPDATE_PHASES.length + 1)) * 100);
+  const headline = failed
+    ? 'The update failed. Your previous version is running again.'
+    : done
+      ? 'Updated. Reloading this page…'
+      : offline
+        ? 'Restarting the app…'
+        : (step ?? 'Starting the installer…');
+
+  return (
+    <div
+      role="status"
+      className={`rounded-lg border p-3 ${
+        failed
+          ? 'border-rose-500/40 bg-rose-500/[0.06]'
+          : slow
+            ? 'border-amber-500/40 bg-amber-500/[0.06]'
+            : 'border-ink-700 bg-ink-950/60'
+      }`}
+    >
+      <div className="flex items-baseline gap-2">
+        {(failed || done) && (
+          <span className={failed ? 'text-rose-400' : 'text-emerald-400'}>{failed ? '✕' : '✓'}</span>
+        )}
+        <span className="min-w-0 flex-1 truncate text-[13px] text-ink-100">{headline}</span>
+        <span className="num shrink-0 text-[11px] text-ink-500">{clock(elapsed)}</span>
+      </div>
+
+      {!failed && (
+        <div className="mt-2 h-1 overflow-hidden rounded-full bg-ink-800">
+          <div
+            className="h-full rounded-full bg-cyan-400 transition-[width] duration-700"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      )}
+
+      <ol className="mt-2.5 flex flex-wrap gap-x-4 gap-y-1">
+        {UPDATE_PHASES.map((p, i) => {
+          // A failed update leaves nothing running, so the step it died on
+          // must stop pulsing — a live marker under an ✕ reads as still working.
+          const state =
+            done || i < phase ? 'done' : i === phase && !failed ? 'now' : 'next';
+          return (
+            <li
+              key={p.key}
+              className={`flex items-center gap-1.5 text-[11px] ${
+                state === 'now' ? 'text-cyan-200' : state === 'done' ? 'text-ink-400' : 'text-ink-600'
+              }`}
+            >
+              <span
+                className={
+                  state === 'done'
+                    ? 'text-emerald-400'
+                    : state === 'now'
+                      ? 'animate-pulse text-cyan-300'
+                      : ''
+                }
+              >
+                {state === 'done' ? '✓' : state === 'now' ? '●' : '○'}
+              </span>
+              {p.label}
+            </li>
+          );
+        })}
+      </ol>
+
+      <p className="mt-2.5 text-[12px] text-ink-400">
+        {failed
+          ? 'Your keys and trade history are untouched. Try again, or run the command yourself.'
+          : slow
+            ? 'This is taking longer than usual. The installer’s own output is below.'
+            : 'Installation running in the background. This page reloads itself when it is done.'}
+      </p>
+
+      <details className="mt-2">
+        <summary className="cursor-pointer text-[11px] text-ink-500 hover:text-ink-300">
+          Show log
+        </summary>
+        <pre className="num mt-1 max-h-48 overflow-auto whitespace-pre-wrap break-all rounded-md border border-ink-800 bg-ink-950 p-2 text-[10px] leading-relaxed text-ink-400">
+          {plain.trim() || 'nothing yet'}
+        </pre>
+        <p className="num mt-1 break-all text-[10px] text-ink-600">{logPath}</p>
+      </details>
+
+      {failed && (
+        <button type="button" className="btn mt-2.5 text-xs" onClick={onRetry}>
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}
 
 export function UpdateIndicator() {
   const { data } = useVersion();
   const runUpdate = useRunUpdate();
   const [open, setOpen] = useState(false);
+  const [route, setRoute] = useState<Route>('auto');
   const [os, setOs] = useState<Os>(thisMachine);
+  /** The dialog's own clock. The server's start time does not survive the swap
+   * that replaces it, and this is what the user is actually timing. */
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+
+  const running = runUpdate.data != null;
+  const log = useUpdateLog(running);
 
   /**
    * RELOAD ONTO THE NEW BUNDLE, once the swap has actually happened.
@@ -42,7 +181,7 @@ export function UpdateIndicator() {
    * copy is serving, however long the install took.
    */
   const installedCommit = data?.install?.commit ?? null;
-  const servingCommit = useInstallWatch(Boolean(runUpdate.data)).data?.install?.commit ?? null;
+  const servingCommit = useInstallWatch(running).data?.install?.commit ?? null;
   useEffect(() => {
     if (installedCommit && servingCommit && servingCommit !== installedCommit) {
       window.location.reload();
@@ -51,11 +190,7 @@ export function UpdateIndicator() {
 
   if (!data?.updateAvailable || !data.latest) return null;
 
-  const pin = data.latestCommit;
-  // This machine first, so the command the user almost always wants is the one
-  // under the cursor as well as the one selected.
-  const order: Os[] = thisMachine() === 'windows' ? ['windows', 'macos'] : ['macos', 'windows'];
-  const target = pin ?? 'main';
+  const target = data.latestCommit ?? 'main';
   const changesUrl = data.install?.commit
     ? `${REPO_URL}/compare/${data.install.commit}...${target}`
     : `${REPO_URL}/commits/${target}`;
@@ -65,87 +200,99 @@ export function UpdateIndicator() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        title={`Version ${data.latest} is available — click to review and update`}
+        title={
+          running
+            ? 'The update is installing — click to watch it'
+            : `Version ${data.latest} is available — click to review and update`
+        }
         className="hdr-ctl border-amber-500/50 bg-amber-500/10 text-amber-400 hover:bg-amber-500/20"
       >
-        Update v{data.latest}
+        {running ? 'Updating…' : `Update v${data.latest}`}
       </button>
       {open && (
-        <Modal title={`Update available — v${data.latest}`} onClose={() => setOpen(false)} widthClass="w-[560px]">
+        <Modal
+          title={running ? `Updating to v${data.latest}` : `Update available — v${data.latest}`}
+          onClose={() => setOpen(false)}
+          widthClass="w-[560px]"
+        >
           <div className="flex flex-col gap-4 px-5 py-5 text-sm leading-relaxed text-ink-200">
-            <p>
-              You're on <span className="num">v{data.current ?? 'unknown'}</span>. Version{' '}
-              <span className="num">v{data.latest}</span> brings:
-            </p>
-            {data.highlights.length > 0 && (
-              <ul className="list-disc pl-5 text-[13px] text-ink-300">
-                {data.highlights.map((h) => (
-                  <li key={h}>{h}</li>
-                ))}
-              </ul>
-            )}
-            <p className="text-[13px] text-ink-300">
-              Update runs this command on this machine. It stops the old version and swaps the new
-              one in. Your keys and trade history are never touched. You can also paste it into a
-              terminal yourself.
-            </p>
-            {pin && (
-              <p className="text-[13px] text-ink-300">
-                It installs commit <span className="num text-ink-200">{pin.slice(0, 7)}</span> —
-                the exact code the link below shows, not whatever lands on the branch later.
+            <div>
+              <p className="text-[13px] text-ink-400">
+                You&rsquo;re on <span className="num">v{data.current ?? 'unknown'}</span>.
               </p>
-            )}
-            <div className="flex flex-col">
-              {/* Folder tabs, same recipe as TabBar: -mb-px pulls the strip down
-                  over the block's top border, and the active tab's opaque
-                  bg-ink-900 — the block's own colour — cuts that line, so the
-                  two read as one surface. Flex items paint in document order, so
-                  the strip needs z-10 or the block below repaints its own border
-                  over the tab. Per-side border colours, never `border-*`, or the
-                  cyan cap loses to the all-sides rule. */}
-              <div
-                role="tablist"
-                aria-label="Operating system"
-                className="relative z-10 -mb-px flex"
-              >
-                {order.map((v) => (
-                  <button
-                    key={v}
-                    type="button"
-                    role="tab"
-                    aria-selected={os === v}
-                    onClick={() => setOs(v)}
-                    className={`shrink-0 whitespace-nowrap rounded-t-md border-x border-t-2 px-3 py-1.5 text-xs font-medium transition-colors ${
-                      os === v
-                        ? 'border-x-ink-700 border-t-cyan-400 bg-ink-900 text-ink-100'
-                        : 'border-transparent text-ink-400 hover:border-t-ink-500 hover:bg-ink-900/40 hover:text-ink-200'
-                    }`}
-                  >
-                    {OS_LABEL[v]}
-                  </button>
-                ))}
-              </div>
-              <CopyBlock text={installCmd(os, pin)} tabbed />
+              {data.highlights.length > 0 && (
+                <ul className="mt-1.5 list-disc space-y-1 pl-5 text-[13px] text-ink-300">
+                  {data.highlights.map((h) => (
+                    <li key={h}>{h}</li>
+                  ))}
+                </ul>
+              )}
             </div>
-            {runUpdate.data ? (
-              <p
-                role="status"
-                className="rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-300"
-              >
-                The install is running. It writes to{' '}
-                <span className="num break-all">{runUpdate.data.logPath}</span>. This page loses the
-                server for a few minutes while it works, then comes back on its own.
-              </p>
+
+            {running && startedAt !== null ? (
+              <UpdateProgress
+                startedAt={startedAt}
+                text={log.data?.text ?? ''}
+                offline={log.isError}
+                logPath={runUpdate.data?.logPath ?? ''}
+                onRetry={() => {
+                  runUpdate.reset();
+                  setStartedAt(null);
+                }}
+              />
             ) : (
-              <button
-                type="button"
-                className="btn btn-primary self-start"
-                disabled={runUpdate.isPending}
-                onClick={() => runUpdate.mutate()}
-              >
-                {runUpdate.isPending ? 'Starting…' : `Update to v${data.latest}`}
-              </button>
+              /* One decision, then one button. The dialog used to show a copy
+                 button and an update button side by side and let the reader
+                 work out which of the two was the update. */
+              <div className="flex flex-col gap-3 rounded-lg border border-ink-700 bg-ink-950/60 p-3">
+                <SegmentedToggle
+                  fill
+                  value={route}
+                  ariaLabel="How to update"
+                  onChange={setRoute}
+                  options={[
+                    { value: 'auto', label: 'Update for me' },
+                    { value: 'manual', label: 'Run it in my terminal' },
+                  ]}
+                />
+                {route === 'auto' ? (
+                  <>
+                    <p className="text-[12px] text-ink-400">
+                      Installs v{data.latest} on this machine and restarts the app. It takes about a
+                      minute. Your keys and trade history are not touched.
+                    </p>
+                    <button
+                      type="button"
+                      className="btn btn-primary self-start"
+                      disabled={runUpdate.isPending}
+                      onClick={() => {
+                        setStartedAt(Date.now());
+                        runUpdate.mutate();
+                      }}
+                    >
+                      {runUpdate.isPending ? 'Starting…' : `Update to v${data.latest}`}
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <p className="text-[12px] text-ink-400">Paste this into a terminal.</p>
+                      <SegmentedToggle
+                        value={os}
+                        ariaLabel="Operating system"
+                        onChange={setOs}
+                        options={(['macos', 'windows'] as Os[]).map((v) => ({
+                          value: v,
+                          label: OS_LABEL[v],
+                        }))}
+                      />
+                    </div>
+                    <CopyBlock text={INSTALL_BY_OS[os]} />
+                  </>
+                )}
+              </div>
             )}
+
             {runUpdate.error != null && (
               <p
                 role="alert"
@@ -156,6 +303,7 @@ export function UpdateIndicator() {
                   : String(runUpdate.error)}
               </p>
             )}
+
             <div className="flex flex-wrap gap-x-4 gap-y-1">
               <a href={changesUrl} target="_blank" rel="noreferrer" className={LINK_CLASS}>
                 Read the code changes →

--- a/web/src/lib/updateProgress.test.ts
+++ b/web/src/lib/updateProgress.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { readUpdateLog, UPDATE_PHASES } from './updateProgress';
+
+/** install.sh colours every step it announces; a redirected log keeps them. */
+const say = (m: string) => `\x1b[1;36m==>\x1b[0m ${m}`;
+const phase = (key: string) => UPDATE_PHASES.findIndex((p) => p.key === key);
+
+describe('readUpdateLog', () => {
+  it('reports the last step the installer named', () => {
+    const s = readUpdateLog(
+      [say('Downloading the app…'), say('Installing dependencies…')].join('\n'),
+    );
+    expect(s.step).toBe('Installing dependencies…');
+    expect(s.phase).toBe(phase('deps'));
+    expect(s.done).toBe(false);
+    expect(s.failed).toBe(false);
+  });
+
+  it('holds the furthest phase when a step is skipped or a note follows it', () => {
+    // "already installed" skips a step, and the last line here is a heading
+    // that matches no phase at all. Neither may walk the checklist backwards.
+    const s = readUpdateLog(
+      [
+        say('Node.js v24.19.0 already installed — skipping.'),
+        say('Building the web interface…'),
+        say('Installing CrossEx-Boros Terminal into /Users/x/.boros-crossex'),
+      ].join('\n'),
+    );
+    expect(s.phase).toBe(phase('build'));
+  });
+
+  it('knows a finished install from a rolled-back one', () => {
+    expect(readUpdateLog(say('Done! Opening http://localhost:6688 …')).done).toBe(true);
+    expect(
+      readUpdateLog('      the previous version is running again at http://localhost:6688').failed,
+    ).toBe(true);
+  });
+
+  it('strips the colour codes it was handed', () => {
+    expect(readUpdateLog(say('Build…')).plain).toBe('==> Build…');
+  });
+});

--- a/web/src/lib/updateProgress.ts
+++ b/web/src/lib/updateProgress.ts
@@ -1,0 +1,68 @@
+/**
+ * Reading the installer's own output back to the user.
+ *
+ * `install.sh` and `install.ps1` both announce each step they start as
+ * `==> <message>`, and both print the same banner when a build fails and the
+ * old version goes back. That is enough to drive a progress panel without
+ * either script having to know an app is watching.
+ *
+ * The match list is deliberately loose. A message that drifts costs the panel
+ * one tick of its checklist — the step line, the elapsed clock and the log are
+ * all still right — where a strict parser would show a stalled update instead.
+ */
+
+/** install.sh colours its `say` output; a redirected log keeps the escapes. */
+// eslint-disable-next-line no-control-regex
+const ANSI = /\x1b\[[0-9;]*m/g;
+
+export const UPDATE_PHASES = [
+  { key: 'runtime', label: 'Runtime', match: /Node\.js|yarn package manager/i },
+  { key: 'fetch', label: 'Download', match: /Downloading the app/i },
+  { key: 'deps', label: 'Dependencies', match: /Installing dependencies/i },
+  { key: 'build', label: 'Build', match: /Building the web interface/i },
+  {
+    key: 'restart',
+    label: 'Restart',
+    match: /Stopping (the previous version|any running instance)|Registering the background service|Waiting for the app to start/i,
+  },
+] as const;
+
+const DONE = /^Done!/i;
+const ROLLED_BACK = /previous version is running again|version that failed is kept/i;
+
+export interface UpdateProgressState {
+  /** The last step the installer named, verbatim. */
+  step: string | null;
+  /** Index into UPDATE_PHASES; -1 before anything is recognised. */
+  phase: number;
+  done: boolean;
+  failed: boolean;
+  /** The log without its colour codes — what "Show log" shows. */
+  plain: string;
+}
+
+export function readUpdateLog(text: string): UpdateProgressState {
+  const plain = text.replace(ANSI, '');
+  const steps = plain
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith('==>'))
+    .map((l) => l.slice(3).trim());
+
+  // The FURTHEST phase reached, not the phase of the last line. A step can be
+  // skipped ("Node.js already installed"), and the installer prints notes
+  // between steps — either would walk the checklist backwards.
+  let phase = -1;
+  for (const s of steps) {
+    const i = UPDATE_PHASES.findIndex((p) => p.match.test(s));
+    if (i > phase) phase = i;
+  }
+
+  return {
+    step: steps.length > 0 ? (steps[steps.length - 1] ?? null) : null,
+    phase,
+    done: steps.some((s) => DONE.test(s)),
+    failed: ROLLED_BACK.test(plain),
+    plain,
+  };
+}

--- a/web/src/panels/SpreadBreakdown.tsx
+++ b/web/src/panels/SpreadBreakdown.tsx
@@ -1,0 +1,98 @@
+/** Where the locked spread comes from: one row per Boros leg.
+ *
+ * The card states a single percentage. That number is the weighted result of
+ * two or four legs, each locked at its own rate, on its own size, over its own
+ * window — so "why this number?" is answered by showing the legs, not by
+ * describing them. Sides are coloured the way they are everywhere else in the
+ * app, and the amount carries its own sign: a trader reads the shape of the
+ * trade before reading a word of it. */
+import { SignedNumber } from '../components/SignedNumber';
+import { microLabelClass } from '../components/Th';
+import { SideVenue } from '../components/VenueChip';
+import { fmtDateUtc, fmtPct, fmtUsd, fmtUsdCompact, prettyVenue } from '../lib/fmt';
+
+export interface SpreadLeg {
+  venue: string;
+  side: 'LONG' | 'SHORT';
+  /** The fixed rate this leg locked at entry. */
+  apr: number;
+  notionalUsd: number;
+  startSec: number;
+  endSec: number;
+  days: number;
+  /** What this leg alone is worth by its maturity — negative when it pays. */
+  usd: number;
+  /** This leg's own open date is unknown, so it accrues from the position
+   * start instead. Marked, never applied silently. */
+  datedFromPosition: boolean;
+}
+
+export function SpreadBreakdown({
+  legs,
+  totalUsd,
+  clockNote,
+}: {
+  legs: readonly SpreadLeg[];
+  totalUsd: number;
+  clockNote: string;
+}) {
+  const anyUndated = legs.some((l) => l.datedFromPosition);
+  return (
+    <div>
+      <div className="mb-1 flex items-baseline justify-between gap-3">
+        <span className={microLabelClass}>Each leg&rsquo;s locked rate</span>
+        <span className={microLabelClass}>By maturity</span>
+      </div>
+      {legs.map((l, i) => (
+        <div
+          key={`${l.venue}-${l.side}-${i}`}
+          className="flex items-center gap-2 border-t border-ink-800 py-1 text-[11px] first:border-t-0"
+        >
+          {/* Never shrinks: "SHORT · Hyperliquid" wrapped to two lines and
+              took the row's numbers out of line with the row above it. */}
+          <span className="shrink-0 whitespace-nowrap">
+            <SideVenue side={l.side} venue={prettyVenue(l.venue)} />
+          </span>
+          <span className="flex-1" />
+          <span className="num w-[86px] shrink-0 text-right">
+            <span className="text-ink-500">{l.side === 'SHORT' ? 'gets' : 'pays'} </span>
+            <span className="text-ink-100">{fmtPct(l.apr)}</span>
+          </span>
+          <span className="num w-[52px] shrink-0 text-right text-ink-400">
+            {fmtUsdCompact(l.notionalUsd)}
+          </span>
+          {/* The window a leg accrues over, as the figure that varies between
+              legs. The dates themselves sit in the title: two ISO dates per row
+              is most of the card's width spent on the part that rarely differs. */}
+          <span
+            className={`num w-[42px] shrink-0 text-right ${
+              l.datedFromPosition ? 'text-amber-300/80' : 'text-ink-500'
+            }`}
+            title={`${fmtDateUtc(l.startSec)} → ${fmtDateUtc(l.endSec)}${
+              l.datedFromPosition ? ' · open date unknown, so it accrues from the position start' : ''
+            }`}
+          >
+            {l.days}d
+          </span>
+          <SignedNumber
+            value={l.usd}
+            format={(n) => fmtUsd(n, 0)}
+            className="num w-[66px] shrink-0 text-right font-medium"
+          />
+        </div>
+      ))}
+      <div className="mt-1 flex items-center justify-between gap-3 border-t border-ink-700 pt-1.5 text-[11px]">
+        <span className="text-ink-300">Spread return</span>
+        <SignedNumber
+          value={totalUsd}
+          format={(n) => fmtUsd(n, 0)}
+          className="num font-semibold"
+        />
+      </div>
+      <p className="mt-1.5 text-[10px] leading-snug text-ink-500">
+        {clockNote}
+        {anyUndated && <span className="text-amber-300/80"> Amber: open date unknown.</span>}
+      </p>
+    </div>
+  );
+}

--- a/web/src/panels/StrategyCard.test.tsx
+++ b/web/src/panels/StrategyCard.test.tsx
@@ -31,6 +31,11 @@ const rollOver = () => {
   fireEvent.click(screen.getByRole('radio', { name: 'Omit (rolling over)' }));
 };
 
+/** The locked-spread breakdown is a hover card now. Click opens it too — and
+ * has to, or reading it would toggle the chart box the trigger sits inside. */
+const openSpread = () => fireEvent.click(screen.getByText(/% spread$/));
+const spreadCard = () => screen.getByRole('tooltip').textContent ?? '';
+
 /** The exit assumption defaults to Omit now — opt in to the charged case. */
 const includeExit = () => {
   openCosts();
@@ -139,9 +144,10 @@ describe('StrategyCard — hero tiers', () => {
     // parenthetical in the title.
     expect(screen.queryByText('(7.07% spread)')).not.toBeInTheDocument();
     expect(screen.getByText(/7\.07% spread/)).toBeInTheDocument();
-    expect(
-      screen.getByTitle(/Each leg earns its fixed rate from its own open date[\s\S]*receives 9\.36% on \$158\.8k/),
-    ).toBeInTheDocument();
+    openSpread();
+    expect(spreadCard()).toMatch(/Each leg earns its fixed rate from its own open date/);
+    expect(spreadCard()).toContain('9.36%');
+    expect(spreadCard()).toContain('$158.8k');
   });
 
   it('folds the checked exit parts into the hero numbers when included', () => {
@@ -1350,33 +1356,36 @@ describe('StrategyCard — the spread tooltip', () => {
       ),
     });
 
-  const tipText = () =>
-    screen.getByTitle(/spread return by maturity/).getAttribute('title') ?? '';
-
-  it('gives each leg its own line, with its own window and its own share', () => {
+  it('gives each leg its own row, with its own window and its own share', () => {
     render(staggered());
     rollOver();
-    const tip = tipText();
-    expect(tip).toContain('pays 2.29% on $100.0k');
-    expect(tip).toContain('(60d) = -$376');
-    expect(tip).toContain('receives 9.36% on $100.0k');
-    expect(tip).toContain('(30d) = +$769');
+    openSpread();
+    const card = spreadCard();
+    expect(card).toContain('pays 2.29%');
+    expect(card).toContain('60d');
+    expect(card).toContain('-$376');
+    expect(card).toContain('gets 9.36%');
+    expect(card).toContain('30d');
+    expect(card).toContain('+$769');
+    expect(card).toContain('$100.0k');
   });
 
-  it('ends on the total, and the leg lines add up to it', () => {
+  it('ends on the total, and the leg rows add up to it', () => {
     render(staggered());
     rollOver();
-    expect(tipText()).toContain('spread return by maturity = $393');
+    openSpread();
+    expect(spreadCard()).toMatch(/Spread return\+\$393/);
     expect(Math.round(769.32 - 376.44)).toBe(393);
   });
 
   it('says so when a user-set clock overrides every leg open', () => {
     render(staggered({ clockBasis: 'custom' }));
     rollOver();
-    const tip = tipText();
-    expect(tip).toContain('Every leg accrues from the clock you set');
-    expect(tip).toContain('(60d) = -$376');
-    expect(tip).toContain('(60d) = +$1,539');
+    openSpread();
+    const card = spreadCard();
+    expect(card).toContain('Every leg accrues from the clock you set');
+    expect(card).toContain('-$376');
+    expect(card).toContain('+$1,539');
   });
 
   it('marks a leg whose open date is unknown, rather than dating it silently', () => {
@@ -1390,6 +1399,8 @@ describe('StrategyCard — the spread tooltip', () => {
       }),
     );
     rollOver();
-    expect(tipText()).toContain('open date unknown, from');
+    openSpread();
+    expect(screen.getAllByTitle(/open date unknown, so it accrues from the position start/).length).toBeGreaterThan(0);
+    expect(spreadCard()).toContain('Amber: open date unknown.');
   });
 });

--- a/web/src/panels/StrategyCard.tsx
+++ b/web/src/panels/StrategyCard.tsx
@@ -38,6 +38,7 @@ import type {
 } from '../api/types';
 import { Chip } from '../components/Chip';
 import { DataTable, type Column } from '../components/DataTable';
+import { HoverCard } from '../components/HoverCard';
 import { Modal } from '../components/Modal';
 import { Notes } from '../components/Notes';
 import { SignedNumber } from '../components/SignedNumber';
@@ -64,6 +65,7 @@ import { CloseBorosForm } from '../trade/CloseBorosForm';
 import { PerpLegExpanded, PositionRowActions } from './PerpLegExpanded';
 import { ProfitBars } from './ProfitBars';
 import { EntryCostParts } from './EntryCostParts';
+import { SpreadBreakdown, type SpreadLeg } from './SpreadBreakdown';
 import {
   hasLapsedLegacyExclusions,
   loadExcludedPartIds,
@@ -331,7 +333,7 @@ export function StrategyCard({
   const perLegClock = s.clockBasis !== 'custom';
   let openWeightUsd = 0;
   let openWeightedSec = 0;
-  const spreadLines: string[] = [];
+  const spreadLegs: SpreadLeg[] = [];
   for (const l of s.legs) {
     if (l.kind !== 'boros') continue;
     const start = perLegClock ? (l.openedAt ?? s.clockStartSec) : s.clockStartSec;
@@ -342,13 +344,17 @@ export function StrategyCard({
     if (start === null) continue;
     const end = l.maturity ?? s.maturity;
     const perYearUsd = (l.side === 'SHORT' ? 1 : -1) * (l.entryApr ?? 0) * l.notionalUsd;
-    const earnsUsd = perYearUsd * (Math.max(0, end - start) / SECONDS_IN_YEAR);
-    const days = Math.max(0, Math.round((end - start) / 86_400));
-    spreadLines.push(
-      `${l.side === 'SHORT' ? 'receives' : 'pays'} ${fmtPct(l.entryApr ?? 0)} on ${fmtUsdCompact(l.notionalUsd)}` +
-        `${perLegClock && l.openedAt === null ? ' · open date unknown, from' : ' · from'} ${fmtDateUtc(start)}` +
-        ` to ${fmtDateUtc(end)} (${days}d) = ${earnsUsd < 0 ? '-' : '+'}${fmtUsd(Math.abs(earnsUsd), 0)}`,
-    );
+    spreadLegs.push({
+      venue: l.venue,
+      side: l.side,
+      apr: l.entryApr ?? 0,
+      notionalUsd: l.notionalUsd,
+      startSec: start,
+      endSec: end,
+      days: Math.max(0, Math.round((end - start) / 86_400)),
+      usd: perYearUsd * (Math.max(0, end - start) / SECONDS_IN_YEAR),
+      datedFromPosition: perLegClock && l.openedAt === null,
+    });
   }
   const lifeSeconds =
     s.clockStartSec === null
@@ -1329,26 +1335,30 @@ export function StrategyCard({
                 <div className="mt-1 flex flex-wrap items-center gap-x-3 text-[11px] text-ink-500">
                   {checks.fullyHedged ? (
                     <>
-                      <span
-                        className="num"
-                        title={
-                          s.spreadReturnUsd !== null && spreadLines.length > 0
-                            ? [
-                                perLegClock
-                                  ? 'Each leg earns its fixed rate from its own open date to its own maturity:'
-                                  : `Every leg accrues from the clock you set (${fmtDateUtc(s.clockStartSec ?? 0)}):`,
-                                '',
-                                ...spreadLines,
-                                '',
-                                `spread return by maturity = ${fmtUsd(s.spreadReturnUsd, 0)}`,
-                              ].join('\n')
-                            : s.spreadReturnUsd !== null
+                      {s.spreadReturnUsd !== null && spreadLegs.length > 0 ? (
+                        <HoverCard widthPx={460} label={<span className="num">{fmtPct(s.spread)} spread</span>}>
+                          <SpreadBreakdown
+                            legs={spreadLegs}
+                            totalUsd={s.spreadReturnUsd}
+                            clockNote={
+                              perLegClock
+                                ? 'Each leg earns its fixed rate from its own open date to its own maturity.'
+                                : `Every leg accrues from the clock you set (${fmtDateUtc(s.clockStartSec ?? 0)}).`
+                            }
+                          />
+                        </HoverCard>
+                      ) : (
+                        <span
+                          className="num"
+                          title={
+                            s.spreadReturnUsd !== null
                               ? `Assumes ${fmtPct(s.spread)} locked on ${fmtUsdCompact(borosNotionalPerSide)} → spread return ≈${fmtUsd(s.spreadReturnUsd, 0)} by maturity`
                               : 'Locked fixed spread across the Boros legs'
-                        }
-                      >
-                        {fmtPct(s.spread)} spread
-                      </span>
+                          }
+                        >
+                          {fmtPct(s.spread)} spread
+                        </span>
+                      )}
                       {roi !== null && (
                         <span
                           className="num"


### PR DESCRIPTION
Feedback on two screens that hide what they know. Folded into 1.5.0 — PR #33 picks it up.

## The locked spread

It was a native `title` holding one line of prose per Boros leg. Nothing on the card said it was there, and what was behind it was a paragraph to parse.

Now a hover card: a dotted rule and an `i` mark on the trigger, one row per leg inside.

```
LONG · Bybit          pays 2.29%   $100.0k   60d    -$376
SHORT · Hyperliquid   gets 9.36%   $100.0k   30d    +$769
Spread return                                       +$393
```

Sides use the app's own long/short colours and the amount carries its own sign, so the shape of the trade reads before any word does. The dates moved into the window cell's own title — two ISO dates a row spent most of the card's width on the part that rarely differs.

`0.68% ROI` beside it keeps a plain `title` and gets no marker. That is the convention: the marker means a breakdown, not a sentence.

New `HoverCard.tsx` opens on hover **and** click. Click is not optional — the trigger sits inside the button that toggles the chart box, so reading the breakdown must not collapse the card.

## The update dialog

It said the install takes a few minutes and then showed the same screen for those minutes, which is what a stuck update looks like. One trader waited five.

Both installers already announce each step as `==> …`, and both print the same banner when a build fails and the old copy goes back. A new `GET /api/version/update/log` hands that output to the dialog, so nothing had to be taught to `install.sh` or `install.ps1`.

The panel names the step, ticks off five phases, runs a clock, and after four minutes says the wait is no longer normal. A rollback shows the installer's own log and offers another go. While the server is down mid-swap it says "Restarting the app…" rather than freezing.

The dialog also stopped offering two buttons and letting the reader work out which one was the update. One question — **Update for me** / **Run it in my terminal** — and one button under the answer.

Dropped: the commit paragraph, and the `BOROS_REF=<sha>` prefix on the copied command. The sha was already one click away in "Read the code changes", the one-click install is pinned server-side either way, and what a user pastes is now the same command as the landing page and the README.

## Two bugs found while reading that log

- **macOS appended to `update.log` instead of truncating it.**
- **Windows left the previous run's log in place** until the scheduled task fired.

Either way the panel would have read the *last* update's `Done!` and called a fresh install finished before it started.

## Testing

Both screens driven in the running app on a second server, not only in jsdom: the hover card against a real card, and the progress panel through its running, rollback and log states. `yarn verify` green — 907 server + 691 web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfmQww5n9Q6qpScqFRR2HD