### PR TITLE
Rebalance USDT and USDC from the Balances tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 Only substantial releases are listed here — each one bumps `version.json` (which is what the
 in-app update check compares against).
 
+## 1.5.1 — 2026-09-07
+
+Pay back borrowed USDC from the Balances tab, or bring spare USDC home, with one hold.
+
+- **A new Rebalance section on the Balances tab.** When a Hyperliquid leg loses money or pays
+  funding, Gate lends the USDC and holds 20% of it as initial margin and 10% as maintenance
+  margin. Past 10,000 USDC short it also charges interest every hour. The section shows the
+  borrow with the margin it holds, the interest per day, and the interest paid in the last 30
+  days. An info mark next to the title explains all of it.
+- **One hold moves cash either way.** USDT to Hyperliquid USDC pays the borrow back and frees
+  the margin. Hyperliquid USDC to USDT brings spare USDC home, capped so it never opens a
+  borrow. The amount is prefilled with the most that can move, and you can type less.
+- **The cheaper route is picked for you and shown.** An instant convert at 20 bps, or a spot
+  loop through Gate that costs $0.05 for a pay-down and a flat $1 for a pull. The quote line
+  names the winner, the price, what lands, the cost, and the borrow after the move. Under
+  1 USDC there is nothing to hold.
+- **You can watch it run.** A progress bar shows each step with its seconds. A job survives a
+  page refresh. If the app restarts mid-job, it halts, says where the funds are, and offers
+  Resume and Abandon.
+
 ## 1.5.0 — 2026-08-27
 
 An update button that updates, gas you never have to think about, and messages that say what

--- a/README.md
+++ b/README.md
@@ -450,8 +450,8 @@ curl -s "https://api.gateio.ws/api/v4/crossex/rule/symbols" | jq '.[] | select(.
     projections), `partition.ts` (which venue leg belongs to which strategy).
   - `preview.ts` — `resolveActions` + estimates = `POST /api/preview`.
 - `src/server/` — Fastify app: TTL cache with request coalescing + 429 stale-serve, localhost
-  Host/Origin guard, `/api/deals` routes (thin intent writers — the loop owns every venue
-  mutation), routes.
+  Host/Origin guard, `/api/deals` routes (thin intent writers — the loop owns every deal's
+  venue mutation; the rebalance runner owns the pay-down's), routes.
 - `web/` — React 18 + Vite + Tailwind + react-query SPA (standalone package).
 - `install.sh` / `uninstall.sh` — the macOS one-command installer (private Node runtime in
   `~/.boros-crossex`, LaunchAgent `com.boros.crossex-terminal`, user data outside the app dir).

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -109,6 +109,12 @@ Every APR on a position is a return *on capital*, so what goes into that number 
 
 The choice is remembered per browser and applies to every position box and the totals strip.
 
+#### Paying down borrowed USDC
+
+When a Hyperliquid position loses money, CrossEx borrows USDC for that venue and charges interest every hour. The terminal shows the borrow as a negative USDC balance on Hyperliquid. While Hyperliquid has a USDC borrow, or a pay-down job runs or is halted, the Balances tab shows a **Pay down** section. Its three tiles show the borrow in USDC, the interest per day, and the interest paid in the last 30 days.
+
+Hold `Pay down <amount> USDC` and the terminal moves that much USDT from CrossEx into USDC on Hyperliquid. The terminal chooses the cheaper route automatically: a spot buy plus two transfers (about 2.5 minutes), or a direct convert (instant). A halted job shows the reason, the line `Funds are in <place>`, and a **Resume** and an **Abandon** button. After **Abandon**, move any USDC left in the Gate spot wallet by hand in Gate.
+
 ## 3. How to maximise return
 These few factors move the needle the most in maximising your return on the 4-legged Funding Rate Arbitrage
 1. Reduce perp fees with a **higher VIP tier** in Gate.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -109,11 +109,24 @@ Every APR on a position is a return *on capital*, so what goes into that number 
 
 The choice is remembered per browser and applies to every position box and the totals strip.
 
-#### Paying down borrowed USDC
+#### Rebalancing USDC and USDT
 
-When a Hyperliquid position loses money, CrossEx borrows USDC for that venue and charges interest every hour. The terminal shows the borrow as a negative USDC balance on Hyperliquid. While Hyperliquid has a USDC borrow, or a pay-down job runs or is halted, the Balances tab shows a **Pay down** section. Its three tiles show the borrow in USDC, the interest per day, and the interest paid in the last 30 days.
+Your CrossEx account holds USDT. Every venue except Hyperliquid margins and settles in USDT. Hyperliquid settles in USDC, so it has its own USDC bucket, which starts at 0.
 
-Hold `Pay down <amount> USDC` and the terminal moves that much USDT from CrossEx into USDC on Hyperliquid. The terminal chooses the cheaper route automatically: a spot buy plus two transfers (about 2.5 minutes), or a direct convert (instant). A halted job shows the reason, the line `Funds are in <place>`, and a **Resume** and an **Abandon** button. After **Abandon**, move any USDC left in the Gate spot wallet by hand in Gate.
+Opening a Hyperliquid leg does not borrow USDC. Its margin comes from your whole account. The USDC bucket moves only when that leg pays or receives USDC: hourly funding, fees, and profit or loss. When the leg loses, the bucket goes negative and Gate lends you the difference. Gate counts the unrealised loss too, so a borrow can show while the cash is still positive.
+
+The borrow costs two things. Gate holds 20% of it as initial margin and 10% as maintenance margin. Once the bucket is more than 10,000 USDC short, Gate also charges interest every hour.
+
+The Balances tab shows a **Rebalance** section whenever Hyperliquid has a USDC borrow or spare USDC, or a job runs or is halted. The pill shows the borrow and the margin it holds. The two tiles show the interest per day and the interest paid in the last 30 days. The info mark next to the title opens a short card that says all this.
+
+Pick a direction, keep the prefilled amount or type one, and hold the button:
+
+- **USDT → Hyperliquid USDC** pays the borrow back. The amount is capped at the borrow, at your free USDT, and at your available margin. The quote line shows the route the terminal picked, the price, what lands, the cost, what it saves per day, the margin it frees, and the borrow after the move. When less than the borrow can move, an amber line says how much stays borrowed and why.
+- **Hyperliquid USDC → USDT** brings spare USDC back. The amount is capped at the USDC you own there after open losses, so a pull never starts a new borrow.
+
+Two routes exist and the terminal takes the cheaper one: a direct convert on Hyperliquid (instant, about 20 bps), or a spot loop through Gate (a spot trade plus two transfers; about 2.5 minutes for a pay-down, about 6.5 minutes plus a flat $1 fee for a pull). Under 1 USDC the hold is hidden.
+
+A running job shows a progress bar, one segment per step with its seconds. A halted job shows the reason, the line `Funds are in <place>`, and a **Resume** and an **Abandon** button. After **Abandon**, move any USDC left in the Gate spot wallet by hand in Gate.
 
 ## 3. How to maximise return
 These few factors move the needle the most in maximising your return on the 4-legged Funding Rate Arbitrage

--- a/src/core/rebalance/plan.ts
+++ b/src/core/rebalance/plan.ts
@@ -1,0 +1,167 @@
+import { roundToStep } from '../numbers';
+
+export const DEFICIT = { coin: 'USDC', venue: 'HYPERLIQUID' } as const;
+export const SURPLUS = { coin: 'USDT', venue: 'CROSSEX' } as const;
+export const SPOT_SYMBOL = 'GATE_SPOT_USDC_USDT';
+export const INTEREST_THRESHOLD = -10000;
+export const LOOP_WAIT_SECONDS = 150;
+export const CONVERT_RATE = 0.002;
+export const DEPOSIT_FEE_USD = 0.05;
+
+export interface AssetLike {
+  coin?: string;
+  exchangeType?: string;
+  balance?: string;
+  upnl?: string;
+  equity?: string;
+  liability?: string;
+  borrowingInitialMargin: string;
+}
+
+export interface AccountLike {
+  availableMargin: string;
+  assets: AssetLike[];
+}
+
+export interface RateLike {
+  coin: string;
+  exchangeType: string;
+  hourInterestRate: string;
+}
+
+export interface InterestRowLike {
+  liabilityCoin: string;
+  exchangeType: string;
+  interest: string;
+}
+
+export interface Bucket {
+  coin: string;
+  venue: string;
+  cash: number;
+  upnl: number;
+  equity: number;
+  borrow: number;
+  interestPaid30dUsd: number;
+  interestPerDayUsd: number;
+}
+
+export interface RouteQuote {
+  costUsd: number;
+  waitSeconds: number;
+  available: boolean;
+  reason: string | null;
+}
+
+export interface Plan {
+  amount: number;
+  deficit: number;
+  shortfall: { reason: 'cash' | 'margin'; remaining: number } | null;
+  routes: { loop: RouteQuote; convert: RouteQuote };
+  route: 'loop' | 'convert' | null;
+  savesPerDayUsd: number;
+  marginFreedUsd: number;
+}
+
+export interface PlanInputs {
+  usdcTransfer: { isDisabled: number; minTransAmount: number } | null;
+  spotRule: { state: string } | null;
+  spotTakerRate: number;
+  ask: number | null;
+}
+
+function num(s: string | undefined): number {
+  const n = Number(s);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function floorCents(value: number): number {
+  return Number(roundToStep(value, '0.01', 'down'));
+}
+
+export function bucketsFrom(account: AccountLike, rates: RateLike[], interestRows: InterestRowLike[]): Bucket[] {
+  return account.assets.map((asset) => {
+    const coin = asset.coin ?? '';
+    const venue = asset.exchangeType ?? '';
+    const equity = num(asset.equity);
+    const borrow = num(asset.liability);
+    const rate = rates.find((r) => r.coin === coin && r.exchangeType === venue);
+    const hourly = rate ? num(rate.hourInterestRate) : 0;
+    const interestPaid30dUsd = interestRows
+      .filter((r) => r.liabilityCoin === coin && r.exchangeType === venue)
+      .reduce((sum, r) => sum + num(r.interest), 0);
+    return {
+      coin,
+      venue,
+      cash: num(asset.balance),
+      upnl: num(asset.upnl),
+      equity,
+      borrow,
+      interestPaid30dUsd,
+      interestPerDayUsd: equity < INTEREST_THRESHOLD ? borrow * hourly * 24 : 0,
+    };
+  });
+}
+
+export function planFor(buckets: Bucket[], account: AccountLike, inputs: PlanInputs): Plan {
+  const deficitBucket = buckets.find((b) => b.coin === DEFICIT.coin && b.venue === DEFICIT.venue);
+  const surplusBucket = buckets.find((b) => b.coin === SURPLUS.coin && b.venue === SURPLUS.venue);
+  const deficit = Math.max(0, -(deficitBucket?.equity ?? 0));
+  const surplusCash = surplusBucket?.cash ?? 0;
+  const availableMargin = num(account.availableMargin);
+  const amount = Math.max(0, floorCents(Math.min(deficit, surplusCash, availableMargin)));
+
+  const shortfall: Plan['shortfall'] =
+    deficit === 0 || (deficit <= surplusCash && deficit <= availableMargin)
+      ? null
+      : { reason: surplusCash <= availableMargin ? 'cash' : 'margin', remaining: floorCents(deficit - amount) };
+
+  const convert: RouteQuote = {
+    costUsd: amount * CONVERT_RATE,
+    waitSeconds: 0,
+    available: amount > 0,
+    reason: amount > 0 ? null : 'nothing to move',
+  };
+
+  const ask = inputs.ask !== null && inputs.ask > 0 ? inputs.ask : null;
+  let loopReason: string | null = null;
+  if (!(amount > 0)) {
+    loopReason = 'nothing to move';
+  } else if (!inputs.usdcTransfer || inputs.usdcTransfer.isDisabled === 1) {
+    loopReason = 'USDC transfers are disabled on CrossEx';
+  } else if (!inputs.spotRule || inputs.spotRule.state !== 'live') {
+    loopReason = `${SPOT_SYMBOL} is not live`;
+  } else if (ask === null) {
+    loopReason = 'no spot price for USDC_USDT';
+  } else {
+    const bought = floorCents(amount / ask);
+    const min = inputs.usdcTransfer.minTransAmount;
+    if (bought < min) loopReason = `loop buys ${bought} USDC, below the ${min} USDC transfer minimum`;
+  }
+  const spread = ask === null ? 0 : Math.max(ask - 1, 0);
+  const loop: RouteQuote = {
+    costUsd: amount * spread + amount * inputs.spotTakerRate + DEPOSIT_FEE_USD,
+    waitSeconds: LOOP_WAIT_SECONDS,
+    available: loopReason === null,
+    reason: loopReason,
+  };
+
+  const route: Plan['route'] =
+    loop.available && convert.available
+      ? loop.costUsd < convert.costUsd
+        ? 'loop'
+        : 'convert'
+      : loop.available
+        ? 'loop'
+        : convert.available
+          ? 'convert'
+          : null;
+
+  const savesPerDayUsd =
+    deficitBucket && deficitBucket.borrow > 0 ? (deficitBucket.interestPerDayUsd * amount) / deficitBucket.borrow : 0;
+  const deficitAsset = account.assets.find((a) => a.coin === DEFICIT.coin && a.exchangeType === DEFICIT.venue);
+  const liability = num(deficitAsset?.liability);
+  const marginFreedUsd = liability > 0 ? (amount * num(deficitAsset?.borrowingInitialMargin)) / liability : 0;
+
+  return { amount, deficit, shortfall, routes: { loop, convert }, route, savesPerDayUsd, marginFreedUsd };
+}

--- a/src/core/rebalance/plan.ts
+++ b/src/core/rebalance/plan.ts
@@ -5,17 +5,23 @@ export const SURPLUS = { coin: 'USDT', venue: 'CROSSEX' } as const;
 export const SPOT_SYMBOL = 'GATE_SPOT_USDC_USDT';
 const INTEREST_THRESHOLD = -10000;
 export const LOOP_WAIT_SECONDS = 150;
+export const PULL_WAIT_SECONDS = 400;
 const CONVERT_RATE = 0.002;
 const DEPOSIT_FEE_USD = 0.05;
+export const PULL_FEE_USD = 1;
+
+export type Direction = 'payDown' | 'pull';
 
 export interface AssetLike {
   coin?: string;
   exchangeType?: string;
   balance?: string;
+  availableBalance?: string;
   upnl?: string;
   equity?: string;
   liability?: string;
   borrowingInitialMargin: string;
+  borrowingMaintenanceMargin: string;
 }
 
 export interface AccountLike {
@@ -42,6 +48,8 @@ export interface Bucket {
   upnl: number;
   equity: number;
   borrow: number;
+  imHeldUsd: number;
+  mmHeldUsd: number;
   interestPaid30dUsd: number;
   interestPerDayUsd: number;
 }
@@ -54,7 +62,11 @@ export interface RouteQuote {
 }
 
 export interface Plan {
+  direction: Direction;
   amount: number;
+  receives: number;
+  price: number | null;
+  borrowAfterUsd: number;
   shortfall: { reason: 'cash' | 'margin'; remaining: number } | null;
   routes: { loop: RouteQuote; convert: RouteQuote };
   route: 'loop' | 'convert' | null;
@@ -67,6 +79,12 @@ export interface PlanInputs {
   spotRule: { state: string } | null;
   spotTakerRate: number;
   ask: number | null;
+  bid: number | null;
+}
+
+export interface PlanRequest {
+  direction?: Direction;
+  requested?: number;
 }
 
 function num(s: string | undefined): number {
@@ -76,6 +94,10 @@ function num(s: string | undefined): number {
 
 function floorCents(value: number): number {
   return Number(roundToStep(value, '0.01', 'down'));
+}
+
+function positive(value: number | null): number | null {
+  return value !== null && value > 0 ? value : null;
 }
 
 export function bucketsFrom(account: AccountLike, rates: RateLike[], interestRows: InterestRowLike[]): Bucket[] {
@@ -96,19 +118,89 @@ export function bucketsFrom(account: AccountLike, rates: RateLike[], interestRow
       upnl: num(asset.upnl),
       equity,
       borrow,
+      imHeldUsd: num(asset.borrowingInitialMargin),
+      mmHeldUsd: num(asset.borrowingMaintenanceMargin),
       interestPaid30dUsd,
       interestPerDayUsd: equity < INTEREST_THRESHOLD ? borrow * hourly * 24 : 0,
     };
   });
 }
 
-export function planFor(buckets: Bucket[], account: AccountLike, inputs: PlanInputs): Plan {
-  const deficitBucket = buckets.find((b) => b.coin === DEFICIT.coin && b.venue === DEFICIT.venue);
+function loopQuote(
+  amount: number,
+  inputs: PlanInputs,
+  price: number | null,
+  spread: number,
+  feeUsd: number,
+  waitSeconds: number,
+  belowMinimum: (min: number) => string | null,
+): RouteQuote {
+  let reason: string | null = null;
+  if (!(amount > 0)) {
+    reason = 'nothing to move';
+  } else if (!inputs.usdcTransfer || inputs.usdcTransfer.isDisabled === 1) {
+    reason = 'USDC transfers are disabled on CrossEx';
+  } else if (!inputs.spotRule || inputs.spotRule.state !== 'live') {
+    reason = `${SPOT_SYMBOL} is not live`;
+  } else if (price === null) {
+    reason = 'no spot price for USDC_USDT';
+  } else {
+    reason = belowMinimum(inputs.usdcTransfer.minTransAmount);
+  }
+  return {
+    costUsd: amount * spread + amount * inputs.spotTakerRate + feeUsd,
+    waitSeconds,
+    available: reason === null,
+    reason,
+  };
+}
+
+export function planFor(
+  buckets: Bucket[],
+  account: AccountLike,
+  inputs: PlanInputs,
+  { direction = 'payDown', requested = Infinity }: PlanRequest = {},
+): Plan {
+  const usdcBucket = buckets.find((b) => b.coin === DEFICIT.coin && b.venue === DEFICIT.venue);
+  const deficit = Math.max(0, -(usdcBucket?.equity ?? 0));
+
+  if (direction === 'pull') {
+    const usdcAsset = (account.assets ?? []).find((a) => a.coin === DEFICIT.coin && a.exchangeType === DEFICIT.venue);
+    const equity = usdcBucket?.equity ?? 0;
+    const amount = equity > 0 ? Math.max(0, floorCents(Math.min(requested, num(usdcAsset?.availableBalance), equity))) : 0;
+    const bid = positive(inputs.bid);
+    const lands = Math.max(0, floorCents(amount - PULL_FEE_USD));
+    const loop = loopQuote(
+      amount,
+      inputs,
+      bid,
+      bid === null ? 0 : Math.max(1 - bid, 0),
+      PULL_FEE_USD,
+      PULL_WAIT_SECONDS,
+      (min) =>
+        lands < min ? `pull lands ${lands} USDC after the $${PULL_FEE_USD} fee, below the ${min} USDC transfer minimum` : null,
+    );
+    const convert: RouteQuote = { costUsd: 0, waitSeconds: 0, available: false, reason: 'convert runs one way only' };
+    const route: Plan['route'] = loop.available ? 'loop' : null;
+    const receives = route === 'loop' && bid !== null ? Math.max(0, floorCents(lands * bid * (1 - inputs.spotTakerRate))) : 0;
+    return {
+      direction,
+      amount,
+      receives,
+      price: route === 'loop' ? bid : null,
+      borrowAfterUsd: deficit,
+      shortfall: null,
+      routes: { loop, convert },
+      route,
+      savesPerDayUsd: 0,
+      marginFreedUsd: 0,
+    };
+  }
+
   const surplusBucket = buckets.find((b) => b.coin === SURPLUS.coin && b.venue === SURPLUS.venue);
-  const deficit = Math.max(0, -(deficitBucket?.equity ?? 0));
   const surplusCash = surplusBucket?.cash ?? 0;
   const availableMargin = num(account.availableMargin);
-  const amount = Math.max(0, floorCents(Math.min(deficit, surplusCash, availableMargin)));
+  const amount = Math.max(0, floorCents(Math.min(requested, deficit, surplusCash, availableMargin)));
 
   const shortfall: Plan['shortfall'] =
     deficit === 0 || (deficit <= surplusCash && deficit <= availableMargin)
@@ -122,28 +214,17 @@ export function planFor(buckets: Bucket[], account: AccountLike, inputs: PlanInp
     reason: amount > 0 ? null : 'nothing to move',
   };
 
-  const ask = inputs.ask !== null && inputs.ask > 0 ? inputs.ask : null;
-  let loopReason: string | null = null;
-  if (!(amount > 0)) {
-    loopReason = 'nothing to move';
-  } else if (!inputs.usdcTransfer || inputs.usdcTransfer.isDisabled === 1) {
-    loopReason = 'USDC transfers are disabled on CrossEx';
-  } else if (!inputs.spotRule || inputs.spotRule.state !== 'live') {
-    loopReason = `${SPOT_SYMBOL} is not live`;
-  } else if (ask === null) {
-    loopReason = 'no spot price for USDC_USDT';
-  } else {
-    const bought = floorCents(amount / ask);
-    const min = inputs.usdcTransfer.minTransAmount;
-    if (bought < min) loopReason = `loop buys ${bought} USDC, below the ${min} USDC transfer minimum`;
-  }
-  const spread = ask === null ? 0 : Math.max(ask - 1, 0);
-  const loop: RouteQuote = {
-    costUsd: amount * spread + amount * inputs.spotTakerRate + DEPOSIT_FEE_USD,
-    waitSeconds: LOOP_WAIT_SECONDS,
-    available: loopReason === null,
-    reason: loopReason,
-  };
+  const ask = positive(inputs.ask);
+  const bought = ask === null ? 0 : floorCents(amount / ask);
+  const loop = loopQuote(
+    amount,
+    inputs,
+    ask,
+    ask === null ? 0 : Math.max(ask - 1, 0),
+    DEPOSIT_FEE_USD,
+    LOOP_WAIT_SECONDS,
+    (min) => (bought < min ? `loop buys ${bought} USDC, below the ${min} USDC transfer minimum` : null),
+  );
 
   const route: Plan['route'] =
     loop.available && convert.available
@@ -156,11 +237,28 @@ export function planFor(buckets: Bucket[], account: AccountLike, inputs: PlanInp
           ? 'convert'
           : null;
 
-  const savesPerDayUsd =
-    deficitBucket && deficitBucket.borrow > 0 ? (deficitBucket.interestPerDayUsd * amount) / deficitBucket.borrow : 0;
-  const deficitAsset = (account.assets ?? []).find((a) => a.coin === DEFICIT.coin && a.exchangeType === DEFICIT.venue);
-  const liability = num(deficitAsset?.liability);
-  const marginFreedUsd = liability > 0 ? (amount * num(deficitAsset?.borrowingInitialMargin)) / liability : 0;
+  const receives =
+    route === 'loop'
+      ? Math.max(0, floorCents(bought - amount * inputs.spotTakerRate - DEPOSIT_FEE_USD))
+      : route === 'convert'
+        ? floorCents(amount * (1 - CONVERT_RATE))
+        : 0;
+  const price = route === 'loop' ? ask : route === 'convert' ? 1 - CONVERT_RATE : null;
 
-  return { amount, shortfall, routes: { loop, convert }, route, savesPerDayUsd, marginFreedUsd };
+  const savesPerDayUsd =
+    usdcBucket && usdcBucket.borrow > 0 ? (usdcBucket.interestPerDayUsd * amount) / usdcBucket.borrow : 0;
+  const marginFreedUsd = usdcBucket && usdcBucket.borrow > 0 ? (amount * usdcBucket.imHeldUsd) / usdcBucket.borrow : 0;
+
+  return {
+    direction,
+    amount,
+    receives,
+    price,
+    borrowAfterUsd: Math.max(0, deficit - receives),
+    shortfall,
+    routes: { loop, convert },
+    route,
+    savesPerDayUsd,
+    marginFreedUsd,
+  };
 }

--- a/src/core/rebalance/plan.ts
+++ b/src/core/rebalance/plan.ts
@@ -3,10 +3,10 @@ import { roundToStep } from '../numbers';
 export const DEFICIT = { coin: 'USDC', venue: 'HYPERLIQUID' } as const;
 export const SURPLUS = { coin: 'USDT', venue: 'CROSSEX' } as const;
 export const SPOT_SYMBOL = 'GATE_SPOT_USDC_USDT';
-export const INTEREST_THRESHOLD = -10000;
+const INTEREST_THRESHOLD = -10000;
 export const LOOP_WAIT_SECONDS = 150;
-export const CONVERT_RATE = 0.002;
-export const DEPOSIT_FEE_USD = 0.05;
+const CONVERT_RATE = 0.002;
+const DEPOSIT_FEE_USD = 0.05;
 
 export interface AssetLike {
   coin?: string;
@@ -20,7 +20,7 @@ export interface AssetLike {
 
 export interface AccountLike {
   availableMargin: string;
-  assets: AssetLike[];
+  assets?: AssetLike[];
 }
 
 export interface RateLike {
@@ -55,7 +55,6 @@ export interface RouteQuote {
 
 export interface Plan {
   amount: number;
-  deficit: number;
   shortfall: { reason: 'cash' | 'margin'; remaining: number } | null;
   routes: { loop: RouteQuote; convert: RouteQuote };
   route: 'loop' | 'convert' | null;
@@ -80,7 +79,7 @@ function floorCents(value: number): number {
 }
 
 export function bucketsFrom(account: AccountLike, rates: RateLike[], interestRows: InterestRowLike[]): Bucket[] {
-  return account.assets.map((asset) => {
+  return (account.assets ?? []).map((asset) => {
     const coin = asset.coin ?? '';
     const venue = asset.exchangeType ?? '';
     const equity = num(asset.equity);
@@ -159,9 +158,9 @@ export function planFor(buckets: Bucket[], account: AccountLike, inputs: PlanInp
 
   const savesPerDayUsd =
     deficitBucket && deficitBucket.borrow > 0 ? (deficitBucket.interestPerDayUsd * amount) / deficitBucket.borrow : 0;
-  const deficitAsset = account.assets.find((a) => a.coin === DEFICIT.coin && a.exchangeType === DEFICIT.venue);
+  const deficitAsset = (account.assets ?? []).find((a) => a.coin === DEFICIT.coin && a.exchangeType === DEFICIT.venue);
   const liability = num(deficitAsset?.liability);
   const marginFreedUsd = liability > 0 ? (amount * num(deficitAsset?.borrowingInitialMargin)) / liability : 0;
 
-  return { amount, deficit, shortfall, routes: { loop, convert }, route, savesPerDayUsd, marginFreedUsd };
+  return { amount, shortfall, routes: { loop, convert }, route, savesPerDayUsd, marginFreedUsd };
 }

--- a/src/core/rebalance/plan.ts
+++ b/src/core/rebalance/plan.ts
@@ -126,6 +126,21 @@ export function bucketsFrom(account: AccountLike, rates: RateLike[], interestRow
   });
 }
 
+function convertQuote(amount: number): RouteQuote {
+  return {
+    costUsd: amount * CONVERT_RATE,
+    waitSeconds: 0,
+    available: amount > 0,
+    reason: amount > 0 ? null : 'nothing to move',
+  };
+}
+
+function pickRoute(loop: RouteQuote, convert: RouteQuote): Plan['route'] {
+  if (loop.available && convert.available) return loop.costUsd < convert.costUsd ? 'loop' : 'convert';
+  if (loop.available) return 'loop';
+  return convert.available ? 'convert' : null;
+}
+
 function loopQuote(
   amount: number,
   inputs: PlanInputs,
@@ -182,14 +197,19 @@ export function planFor(
           ? `Too small to pull. Gate takes a flat $${PULL_FEE_USD} fee on the way out and needs at least ${min} USDC to arrive. Pull at least ${min + PULL_FEE_USD} USDC.`
           : null,
     );
-    const convert: RouteQuote = { costUsd: 0, waitSeconds: 0, available: false, reason: 'Convert runs only from USDT to USDC.' };
-    const route: Plan['route'] = loop.available ? 'loop' : null;
-    const receives = route === 'loop' && bid !== null ? Math.max(0, floorCents(lands * bid * (1 - inputs.spotTakerRate))) : 0;
+    const convert = convertQuote(amount);
+    const route = pickRoute(loop, convert);
+    const receives =
+      route === 'loop' && bid !== null
+        ? Math.max(0, floorCents(lands * bid * (1 - inputs.spotTakerRate)))
+        : route === 'convert'
+          ? floorCents(amount * (1 - CONVERT_RATE))
+          : 0;
     return {
       direction,
       amount,
       receives,
-      price: route === 'loop' ? bid : null,
+      price: route === 'loop' ? bid : route === 'convert' ? 1 - CONVERT_RATE : null,
       borrowAfterUsd: deficit,
       shortfall: null,
       routes: { loop, convert },
@@ -209,12 +229,7 @@ export function planFor(
       ? null
       : { reason: surplusCash <= availableMargin ? 'cash' : 'margin', remaining: floorCents(deficit - amount) };
 
-  const convert: RouteQuote = {
-    costUsd: amount * CONVERT_RATE,
-    waitSeconds: 0,
-    available: amount > 0,
-    reason: amount > 0 ? null : 'nothing to move',
-  };
+  const convert = convertQuote(amount);
 
   const ask = positive(inputs.ask);
   const bought = ask === null ? 0 : floorCents(amount / ask);
@@ -228,16 +243,7 @@ export function planFor(
     (min) => (bought < min ? `Too small for the spot loop. Gate needs at least ${min} USDC per transfer.` : null),
   );
 
-  const route: Plan['route'] =
-    loop.available && convert.available
-      ? loop.costUsd < convert.costUsd
-        ? 'loop'
-        : 'convert'
-      : loop.available
-        ? 'loop'
-        : convert.available
-          ? 'convert'
-          : null;
+  const route = pickRoute(loop, convert);
 
   const receives =
     route === 'loop'

--- a/src/core/rebalance/plan.ts
+++ b/src/core/rebalance/plan.ts
@@ -139,11 +139,11 @@ function loopQuote(
   if (!(amount > 0)) {
     reason = 'nothing to move';
   } else if (!inputs.usdcTransfer || inputs.usdcTransfer.isDisabled === 1) {
-    reason = 'USDC transfers are disabled on CrossEx';
+    reason = 'Gate has paused USDC transfers on CrossEx. Try again later.';
   } else if (!inputs.spotRule || inputs.spotRule.state !== 'live') {
-    reason = `${SPOT_SYMBOL} is not live`;
+    reason = 'The USDC/USDT spot market on Gate is not trading right now.';
   } else if (price === null) {
-    reason = 'no spot price for USDC_USDT';
+    reason = 'No price for USDC/USDT on Gate spot right now.';
   } else {
     reason = belowMinimum(inputs.usdcTransfer.minTransAmount);
   }
@@ -178,9 +178,11 @@ export function planFor(
       PULL_FEE_USD,
       PULL_WAIT_SECONDS,
       (min) =>
-        lands < min ? `pull lands ${lands} USDC after the $${PULL_FEE_USD} fee, below the ${min} USDC transfer minimum` : null,
+        lands < min
+          ? `Too small to pull. Gate takes a flat $${PULL_FEE_USD} fee on the way out and needs at least ${min} USDC to arrive. Pull at least ${min + PULL_FEE_USD} USDC.`
+          : null,
     );
-    const convert: RouteQuote = { costUsd: 0, waitSeconds: 0, available: false, reason: 'convert runs one way only' };
+    const convert: RouteQuote = { costUsd: 0, waitSeconds: 0, available: false, reason: 'Convert runs only from USDT to USDC.' };
     const route: Plan['route'] = loop.available ? 'loop' : null;
     const receives = route === 'loop' && bid !== null ? Math.max(0, floorCents(lands * bid * (1 - inputs.spotTakerRate))) : 0;
     return {
@@ -223,7 +225,7 @@ export function planFor(
     ask === null ? 0 : Math.max(ask - 1, 0),
     DEPOSIT_FEE_USD,
     LOOP_WAIT_SECONDS,
-    (min) => (bought < min ? `loop buys ${bought} USDC, below the ${min} USDC transfer minimum` : null),
+    (min) => (bought < min ? `Too small for the spot loop. Gate needs at least ${min} USDC per transfer.` : null),
   );
 
   const route: Plan['route'] =

--- a/src/engine/loop.ts
+++ b/src/engine/loop.ts
@@ -45,7 +45,7 @@ export interface LoopDeps {
 const OPENISH = /^(NEW|OPEN|LIVE|PENDING|ACTIVE|CREATED|ACCEPTED|PARTIAL(LY)?[-_ ]?FILL(ED)?)$/i;
 const CLOSEDISH = /^(FILLED|FINISHED|CLOSED|DONE|CANCELL?ED|EXPIRED|REJECT(ED)?|FAIL(ED)?|IOC_?CANCELL?ED)$/i;
 
-function decodeStatus(raw: string): 'open' | 'closed' | 'unknown' {
+export function decodeStatus(raw: string): 'open' | 'closed' | 'unknown' {
   const s = raw.trim();
   if (CLOSEDISH.test(s)) return 'closed';
   if (OPENISH.test(s)) return 'open';

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -12,6 +12,7 @@ import { classifyGateError, CoreError, type ClassifiedError } from '../core/erro
 import type { Store } from '../engine/db';
 import type { Clock, VenuePort } from '../engine/types';
 import type { TtlCache } from './cache';
+import type { JobFile } from './rebalanceJob';
 import { accountRoutes } from './routes/account';
 import { booksRoutes } from './routes/books';
 import { credentialsRoutes } from './routes/credentials';
@@ -88,7 +89,7 @@ export interface AppDeps {
    * copy's version from <repoRoot>/version.json — null means "unknown", which
    * disables the remote read entirely — plus the UPDATE_CHECK=0 opt-out. */
   updateCheck?: { current: string | null; disabled?: boolean };
-  rebalance?: { dataDir: string; sleep?: (ms: number) => Promise<void> };
+  rebalance?: { jobs: JobFile; sleep?: (ms: number) => Promise<void> };
 }
 
 declare module 'fastify' {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -26,6 +26,7 @@ import { opportunitiesRoutes } from './routes/opportunities';
 import { ordersRoutes } from './routes/orders';
 import { positionsRoutes } from './routes/positions';
 import { previewRoutes } from './routes/preview';
+import { rebalanceRoutes } from './routes/rebalance';
 import { strategyRoutes } from './routes/strategy';
 import { symbolsRoutes } from './routes/symbols';
 import { shareLinkRoutes } from './routes/shareLink';
@@ -87,6 +88,7 @@ export interface AppDeps {
    * copy's version from <repoRoot>/version.json — null means "unknown", which
    * disables the remote read entirely — plus the UPDATE_CHECK=0 opt-out. */
   updateCheck?: { current: string | null; disabled?: boolean };
+  rebalance?: { dataDir: string; sleep?: (ms: number) => Promise<void> };
 }
 
 declare module 'fastify' {
@@ -230,6 +232,7 @@ export function buildApp(deps: AppDeps): FastifyInstance {
     leverageRoutes,
     previewRoutes,
     dealsRoutes,
+    rebalanceRoutes,
     versionRoutes,
     shareLinkRoutes,
   ];

--- a/src/server/cache.ts
+++ b/src/server/cache.ts
@@ -117,8 +117,10 @@ export class TtlCache {
       entry.value = value;
       entry.has = true;
       entry.expiresAt = Date.now() + ttlMs;
-      this.touch(key, entry);
-      this.evictIfNeeded();
+      if (this.entries.get(key) === entry) {
+        this.touch(key, entry);
+        this.evictIfNeeded();
+      }
       return { value, stale: false };
     } catch (err) {
       if (classifyGateError(err).category === 'rate-limited') {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -20,6 +20,7 @@ import { makeBorosApiOrderClient, USD_TOKEN_ID } from '../core/boros/borosApi';
 import type { BorosOrderClient } from '../core/boros/orders';
 import { TtlCache, TTL } from './cache';
 import { readOrCreateApiToken } from './authToken';
+import { JobFile } from './rebalanceJob';
 import { tokenizedIndexHtml } from './spa';
 import { restrictToOwner } from './secretFile';
 import { readInstallInfo, readLocalVersion } from './version';
@@ -168,7 +169,7 @@ const appDeps = {
   // UPDATE_CHECK=0 lets an install opt out of the GitHub read entirely.
   install: readInstallInfo(repoRoot),
   updateCheck: { current: readLocalVersion(repoRoot), disabled: process.env.UPDATE_CHECK === '0' },
-  rebalance: { dataDir },
+  rebalance: { jobs: new JobFile(dataDir) },
   getBorosOrders: () => borosOrdersRef.current,
   borosAgent: {
     envPath,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -168,6 +168,7 @@ const appDeps = {
   // UPDATE_CHECK=0 lets an install opt out of the GitHub read entirely.
   install: readInstallInfo(repoRoot),
   updateCheck: { current: readLocalVersion(repoRoot), disabled: process.env.UPDATE_CHECK === '0' },
+  rebalance: { dataDir },
   getBorosOrders: () => borosOrdersRef.current,
   borosAgent: {
     envPath,

--- a/src/server/rebalanceJob.ts
+++ b/src/server/rebalanceJob.ts
@@ -46,7 +46,7 @@ const JOB_STATUSES: readonly string[] = ['running', 'halted', 'done', 'abandoned
 const FUNDS_AT: readonly string[] = ['CROSSEX', 'GATE', 'SPOT', 'HYPERLIQUID'];
 
 export function newJob(direction: Direction, route: RouteName, amount: number, now: number): Job {
-  const names: readonly string[] = direction === 'pull' ? PULL_STEPS : route === 'loop' ? LOOP_STEPS : CONVERT_STEPS;
+  const names: readonly string[] = route === 'convert' ? CONVERT_STEPS : direction === 'pull' ? PULL_STEPS : LOOP_STEPS;
   return {
     id: now.toString(36),
     direction,

--- a/src/server/rebalanceJob.ts
+++ b/src/server/rebalanceJob.ts
@@ -1,7 +1,9 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import type { Direction } from '../core/rebalance/plan';
 import { restrictToOwner } from './secretFile';
 
+export type { Direction };
 export type JobStatus = 'running' | 'halted' | 'done' | 'abandoned';
 export type StepStatus = 'pending' | 'running' | 'done';
 export type FundsAt = 'CROSSEX' | 'GATE' | 'SPOT' | 'HYPERLIQUID';
@@ -22,6 +24,7 @@ export interface Step {
 
 export interface Job {
   id: string;
+  direction: Direction;
   route: RouteName;
   amount: number;
   status: JobStatus;
@@ -35,15 +38,18 @@ export interface Job {
 
 export const LOOP_STEPS = ['Buy USDC', 'To spot', 'To Hyperliquid'] as const;
 export const CONVERT_STEPS = ['Convert'] as const;
-export const STEP_NAMES: readonly string[] = [...LOOP_STEPS, ...CONVERT_STEPS];
+export const PULL_STEPS = ['Pull from Hyperliquid', 'To Gate', 'Sell USDC'] as const;
+export type StepName = (typeof LOOP_STEPS)[number] | (typeof CONVERT_STEPS)[number] | (typeof PULL_STEPS)[number];
+export const STEP_NAMES: readonly string[] = [...LOOP_STEPS, ...CONVERT_STEPS, ...PULL_STEPS];
 
 const JOB_STATUSES: readonly string[] = ['running', 'halted', 'done', 'abandoned'];
 const FUNDS_AT: readonly string[] = ['CROSSEX', 'GATE', 'SPOT', 'HYPERLIQUID'];
 
-export function newJob(route: RouteName, amount: number, now: number): Job {
-  const names: readonly string[] = route === 'loop' ? LOOP_STEPS : CONVERT_STEPS;
+export function newJob(direction: Direction, route: RouteName, amount: number, now: number): Job {
+  const names: readonly string[] = direction === 'pull' ? PULL_STEPS : route === 'loop' ? LOOP_STEPS : CONVERT_STEPS;
   return {
     id: now.toString(36),
+    direction,
     route,
     amount,
     status: 'running',
@@ -60,7 +66,7 @@ export function newJob(route: RouteName, amount: number, now: number): Job {
       startedAt: null,
       doneAt: null,
     })),
-    fundsAt: 'CROSSEX',
+    fundsAt: direction === 'pull' ? 'HYPERLIQUID' : 'CROSSEX',
     haltReason: null,
     createdAt: now,
     updatedAt: now,
@@ -72,15 +78,18 @@ export function haltMessage(job: Job): string {
   return `rebalance ${job.id} halted at ${step.name}: ${job.haltReason}. Funds are in ${job.fundsAt}.`;
 }
 
-function isJob(value: unknown): value is Job {
+function parseJob(value: unknown): Job | null {
   const job = value as Partial<Job> | null;
-  if (typeof job !== 'object' || job === null) return false;
-  if (!JOB_STATUSES.includes(String(job.status))) return false;
-  if (!Array.isArray(job.steps) || job.steps.length === 0) return false;
+  if (typeof job !== 'object' || job === null) return null;
+  if (job.direction === undefined) job.direction = 'payDown';
+  if (job.direction !== 'payDown' && job.direction !== 'pull') return null;
+  if (!JOB_STATUSES.includes(String(job.status))) return null;
+  if (!Array.isArray(job.steps) || job.steps.length === 0) return null;
   const index = job.stepIndex;
-  if (!Number.isInteger(index) || (index as number) < 0 || (index as number) >= job.steps.length) return false;
-  if (!job.steps.every((step) => STEP_NAMES.includes(String((step as Partial<Step> | null)?.name)))) return false;
-  return FUNDS_AT.includes(String(job.fundsAt));
+  if (!Number.isInteger(index) || (index as number) < 0 || (index as number) >= job.steps.length) return null;
+  if (!job.steps.every((step) => STEP_NAMES.includes(String((step as Partial<Step> | null)?.name)))) return null;
+  if (!FUNDS_AT.includes(String(job.fundsAt))) return null;
+  return job as Job;
 }
 
 export class JobFile {
@@ -99,8 +108,7 @@ export class JobFile {
     this.job = null;
     if (!fs.existsSync(this.file)) return null;
     try {
-      const parsed: unknown = JSON.parse(fs.readFileSync(this.file, 'utf8'));
-      if (isJob(parsed)) this.job = parsed;
+      this.job = parseJob(JSON.parse(fs.readFileSync(this.file, 'utf8')));
     } catch {}
     if (this.job === null) console.error(`rebalance.json at ${this.file} is unreadable; treating as no job`);
     return this.job;

--- a/src/server/rebalanceJob.ts
+++ b/src/server/rebalanceJob.ts
@@ -1,0 +1,100 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { restrictToOwner } from './secretFile';
+
+export type JobStatus = 'running' | 'halted' | 'done' | 'abandoned';
+export type StepStatus = 'pending' | 'running' | 'done';
+export type FundsAt = 'CROSSEX' | 'GATE' | 'SPOT' | 'HYPERLIQUID';
+export type RouteName = 'loop' | 'convert';
+
+export interface Step {
+  name: string;
+  text: string | null;
+  quoteId: string | null;
+  venueId: string | null;
+  qty: number | null;
+  balanceBefore: number | null;
+  status: StepStatus;
+  startedAt: number | null;
+  doneAt: number | null;
+}
+
+export interface Job {
+  id: string;
+  route: RouteName;
+  amount: number;
+  status: JobStatus;
+  stepIndex: number;
+  steps: Step[];
+  fundsAt: FundsAt;
+  haltReason: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export const LOOP_STEPS = ['Buy USDC', 'To spot', 'To Hyperliquid'] as const;
+export const CONVERT_STEPS = ['Convert'] as const;
+
+export function newJob(route: RouteName, amount: number, now: number): Job {
+  const names: readonly string[] = route === 'loop' ? LOOP_STEPS : CONVERT_STEPS;
+  return {
+    id: now.toString(36),
+    route,
+    amount,
+    status: 'running',
+    stepIndex: 0,
+    steps: names.map((name) => ({
+      name,
+      text: null,
+      quoteId: null,
+      venueId: null,
+      qty: null,
+      balanceBefore: null,
+      status: 'pending',
+      startedAt: null,
+      doneAt: null,
+    })),
+    fundsAt: 'CROSSEX',
+    haltReason: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export class JobFile {
+  private readonly file: string;
+  private job: Job | null | undefined;
+
+  constructor(dataDir: string) {
+    this.file = path.join(dataDir, 'rebalance.json');
+  }
+
+  read(): Job | null {
+    if (this.job === undefined) {
+      try {
+        this.job = JSON.parse(fs.readFileSync(this.file, 'utf8')) as Job;
+      } catch {
+        this.job = null;
+      }
+    }
+    return this.job;
+  }
+
+  write(job: Job): void {
+    job.updatedAt = Date.now();
+    fs.mkdirSync(path.dirname(this.file), { recursive: true, mode: 0o700 });
+    const tmp = `${this.file}.tmp-${process.pid}`;
+    fs.writeFileSync(tmp, JSON.stringify(job, null, 2), { mode: 0o600 });
+    fs.renameSync(tmp, this.file);
+    restrictToOwner(this.file);
+    this.job = job;
+  }
+
+  haltIfRunning(reason: string): void {
+    const job = this.read();
+    if (job?.status !== 'running') return;
+    job.status = 'halted';
+    job.haltReason = reason;
+    this.write(job);
+  }
+}

--- a/src/server/rebalanceJob.ts
+++ b/src/server/rebalanceJob.ts
@@ -14,6 +14,7 @@ export interface Step {
   venueId: string | null;
   qty: number | null;
   balanceBefore: number | null;
+  attempt: number;
   status: StepStatus;
   startedAt: number | null;
   doneAt: number | null;
@@ -34,6 +35,10 @@ export interface Job {
 
 export const LOOP_STEPS = ['Buy USDC', 'To spot', 'To Hyperliquid'] as const;
 export const CONVERT_STEPS = ['Convert'] as const;
+export const STEP_NAMES: readonly string[] = [...LOOP_STEPS, ...CONVERT_STEPS];
+
+const JOB_STATUSES: readonly string[] = ['running', 'halted', 'done', 'abandoned'];
+const FUNDS_AT: readonly string[] = ['CROSSEX', 'GATE', 'SPOT', 'HYPERLIQUID'];
 
 export function newJob(route: RouteName, amount: number, now: number): Job {
   const names: readonly string[] = route === 'loop' ? LOOP_STEPS : CONVERT_STEPS;
@@ -50,6 +55,7 @@ export function newJob(route: RouteName, amount: number, now: number): Job {
       venueId: null,
       qty: null,
       balanceBefore: null,
+      attempt: 0,
       status: 'pending',
       startedAt: null,
       doneAt: null,
@@ -61,27 +67,47 @@ export function newJob(route: RouteName, amount: number, now: number): Job {
   };
 }
 
+export function haltMessage(job: Job): string {
+  const step = job.steps[job.stepIndex];
+  return `rebalance ${job.id} halted at ${step.name}: ${job.haltReason}. Funds are in ${job.fundsAt}.`;
+}
+
+function isJob(value: unknown): value is Job {
+  const job = value as Partial<Job> | null;
+  if (typeof job !== 'object' || job === null) return false;
+  if (!JOB_STATUSES.includes(String(job.status))) return false;
+  if (!Array.isArray(job.steps) || job.steps.length === 0) return false;
+  const index = job.stepIndex;
+  if (!Number.isInteger(index) || (index as number) < 0 || (index as number) >= job.steps.length) return false;
+  if (!job.steps.every((step) => STEP_NAMES.includes(String((step as Partial<Step> | null)?.name)))) return false;
+  return FUNDS_AT.includes(String(job.fundsAt));
+}
+
 export class JobFile {
   private readonly file: string;
   private job: Job | null | undefined;
 
-  constructor(dataDir: string) {
+  constructor(
+    dataDir: string,
+    private readonly now: () => number = Date.now,
+  ) {
     this.file = path.join(dataDir, 'rebalance.json');
   }
 
   read(): Job | null {
-    if (this.job === undefined) {
-      try {
-        this.job = JSON.parse(fs.readFileSync(this.file, 'utf8')) as Job;
-      } catch {
-        this.job = null;
-      }
-    }
+    if (this.job !== undefined) return this.job;
+    this.job = null;
+    if (!fs.existsSync(this.file)) return null;
+    try {
+      const parsed: unknown = JSON.parse(fs.readFileSync(this.file, 'utf8'));
+      if (isJob(parsed)) this.job = parsed;
+    } catch {}
+    if (this.job === null) console.error(`rebalance.json at ${this.file} is unreadable; treating as no job`);
     return this.job;
   }
 
   write(job: Job): void {
-    job.updatedAt = Date.now();
+    job.updatedAt = this.now();
     fs.mkdirSync(path.dirname(this.file), { recursive: true, mode: 0o700 });
     const tmp = `${this.file}.tmp-${process.pid}`;
     fs.writeFileSync(tmp, JSON.stringify(job, null, 2), { mode: 0o600 });
@@ -90,11 +116,12 @@ export class JobFile {
     this.job = job;
   }
 
-  haltIfRunning(reason: string): void {
+  haltIfRunning(reason: string): boolean {
     const job = this.read();
-    if (job?.status !== 'running') return;
+    if (job?.status !== 'running') return false;
     job.status = 'halted';
     job.haltReason = reason;
     this.write(job);
+    return true;
   }
 }

--- a/src/server/rebalanceRunner.ts
+++ b/src/server/rebalanceRunner.ts
@@ -3,8 +3,9 @@ import type { Clients } from '../core/clients';
 import { classifyGateError } from '../core/errors';
 import { roundToStep } from '../core/numbers';
 import { SPOT_SYMBOL } from '../core/rebalance/plan';
+import { decodeStatus } from '../engine/loop';
 import type { TtlCache } from './cache';
-import type { FundsAt, JobFile, Step } from './rebalanceJob';
+import { haltMessage, STEP_NAMES, type FundsAt, type JobFile, type Step } from './rebalanceJob';
 
 export interface RunnerDeps {
   clients: () => Clients;
@@ -12,6 +13,7 @@ export interface RunnerDeps {
   cache: TtlCache;
   now: () => number;
   sleep: (ms: number) => Promise<void>;
+  log: (message: string) => void;
 }
 
 export const STEP_TIMEOUT_MS = 600_000;
@@ -20,11 +22,11 @@ export const LOOKUP_RETRY_MS = 10_000;
 export const QUOTE_FLOOR = 0.997;
 export const TRANSFER_STEP = '0.00001';
 
-const OPEN_STATE = /OPEN|NEW|PENDING|PARTIAL/i;
 const NOT_FOUND = /NOT_FOUND/i;
+const TRANSFER_DEAD = /FAIL|CANCEL|REJECT|EXPIRE/i;
 
-export function tagFor(jobId: string, stepIndex: number): string {
-  return `t-rb${jobId}${stepIndex}`;
+export function tagFor(jobId: string, stepIndex: number, attempt = 0): string {
+  return attempt > 0 ? `t-rb${jobId}${stepIndex}x${attempt}` : `t-rb${jobId}${stepIndex}`;
 }
 
 export async function runJob(deps: RunnerDeps): Promise<void> {
@@ -36,6 +38,14 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
     job.status = 'halted';
     job.haltReason = reason;
     deps.jobs.write(job);
+    deps.log(haltMessage(job));
+  };
+
+  const haltDead = (step: Step, reason: string): void => {
+    step.venueId = null;
+    step.text = null;
+    step.attempt += 1;
+    halt(reason);
   };
 
   const finish = (step: Step, qty: number, fundsAt: FundsAt): void => {
@@ -58,26 +68,41 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
   const transferRow = async (
     match: (row: CrossexTransferRecord) => boolean,
   ): Promise<CrossexTransferRecord | null> => {
-    const { body } = await crossEx().listCrossexTransfers({ coin: 'USDC', limit: 20 });
+    const { body } = await crossEx().listCrossexTransfers({ coin: 'USDC', limit: 100 });
     return (body ?? []).find(match) ?? null;
+  };
+
+  const convertLanded = async (step: Step): Promise<boolean> => {
+    const balance = await usdcOnHyperliquid();
+    if (step.balanceBefore === null || step.qty === null || balance - step.balanceBefore < step.qty - 0.01) {
+      return false;
+    }
+    finish(step, step.qty, 'HYPERLIQUID');
+    return true;
   };
 
   const poll = async (step: Step, venueId: string): Promise<void> => {
     if (step.name === 'Buy USDC') {
       const { body } = await crossEx().getCrossexOrder(venueId);
       const state = String(body.state ?? '');
-      if (OPEN_STATE.test(state)) return;
-      const filled = Number(body.executedQty ?? 0);
+      if (decodeStatus(state) !== 'closed') return;
+      const fee = String(body.feeCoin ?? '') === 'USDC' ? Number(body.fee ?? 0) : 0;
+      const filled = Number(body.executedQty ?? 0) - (Number.isFinite(fee) ? fee : 0);
       if (filled > 0) finish(step, filled, 'GATE');
-      else halt(`order ${state} with nothing filled`);
-      return;
-    }
-    const row = await transferRow((r) => r.id === venueId);
-    if (!row) return;
-    if (row.status === 'SUCCESS') {
-      finish(step, Number(row.actualReceive ?? row.amount), step.name === 'To spot' ? 'SPOT' : 'HYPERLIQUID');
-    } else if (row.status === 'FAILED') {
-      halt(row.failReason || 'transfer FAILED');
+      else haltDead(step, `order ${state} with nothing filled`);
+    } else if (step.name === 'Convert') {
+      await convertLanded(step);
+    } else {
+      const row = await transferRow((r) => r.id === venueId);
+      if (!row) return;
+      const status = String(row.status ?? '');
+      if (status === 'SUCCESS') {
+        const received = Number(row.actualReceive ?? row.amount);
+        if (received > 0) finish(step, received, step.name === 'To spot' ? 'SPOT' : 'HYPERLIQUID');
+        else halt('transfer SUCCESS with nothing received');
+      } else if (TRANSFER_DEAD.test(status)) {
+        haltDead(step, row.failReason || `transfer ${status}`);
+      }
     }
   };
 
@@ -96,24 +121,17 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
     }
   };
 
-  const convertLanded = async (step: Step): Promise<boolean> => {
-    const balance = await usdcOnHyperliquid();
-    if (step.balanceBefore === null || step.qty === null || balance - step.balanceBefore < step.qty - 0.01) {
-      return false;
-    }
-    finish(step, step.qty, 'HYPERLIQUID');
-    return true;
-  };
-
   const transfer = async (from: string, to: string, tag: string): Promise<string> => {
     const amount = job.steps[job.stepIndex - 1].qty ?? 0;
     const { body } = await crossEx().createCrossexTransfer({
       crossexTransferRequest: { coin: 'USDC', amount: roundToStep(amount, TRANSFER_STEP, 'down'), from, to, text: tag },
     });
+    if (!body.txId) throw new Error('transfer response has no txId');
     return String(body.txId);
   };
 
   const sendConvert = async (step: Step): Promise<void> => {
+    if (step.balanceBefore === null) step.balanceBefore = await usdcOnHyperliquid();
     const { body: quote } = await crossEx().createCrossexConvertQuote({
       crossexConvertQuoteRequest: {
         exchangeType: 'HYPERLIQUID',
@@ -127,14 +145,13 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
       halt('quote worse than 30 bps');
       return;
     }
-    const balanceBefore = await usdcOnHyperliquid();
     step.quoteId = String(quote.quoteId);
     step.qty = toAmount;
-    step.balanceBefore = balanceBefore;
     deps.jobs.write(job);
     const { body } = await crossEx().createCrossexConvertOrder({
       crossexConvertOrderRequest: { quoteId: step.quoteId },
     });
+    if (!body.orderId) throw new Error('convert order response has no orderId');
     step.venueId = String(body.orderId);
     finish(step, toAmount, 'HYPERLIQUID');
   };
@@ -151,10 +168,11 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
           text: tag,
         },
       });
+      if (!body.orderId) throw new Error('order response has no orderId');
       step.venueId = String(body.orderId);
     } else if (step.name === 'To spot') {
       step.venueId = await transfer('CROSSEX_GATE', 'SPOT', tag);
-    } else {
+    } else if (step.name === 'To Hyperliquid') {
       step.venueId = await transfer('SPOT', 'CROSSEX_HYPERLIQUID', tag);
     }
     deps.jobs.write(job);
@@ -163,6 +181,10 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
   try {
     while (job.status === 'running') {
       const step = job.steps[job.stepIndex];
+      if (!STEP_NAMES.includes(step.name)) {
+        halt(`unknown step ${step.name}`);
+        return;
+      }
       if (step.startedAt === null) {
         step.startedAt = deps.now();
         step.status = 'running';
@@ -180,11 +202,18 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
           continue;
         }
         if (step.text === null) {
-          step.text = tagFor(job.id, job.stepIndex);
+          step.text = tagFor(job.id, job.stepIndex, step.attempt);
           deps.jobs.write(job);
         } else if (step.name === 'Convert') {
           phase = 'lookup';
-          if (step.quoteId !== null && (await convertLanded(step))) continue;
+          if (step.quoteId !== null) {
+            let landed = await convertLanded(step);
+            if (!landed) {
+              await deps.sleep(LOOKUP_RETRY_MS);
+              landed = await convertLanded(step);
+            }
+            if (landed) continue;
+          }
         } else {
           phase = 'lookup';
           let found = await lookup(step, step.text);
@@ -202,7 +231,8 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
         await send(step, step.text);
       } catch (err) {
         const c = classifyGateError(err);
-        if (c.retryable) {
+        const notFound = c.httpStatus === 404 || NOT_FOUND.test(c.label ?? '');
+        if (c.retryable || (phase === 'poll' && notFound)) {
           await deps.sleep(POLL_MS);
         } else if (phase !== 'send') {
           halt(c.message);
@@ -218,8 +248,7 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
     job.haltReason = classifyGateError(err).message;
     try {
       deps.jobs.write(job);
-    } catch {
-      return;
-    }
+    } catch {}
+    deps.log(haltMessage(job));
   }
 }

--- a/src/server/rebalanceRunner.ts
+++ b/src/server/rebalanceRunner.ts
@@ -1,0 +1,225 @@
+import { CrossexOrderRequest, type CrossexTransferRecord } from 'gate-api';
+import type { Clients } from '../core/clients';
+import { classifyGateError } from '../core/errors';
+import { roundToStep } from '../core/numbers';
+import { SPOT_SYMBOL } from '../core/rebalance/plan';
+import type { TtlCache } from './cache';
+import type { FundsAt, JobFile, Step } from './rebalanceJob';
+
+export interface RunnerDeps {
+  clients: () => Clients;
+  jobs: JobFile;
+  cache: TtlCache;
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+}
+
+export const STEP_TIMEOUT_MS = 600_000;
+export const POLL_MS = 1_000;
+export const LOOKUP_RETRY_MS = 10_000;
+export const QUOTE_FLOOR = 0.997;
+export const TRANSFER_STEP = '0.00001';
+
+const OPEN_STATE = /OPEN|NEW|PENDING|PARTIAL/i;
+const NOT_FOUND = /NOT_FOUND/i;
+
+export function tagFor(jobId: string, stepIndex: number): string {
+  return `t-rb${jobId}${stepIndex}`;
+}
+
+export async function runJob(deps: RunnerDeps): Promise<void> {
+  const job = deps.jobs.read();
+  if (!job) return;
+  const crossEx = () => deps.clients().crossEx;
+
+  const halt = (reason: string): void => {
+    job.status = 'halted';
+    job.haltReason = reason;
+    deps.jobs.write(job);
+  };
+
+  const finish = (step: Step, qty: number, fundsAt: FundsAt): void => {
+    step.qty = qty;
+    step.status = 'done';
+    step.doneAt = deps.now();
+    job.fundsAt = fundsAt;
+    if (fundsAt === 'HYPERLIQUID') deps.cache.bust('account');
+    if (job.stepIndex === job.steps.length - 1) job.status = 'done';
+    else job.stepIndex += 1;
+    deps.jobs.write(job);
+  };
+
+  const usdcOnHyperliquid = async (): Promise<number> => {
+    const { body } = await crossEx().getCrossexAccount();
+    const asset = body.assets?.find((a) => a.coin === 'USDC' && a.exchangeType === 'HYPERLIQUID');
+    return Number(asset?.balance ?? 0);
+  };
+
+  const transferRow = async (
+    match: (row: CrossexTransferRecord) => boolean,
+  ): Promise<CrossexTransferRecord | null> => {
+    const { body } = await crossEx().listCrossexTransfers({ coin: 'USDC', limit: 20 });
+    return (body ?? []).find(match) ?? null;
+  };
+
+  const poll = async (step: Step, venueId: string): Promise<void> => {
+    if (step.name === 'Buy USDC') {
+      const { body } = await crossEx().getCrossexOrder(venueId);
+      const state = String(body.state ?? '');
+      if (OPEN_STATE.test(state)) return;
+      const filled = Number(body.executedQty ?? 0);
+      if (filled > 0) finish(step, filled, 'GATE');
+      else halt(`order ${state} with nothing filled`);
+      return;
+    }
+    const row = await transferRow((r) => r.id === venueId);
+    if (!row) return;
+    if (row.status === 'SUCCESS') {
+      finish(step, Number(row.actualReceive ?? row.amount), step.name === 'To spot' ? 'SPOT' : 'HYPERLIQUID');
+    } else if (row.status === 'FAILED') {
+      halt(row.failReason || 'transfer FAILED');
+    }
+  };
+
+  const lookup = async (step: Step, tag: string): Promise<string | null> => {
+    if (step.name !== 'Buy USDC') {
+      const row = await transferRow((r) => r.text === tag);
+      return row ? row.id : null;
+    }
+    try {
+      const { body } = await crossEx().getCrossexOrder(tag);
+      return body.orderId ? String(body.orderId) : null;
+    } catch (err) {
+      const c = classifyGateError(err);
+      if (c.httpStatus === 404 || NOT_FOUND.test(c.label ?? '')) return null;
+      throw err;
+    }
+  };
+
+  const convertLanded = async (step: Step): Promise<boolean> => {
+    const balance = await usdcOnHyperliquid();
+    if (step.balanceBefore === null || step.qty === null || balance - step.balanceBefore < step.qty - 0.01) {
+      return false;
+    }
+    finish(step, step.qty, 'HYPERLIQUID');
+    return true;
+  };
+
+  const transfer = async (from: string, to: string, tag: string): Promise<string> => {
+    const amount = job.steps[job.stepIndex - 1].qty ?? 0;
+    const { body } = await crossEx().createCrossexTransfer({
+      crossexTransferRequest: { coin: 'USDC', amount: roundToStep(amount, TRANSFER_STEP, 'down'), from, to, text: tag },
+    });
+    return String(body.txId);
+  };
+
+  const sendConvert = async (step: Step): Promise<void> => {
+    const { body: quote } = await crossEx().createCrossexConvertQuote({
+      crossexConvertQuoteRequest: {
+        exchangeType: 'HYPERLIQUID',
+        fromCoin: 'USDT',
+        toCoin: 'USDC',
+        fromAmount: String(job.amount),
+      },
+    });
+    const toAmount = Number(quote.toAmount);
+    if (!(toAmount >= job.amount * QUOTE_FLOOR)) {
+      halt('quote worse than 30 bps');
+      return;
+    }
+    const balanceBefore = await usdcOnHyperliquid();
+    step.quoteId = String(quote.quoteId);
+    step.qty = toAmount;
+    step.balanceBefore = balanceBefore;
+    deps.jobs.write(job);
+    const { body } = await crossEx().createCrossexConvertOrder({
+      crossexConvertOrderRequest: { quoteId: step.quoteId },
+    });
+    step.venueId = String(body.orderId);
+    finish(step, toAmount, 'HYPERLIQUID');
+  };
+
+  const send = async (step: Step, tag: string): Promise<void> => {
+    if (step.name === 'Convert') return sendConvert(step);
+    if (step.name === 'Buy USDC') {
+      const { body } = await crossEx().createCrossexOrder({
+        crossexOrderRequest: {
+          symbol: SPOT_SYMBOL,
+          side: CrossexOrderRequest.Side.BUY,
+          type: CrossexOrderRequest.Type.MARKET,
+          quoteQty: String(job.amount),
+          text: tag,
+        },
+      });
+      step.venueId = String(body.orderId);
+    } else if (step.name === 'To spot') {
+      step.venueId = await transfer('CROSSEX_GATE', 'SPOT', tag);
+    } else {
+      step.venueId = await transfer('SPOT', 'CROSSEX_HYPERLIQUID', tag);
+    }
+    deps.jobs.write(job);
+  };
+
+  try {
+    while (job.status === 'running') {
+      const step = job.steps[job.stepIndex];
+      if (step.startedAt === null) {
+        step.startedAt = deps.now();
+        step.status = 'running';
+        deps.jobs.write(job);
+      }
+      if (deps.now() - step.startedAt > STEP_TIMEOUT_MS) {
+        halt('timeout');
+        return;
+      }
+      let phase: 'poll' | 'lookup' | 'send' = 'poll';
+      try {
+        if (step.venueId !== null) {
+          await poll(step, step.venueId);
+          if (job.status === 'running' && step.status !== 'done') await deps.sleep(POLL_MS);
+          continue;
+        }
+        if (step.text === null) {
+          step.text = tagFor(job.id, job.stepIndex);
+          deps.jobs.write(job);
+        } else if (step.name === 'Convert') {
+          phase = 'lookup';
+          if (step.quoteId !== null && (await convertLanded(step))) continue;
+        } else {
+          phase = 'lookup';
+          let found = await lookup(step, step.text);
+          if (found === null) {
+            await deps.sleep(LOOKUP_RETRY_MS);
+            found = await lookup(step, step.text);
+          }
+          if (found !== null) {
+            step.venueId = found;
+            deps.jobs.write(job);
+            continue;
+          }
+        }
+        phase = 'send';
+        await send(step, step.text);
+      } catch (err) {
+        const c = classifyGateError(err);
+        if (c.retryable) {
+          await deps.sleep(POLL_MS);
+        } else if (phase !== 'send') {
+          halt(c.message);
+        } else if (c.label && c.httpStatus !== undefined && c.httpStatus >= 400 && c.httpStatus < 500) {
+          halt(c.hint ? `${c.message} ${c.hint}` : c.message);
+        } else {
+          await deps.sleep(POLL_MS);
+        }
+      }
+    }
+  } catch (err) {
+    job.status = 'halted';
+    job.haltReason = classifyGateError(err).message;
+    try {
+      deps.jobs.write(job);
+    } catch {
+      return;
+    }
+  }
+}

--- a/src/server/rebalanceRunner.ts
+++ b/src/server/rebalanceRunner.ts
@@ -84,11 +84,19 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
 
   const previousQty = (): number => (job.stepIndex === 0 ? job.amount : (job.steps[job.stepIndex - 1].qty ?? 0));
 
-  const usdcOnHyperliquid = async (): Promise<number> => {
+  const balanceOf = async (coin: string, venue: string): Promise<number> => {
     const { body } = await crossEx().getCrossexAccount();
-    const asset = body.assets?.find((a) => a.coin === 'USDC' && a.exchangeType === 'HYPERLIQUID');
+    const asset = body.assets?.find((a) => a.coin === coin && a.exchangeType === venue);
     return Number(asset?.balance ?? 0);
   };
+
+  /** Convert runs on Hyperliquid in both directions. Pay-down turns USDT into
+   * USDC there; pull turns USDC into USDT, which lands in the pooled CROSSEX
+   * bucket. The landing check watches the bucket that receives. */
+  const convertSpec = () =>
+    job.direction === 'pull'
+      ? { fromCoin: 'USDC', toCoin: 'USDT', dest: 'CROSSEX' as FundsAt, landed: () => balanceOf('USDT', 'CROSSEX') }
+      : { fromCoin: 'USDT', toCoin: 'USDC', dest: 'HYPERLIQUID' as FundsAt, landed: () => balanceOf('USDC', 'HYPERLIQUID') };
 
   const transferRow = async (
     match: (row: CrossexTransferRecord) => boolean,
@@ -98,11 +106,12 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
   };
 
   const convertLanded = async (step: Step): Promise<boolean> => {
-    const balance = await usdcOnHyperliquid();
+    const spec = convertSpec();
+    const balance = await spec.landed();
     if (step.balanceBefore === null || step.qty === null || balance - step.balanceBefore < step.qty - 0.01) {
       return false;
     }
-    finish(step, step.qty, 'HYPERLIQUID');
+    finish(step, step.qty, spec.dest);
     return true;
   };
 
@@ -166,12 +175,13 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
   };
 
   const sendConvert = async (step: Step): Promise<void> => {
-    if (step.balanceBefore === null) step.balanceBefore = await usdcOnHyperliquid();
+    const spec = convertSpec();
+    if (step.balanceBefore === null) step.balanceBefore = await spec.landed();
     const { body: quote } = await crossEx().createCrossexConvertQuote({
       crossexConvertQuoteRequest: {
         exchangeType: 'HYPERLIQUID',
-        fromCoin: 'USDT',
-        toCoin: 'USDC',
+        fromCoin: spec.fromCoin,
+        toCoin: spec.toCoin,
         fromAmount: String(job.amount),
       },
     });
@@ -188,7 +198,7 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
     });
     if (!body.orderId) throw new Error('convert order response has no orderId');
     step.venueId = String(body.orderId);
-    finish(step, toAmount, 'HYPERLIQUID');
+    finish(step, toAmount, spec.dest);
   };
 
   const send = async (step: Step, spec: StepSpec, tag: string): Promise<void> => {

--- a/src/server/rebalanceRunner.ts
+++ b/src/server/rebalanceRunner.ts
@@ -5,7 +5,7 @@ import { roundToStep } from '../core/numbers';
 import { SPOT_SYMBOL } from '../core/rebalance/plan';
 import { decodeStatus } from '../engine/loop';
 import type { TtlCache } from './cache';
-import { haltMessage, STEP_NAMES, type FundsAt, type JobFile, type Step } from './rebalanceJob';
+import { haltMessage, type FundsAt, type JobFile, type Step, type StepName } from './rebalanceJob';
 
 export interface RunnerDeps {
   clients: () => Clients;
@@ -17,13 +17,36 @@ export interface RunnerDeps {
 }
 
 export const STEP_TIMEOUT_MS = 600_000;
+export const HL_TRANSFER_TIMEOUT_MS = 1_800_000;
 export const POLL_MS = 1_000;
 export const LOOKUP_RETRY_MS = 10_000;
 export const QUOTE_FLOOR = 0.997;
 export const TRANSFER_STEP = '0.00001';
+const SELL_STEP = '0.01';
+const HYPERLIQUID_ACCOUNT = 'CROSSEX_HYPERLIQUID';
 
 const NOT_FOUND = /NOT_FOUND/i;
 const TRANSFER_DEAD = /FAIL|CANCEL|REJECT|EXPIRE/i;
+
+type StepSpec =
+  | { kind: 'order'; side: CrossexOrderRequest.Side; dest: FundsAt }
+  | { kind: 'transfer'; from: string; to: string; dest: FundsAt }
+  | { kind: 'convert'; dest: FundsAt };
+
+const STEPS: Record<StepName, StepSpec> = {
+  'Buy USDC': { kind: 'order', side: CrossexOrderRequest.Side.BUY, dest: 'GATE' },
+  'To spot': { kind: 'transfer', from: 'CROSSEX_GATE', to: 'SPOT', dest: 'SPOT' },
+  'To Hyperliquid': { kind: 'transfer', from: 'SPOT', to: HYPERLIQUID_ACCOUNT, dest: 'HYPERLIQUID' },
+  Convert: { kind: 'convert', dest: 'HYPERLIQUID' },
+  'Pull from Hyperliquid': { kind: 'transfer', from: HYPERLIQUID_ACCOUNT, to: 'SPOT', dest: 'SPOT' },
+  'To Gate': { kind: 'transfer', from: 'SPOT', to: 'CROSSEX_GATE', dest: 'GATE' },
+  'Sell USDC': { kind: 'order', side: CrossexOrderRequest.Side.SELL, dest: 'CROSSEX' },
+};
+
+const timeoutFor = (spec: StepSpec): number =>
+  spec.kind === 'transfer' && (spec.from === HYPERLIQUID_ACCOUNT || spec.to === HYPERLIQUID_ACCOUNT)
+    ? HL_TRANSFER_TIMEOUT_MS
+    : STEP_TIMEOUT_MS;
 
 export function tagFor(jobId: string, stepIndex: number, attempt = 0): string {
   return attempt > 0 ? `t-rb${jobId}${stepIndex}x${attempt}` : `t-rb${jobId}${stepIndex}`;
@@ -53,11 +76,13 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
     step.status = 'done';
     step.doneAt = deps.now();
     job.fundsAt = fundsAt;
-    if (fundsAt === 'HYPERLIQUID') deps.cache.bust('account');
+    if (fundsAt === 'HYPERLIQUID' || fundsAt === 'CROSSEX') deps.cache.bust('account');
     if (job.stepIndex === job.steps.length - 1) job.status = 'done';
     else job.stepIndex += 1;
     deps.jobs.write(job);
   };
+
+  const previousQty = (): number => (job.stepIndex === 0 ? job.amount : (job.steps[job.stepIndex - 1].qty ?? 0));
 
   const usdcOnHyperliquid = async (): Promise<number> => {
     const { body } = await crossEx().getCrossexAccount();
@@ -81,16 +106,21 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
     return true;
   };
 
-  const poll = async (step: Step, venueId: string): Promise<void> => {
-    if (step.name === 'Buy USDC') {
+  const poll = async (step: Step, spec: StepSpec, venueId: string): Promise<void> => {
+    if (spec.kind === 'order') {
       const { body } = await crossEx().getCrossexOrder(venueId);
       const state = String(body.state ?? '');
       if (decodeStatus(state) !== 'closed') return;
-      const fee = String(body.feeCoin ?? '') === 'USDC' ? Number(body.fee ?? 0) : 0;
-      const filled = Number(body.executedQty ?? 0) - (Number.isFinite(fee) ? fee : 0);
-      if (filled > 0) finish(step, filled, 'GATE');
+      let filled: number;
+      if (spec.side === CrossexOrderRequest.Side.SELL) {
+        filled = Number(body.executedAmount ?? 0);
+      } else {
+        const fee = String(body.feeCoin ?? '') === 'USDC' ? Number(body.fee ?? 0) : 0;
+        filled = Number(body.executedQty ?? 0) - (Number.isFinite(fee) ? fee : 0);
+      }
+      if (filled > 0) finish(step, filled, spec.dest);
       else haltDead(step, `order ${state} with nothing filled`);
-    } else if (step.name === 'Convert') {
+    } else if (spec.kind === 'convert') {
       await convertLanded(step);
     } else {
       const row = await transferRow((r) => r.id === venueId);
@@ -98,7 +128,7 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
       const status = String(row.status ?? '');
       if (status === 'SUCCESS') {
         const received = Number(row.actualReceive ?? row.amount);
-        if (received > 0) finish(step, received, step.name === 'To spot' ? 'SPOT' : 'HYPERLIQUID');
+        if (received > 0) finish(step, received, spec.dest);
         else halt('transfer SUCCESS with nothing received');
       } else if (TRANSFER_DEAD.test(status)) {
         haltDead(step, row.failReason || `transfer ${status}`);
@@ -106,8 +136,8 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
     }
   };
 
-  const lookup = async (step: Step, tag: string): Promise<string | null> => {
-    if (step.name !== 'Buy USDC') {
+  const lookup = async (spec: StepSpec, tag: string): Promise<string | null> => {
+    if (spec.kind !== 'order') {
       const row = await transferRow((r) => r.text === tag);
       return row ? row.id : null;
     }
@@ -122,9 +152,14 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
   };
 
   const transfer = async (from: string, to: string, tag: string): Promise<string> => {
-    const amount = job.steps[job.stepIndex - 1].qty ?? 0;
     const { body } = await crossEx().createCrossexTransfer({
-      crossexTransferRequest: { coin: 'USDC', amount: roundToStep(amount, TRANSFER_STEP, 'down'), from, to, text: tag },
+      crossexTransferRequest: {
+        coin: 'USDC',
+        amount: roundToStep(previousQty(), TRANSFER_STEP, 'down'),
+        from,
+        to,
+        text: tag,
+      },
     });
     if (!body.txId) throw new Error('transfer response has no txId');
     return String(body.txId);
@@ -156,24 +191,26 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
     finish(step, toAmount, 'HYPERLIQUID');
   };
 
-  const send = async (step: Step, tag: string): Promise<void> => {
-    if (step.name === 'Convert') return sendConvert(step);
-    if (step.name === 'Buy USDC') {
+  const send = async (step: Step, spec: StepSpec, tag: string): Promise<void> => {
+    if (spec.kind === 'convert') return sendConvert(step);
+    if (spec.kind === 'order') {
+      const size =
+        spec.side === CrossexOrderRequest.Side.SELL
+          ? { qty: roundToStep(previousQty(), SELL_STEP, 'down') }
+          : { quoteQty: String(job.amount) };
       const { body } = await crossEx().createCrossexOrder({
         crossexOrderRequest: {
           symbol: SPOT_SYMBOL,
-          side: CrossexOrderRequest.Side.BUY,
+          side: spec.side,
           type: CrossexOrderRequest.Type.MARKET,
-          quoteQty: String(job.amount),
+          ...size,
           text: tag,
         },
       });
       if (!body.orderId) throw new Error('order response has no orderId');
       step.venueId = String(body.orderId);
-    } else if (step.name === 'To spot') {
-      step.venueId = await transfer('CROSSEX_GATE', 'SPOT', tag);
-    } else if (step.name === 'To Hyperliquid') {
-      step.venueId = await transfer('SPOT', 'CROSSEX_HYPERLIQUID', tag);
+    } else {
+      step.venueId = await transfer(spec.from, spec.to, tag);
     }
     deps.jobs.write(job);
   };
@@ -181,7 +218,8 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
   try {
     while (job.status === 'running') {
       const step = job.steps[job.stepIndex];
-      if (!STEP_NAMES.includes(step.name)) {
+      const spec: StepSpec | undefined = STEPS[step.name as StepName];
+      if (!spec) {
         halt(`unknown step ${step.name}`);
         return;
       }
@@ -190,21 +228,21 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
         step.status = 'running';
         deps.jobs.write(job);
       }
-      if (deps.now() - step.startedAt > STEP_TIMEOUT_MS) {
+      if (deps.now() - step.startedAt > timeoutFor(spec)) {
         halt('timeout');
         return;
       }
       let phase: 'poll' | 'lookup' | 'send' = 'poll';
       try {
         if (step.venueId !== null) {
-          await poll(step, step.venueId);
+          await poll(step, spec, step.venueId);
           if (job.status === 'running' && step.status !== 'done') await deps.sleep(POLL_MS);
           continue;
         }
         if (step.text === null) {
           step.text = tagFor(job.id, job.stepIndex, step.attempt);
           deps.jobs.write(job);
-        } else if (step.name === 'Convert') {
+        } else if (spec.kind === 'convert') {
           phase = 'lookup';
           if (step.quoteId !== null) {
             let landed = await convertLanded(step);
@@ -216,10 +254,10 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
           }
         } else {
           phase = 'lookup';
-          let found = await lookup(step, step.text);
+          let found = await lookup(spec, step.text);
           if (found === null) {
             await deps.sleep(LOOKUP_RETRY_MS);
-            found = await lookup(step, step.text);
+            found = await lookup(spec, step.text);
           }
           if (found !== null) {
             step.venueId = found;
@@ -228,7 +266,7 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
           }
         }
         phase = 'send';
-        await send(step, step.text);
+        await send(step, spec, step.text);
       } catch (err) {
         const c = classifyGateError(err);
         const notFound = c.httpStatus === 404 || NOT_FOUND.test(c.label ?? '');

--- a/src/server/routes/credentials.ts
+++ b/src/server/routes/credentials.ts
@@ -7,6 +7,15 @@ import { classifyGateError, CoreError } from '../../core/errors';
 import type { AppDeps } from '../app';
 import { restrictToOwner } from '../secretFile';
 
+const PAY_DOWN_RUNNING = {
+  ok: false,
+  error: {
+    category: 'validation',
+    message: 'a pay-down is still running — wait for it to finish before changing credentials',
+    retryable: true,
+  },
+};
+
 /**
  * Credentials: read masked status; replace keys with validate-before-commit.
  * PUT builds a CANDIDATE client and calls getCrossexAccount first — only a key
@@ -43,6 +52,7 @@ export function credentialsRoutes(deps: AppDeps) {
           },
         });
       }
+      if (deps.rebalance?.jobs.read()?.status === 'running') return reply.code(409).send(PAY_DOWN_RUNNING);
 
       // Validate with a candidate client; nothing is persisted on failure.
       const candidate = makeClients({ key, secret });
@@ -73,6 +83,7 @@ export function credentialsRoutes(deps: AppDeps) {
           },
         });
       }
+      if (deps.rebalance?.jobs.read()?.status === 'running') return reply.code(409).send(PAY_DOWN_RUNNING);
 
       rewriteEnvFile(svc.envPath, { GATE_API_KEY: key, GATE_API_SECRET: secret }, svc.hardenConfigDir);
       process.env.GATE_API_KEY = key;

--- a/src/server/routes/deals.ts
+++ b/src/server/routes/deals.ts
@@ -1,5 +1,6 @@
 /**
- * Deal routes — the app's ONLY execution surface (engine). The route layer
+ * Deal routes — one of the app's two execution surfaces (engine). The other
+ * is the rebalance runner (src/server/rebalanceRunner.ts). The route layer
  * never touches venue-mutating endpoints itself: creation writes an intent row
  * the reconcile loop picks up on its next tick; commands are one-row intent
  * edits (levels, not events).

--- a/src/server/routes/rebalance.ts
+++ b/src/server/routes/rebalance.ts
@@ -92,11 +92,16 @@ export function rebalanceRoutes(deps: AppDeps) {
       const special = gateFees?.specialFeeList?.find((s) => s.symbol === SPOT_SYMBOL);
       const ask = Number(tickers.value[0]?.lowestAsk);
       const bid = Number(tickers.value[0]?.highestBid);
+      // Gate sends min_trans_amount as a string although the SDK declares a
+      // number. Coerce here so the plan's arithmetic never concatenates.
+      const usdcCoin = coins.value.find((c) => c.coin === 'USDC');
       const plan = planFor(
         buckets,
         account.value,
         {
-          usdcTransfer: coins.value.find((c) => c.coin === 'USDC') ?? null,
+          usdcTransfer: usdcCoin
+            ? { isDisabled: Number(usdcCoin.isDisabled), minTransAmount: Number(usdcCoin.minTransAmount) }
+            : null,
           spotRule: rules.value.find((r) => r.symbol === SPOT_SYMBOL) ?? null,
           spotTakerRate: Number(special?.takerFeeRate ?? gateFees?.spotTakerFee ?? 0),
           ask: Number.isFinite(ask) ? ask : null,

--- a/src/server/routes/rebalance.ts
+++ b/src/server/routes/rebalance.ts
@@ -1,9 +1,11 @@
 import type { FastifyInstance, FastifyReply } from 'fastify';
 import { CoreError } from '../../core/errors';
+import { roundToStep } from '../../core/numbers';
 import { bucketsFrom, planFor, SPOT_SYMBOL, type InterestRowLike } from '../../core/rebalance/plan';
 import type { AppDeps } from '../app';
 import { TTL } from '../cache';
-import { JobFile, newJob, type Job } from '../rebalanceJob';
+import { isDisclaimerAccepted } from '../disclaimer';
+import { haltMessage, newJob, type Job, type JobFile } from '../rebalanceJob';
 import { runJob } from '../rebalanceRunner';
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
@@ -15,13 +17,18 @@ const conflict = (reply: FastifyReply, message: string): FastifyReply =>
   reply.code(409).send({ ok: false, error: { category: 'validation', message, retryable: true } });
 
 const orEmpty = <T>(read: Promise<{ value: T[]; stale: boolean }>): Promise<{ value: T[]; stale: boolean }> =>
-  read.catch(() => ({ value: [], stale: false }));
+  read.catch(() => ({ value: [], stale: true }));
 
 export function rebalanceRoutes(deps: AppDeps) {
   return async function plugin(app: FastifyInstance): Promise<void> {
-    const jobs = deps.rebalance ? new JobFile(deps.rebalance.dataDir) : null;
-    jobs?.haltIfRunning('server restarted');
+    const jobs = deps.rebalance?.jobs ?? null;
     const now = (): number => deps.engine!.clock.now();
+    const log = (message: string): void => {
+      console.error(message);
+      const engine = deps.engine;
+      if (engine) engine.store.alert('error', null, message, engine.clock.now(), { once: true });
+    };
+    if (jobs?.haltIfRunning('server restarted')) log(haltMessage(jobs.read()!));
     let inflight: Promise<void> | null = null;
 
     const requireJobs = (): JobFile => {
@@ -29,11 +36,16 @@ export function rebalanceRoutes(deps: AppDeps) {
       return jobs;
     };
 
+    const busyJob = (store: JobFile): Job | null => {
+      const current = store.read();
+      return current && (current.status === 'running' || current.status === 'halted') ? current : null;
+    };
+
     const start = (store: JobFile): void => {
       if (inflight) return;
       const sleep =
         deps.rebalance?.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
-      inflight = runJob({ clients: () => deps.getClients(), jobs: store, cache: deps.cache, now, sleep }).finally(
+      inflight = runJob({ clients: () => deps.getClients(), jobs: store, cache: deps.cache, now, sleep, log }).finally(
         () => {
           inflight = null;
         },
@@ -45,10 +57,10 @@ export function rebalanceRoutes(deps: AppDeps) {
       for (let page = 1; page <= INTEREST_MAX_PAGES; page += 1) {
         const { body } = await deps
           .getClients()
-          .crossEx.listCrossexHistoryMarginInterests({ page, limit: INTEREST_PAGE_SIZE });
+          .crossEx.listCrossexHistoryMarginInterests({ from: since, to: now(), page, limit: INTEREST_PAGE_SIZE });
         const list = body ?? [];
         rows.push(...list.filter((r) => Number(r.createTime) >= since));
-        if (list.length < INTEREST_PAGE_SIZE || list.some((r) => Number(r.createTime) < since)) break;
+        if (list.length < INTEREST_PAGE_SIZE) break;
       }
       return rows;
     };
@@ -59,7 +71,7 @@ export function rebalanceRoutes(deps: AppDeps) {
       const [account, rates, paid, coins, rules, fees, tickers] = await Promise.all([
         deps.cache.get('account', TTL.live, async () => (await crossEx().getCrossexAccount()).body, { fresh }),
         orEmpty(deps.cache.get('interest:rate', TTL.static, async () => (await crossEx().getCrossexInterestRate()).body)),
-        orEmpty(deps.cache.get('interest:paid', TTL.historyOrders, () => interestPaidSince(since))),
+        orEmpty(deps.cache.get('interest:paid', TTL.fills, () => interestPaidSince(since))),
         deps.cache.get('transfer:coins', TTL.static, async () => (await crossEx().listCrossexTransferCoins()).body),
         deps.cache.get('rules:all', TTL.static, async () => (await crossEx().listCrossexRuleSymbols()).body),
         deps.cache.get('fees', TTL.static, async () => (await crossEx().getCrossexFee()).body),
@@ -85,10 +97,7 @@ export function rebalanceRoutes(deps: AppDeps) {
 
     const haltedOr409 = (store: JobFile, id: string, reply: FastifyReply): Job | null => {
       const job = store.read();
-      if (!job || job.id !== id) {
-        conflict(reply, `unknown rebalance ${id}`);
-        return null;
-      }
+      if (!job || job.id !== id) throw new CoreError(`unknown rebalance ${id}`);
       if (job.status !== 'halted') {
         conflict(reply, `rebalance ${job.id} is ${job.status}`);
         return null;
@@ -101,17 +110,38 @@ export function rebalanceRoutes(deps: AppDeps) {
       return reply.ok({ buckets, plan, job }, { stale });
     });
 
-    app.post('/rebalance', async (_req, reply) => {
-      const store = requireJobs();
-      const { plan } = await loadView(true);
-      const current = store.read();
-      if (current && (current.status === 'running' || current.status === 'halted')) {
-        return conflict(reply, `rebalance ${current.id} is ${current.status}`);
+    app.post('/rebalance', async (req, reply) => {
+      const envPath = deps.credentials?.envPath;
+      if (envPath && !isDisclaimerAccepted(envPath)) {
+        return reply.code(403).send({
+          ok: false,
+          error: {
+            category: 'validation',
+            label: 'DISCLAIMER_NOT_ACCEPTED',
+            message: 'You must accept the disclaimer before placing any order.',
+            retryable: false,
+          },
+        });
       }
+      const store = requireJobs();
+      const busy = busyJob(store);
+      if (busy) return conflict(reply, `rebalance ${busy.id} is ${busy.status}`);
       const working = deps.engine!.store.listPairs({ activeOnly: true });
       if (working.length > 0) return conflict(reply, `deal ${working[0].id} is still working`);
+      const { plan } = await loadView(true);
+      const body = (req.body ?? {}) as { amount?: unknown; route?: unknown };
+      if (typeof body.route === 'string' && body.route !== plan.route) {
+        return conflict(reply, `plan changed: now ${plan.route ?? 'no route'}`);
+      }
       if (!plan.route) return conflict(reply, 'no route');
-      const job = newJob(plan.route, plan.amount, now());
+      let amount = plan.amount;
+      if (typeof body.amount === 'number' && Number.isFinite(body.amount) && body.amount > 0) {
+        amount = Number(roundToStep(Math.min(plan.amount, body.amount), '0.01', 'down'));
+      }
+      if (!(amount > 0)) return conflict(reply, 'nothing to move');
+      const again = busyJob(store);
+      if (again) return conflict(reply, `rebalance ${again.id} is ${again.status}`);
+      const job = newJob(plan.route, amount, now());
       store.write(job);
       start(store);
       return reply.code(202).ok({ id: job.id });

--- a/src/server/routes/rebalance.ts
+++ b/src/server/routes/rebalance.ts
@@ -1,7 +1,6 @@
 import type { FastifyInstance, FastifyReply } from 'fastify';
 import { CoreError } from '../../core/errors';
-import { roundToStep } from '../../core/numbers';
-import { bucketsFrom, planFor, SPOT_SYMBOL, type InterestRowLike } from '../../core/rebalance/plan';
+import { bucketsFrom, planFor, SPOT_SYMBOL, type Direction, type InterestRowLike } from '../../core/rebalance/plan';
 import type { AppDeps } from '../app';
 import { TTL } from '../cache';
 import { isDisclaimerAccepted } from '../disclaimer';
@@ -18,6 +17,13 @@ const conflict = (reply: FastifyReply, message: string): FastifyReply =>
 
 const orEmpty = <T>(read: Promise<{ value: T[]; stale: boolean }>): Promise<{ value: T[]; stale: boolean }> =>
   read.catch(() => ({ value: [], stale: true }));
+
+const directionOf = (value: unknown): Direction => (value === 'pull' ? 'pull' : 'payDown');
+
+const requestedOf = (value: unknown): number => {
+  const n = typeof value === 'number' || typeof value === 'string' ? Number(value) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : Infinity;
+};
 
 export function rebalanceRoutes(deps: AppDeps) {
   return async function plugin(app: FastifyInstance): Promise<void> {
@@ -65,7 +71,7 @@ export function rebalanceRoutes(deps: AppDeps) {
       return rows;
     };
 
-    const loadView = async (fresh: boolean) => {
+    const loadView = async (fresh: boolean, direction: Direction, requested: number) => {
       const crossEx = () => deps.getClients().crossEx;
       const since = now() - THIRTY_DAYS_MS;
       const [account, rates, paid, coins, rules, fees, tickers] = await Promise.all([
@@ -85,12 +91,19 @@ export function rebalanceRoutes(deps: AppDeps) {
       const gateFees = fees.value.find((f) => f.exchangeType === 'GATE');
       const special = gateFees?.specialFeeList?.find((s) => s.symbol === SPOT_SYMBOL);
       const ask = Number(tickers.value[0]?.lowestAsk);
-      const plan = planFor(buckets, account.value, {
-        usdcTransfer: coins.value.find((c) => c.coin === 'USDC') ?? null,
-        spotRule: rules.value.find((r) => r.symbol === SPOT_SYMBOL) ?? null,
-        spotTakerRate: Number(special?.takerFeeRate ?? gateFees?.spotTakerFee ?? 0),
-        ask: Number.isFinite(ask) ? ask : null,
-      });
+      const bid = Number(tickers.value[0]?.highestBid);
+      const plan = planFor(
+        buckets,
+        account.value,
+        {
+          usdcTransfer: coins.value.find((c) => c.coin === 'USDC') ?? null,
+          spotRule: rules.value.find((r) => r.symbol === SPOT_SYMBOL) ?? null,
+          spotTakerRate: Number(special?.takerFeeRate ?? gateFees?.spotTakerFee ?? 0),
+          ask: Number.isFinite(ask) ? ask : null,
+          bid: Number.isFinite(bid) ? bid : null,
+        },
+        { direction, requested },
+      );
       const stale = [account, rates, paid, coins, rules, fees, tickers].some((r) => r.stale);
       return { buckets, plan, job: jobs?.read() ?? null, stale };
     };
@@ -105,8 +118,9 @@ export function rebalanceRoutes(deps: AppDeps) {
       return job;
     };
 
-    app.get('/rebalance', async (_req, reply) => {
-      const { buckets, plan, job, stale } = await loadView(false);
+    app.get('/rebalance', async (req, reply) => {
+      const query = (req.query ?? {}) as { direction?: unknown; amount?: unknown };
+      const { buckets, plan, job, stale } = await loadView(false, directionOf(query.direction), requestedOf(query.amount));
       return reply.ok({ buckets, plan, job }, { stale });
     });
 
@@ -128,20 +142,17 @@ export function rebalanceRoutes(deps: AppDeps) {
       if (busy) return conflict(reply, `rebalance ${busy.id} is ${busy.status}`);
       const working = deps.engine!.store.listPairs({ activeOnly: true });
       if (working.length > 0) return conflict(reply, `deal ${working[0].id} is still working`);
-      const { plan } = await loadView(true);
-      const body = (req.body ?? {}) as { amount?: unknown; route?: unknown };
+      const body = (req.body ?? {}) as { direction?: unknown; amount?: unknown; route?: unknown };
+      const direction = directionOf(body.direction);
+      const { plan } = await loadView(true, direction, requestedOf(body.amount));
       if (typeof body.route === 'string' && body.route !== plan.route) {
         return conflict(reply, `plan changed: now ${plan.route ?? 'no route'}`);
       }
       if (!plan.route) return conflict(reply, 'no route');
-      let amount = plan.amount;
-      if (typeof body.amount === 'number' && Number.isFinite(body.amount) && body.amount > 0) {
-        amount = Number(roundToStep(Math.min(plan.amount, body.amount), '0.01', 'down'));
-      }
-      if (!(amount > 0)) return conflict(reply, 'nothing to move');
+      if (!(plan.amount > 0)) return conflict(reply, 'nothing to move');
       const again = busyJob(store);
       if (again) return conflict(reply, `rebalance ${again.id} is ${again.status}`);
-      const job = newJob(plan.route, amount, now());
+      const job = newJob(direction, plan.route, plan.amount, now());
       store.write(job);
       start(store);
       return reply.code(202).ok({ id: job.id });

--- a/src/server/routes/rebalance.ts
+++ b/src/server/routes/rebalance.ts
@@ -1,0 +1,141 @@
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import { CoreError } from '../../core/errors';
+import { bucketsFrom, planFor, SPOT_SYMBOL, type InterestRowLike } from '../../core/rebalance/plan';
+import type { AppDeps } from '../app';
+import { TTL } from '../cache';
+import { JobFile, newJob, type Job } from '../rebalanceJob';
+import { runJob } from '../rebalanceRunner';
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const INTEREST_PAGE_SIZE = 100;
+const INTEREST_MAX_PAGES = 8;
+const SPOT_PAIR = 'USDC_USDT';
+
+const conflict = (reply: FastifyReply, message: string): FastifyReply =>
+  reply.code(409).send({ ok: false, error: { category: 'validation', message, retryable: true } });
+
+const orEmpty = <T>(read: Promise<{ value: T[]; stale: boolean }>): Promise<{ value: T[]; stale: boolean }> =>
+  read.catch(() => ({ value: [], stale: false }));
+
+export function rebalanceRoutes(deps: AppDeps) {
+  return async function plugin(app: FastifyInstance): Promise<void> {
+    const jobs = deps.rebalance ? new JobFile(deps.rebalance.dataDir) : null;
+    jobs?.haltIfRunning('server restarted');
+    const now = (): number => deps.engine!.clock.now();
+    let inflight: Promise<void> | null = null;
+
+    const requireJobs = (): JobFile => {
+      if (!jobs) throw new CoreError('rebalance store not configured', 'not-configured');
+      return jobs;
+    };
+
+    const start = (store: JobFile): void => {
+      if (inflight) return;
+      const sleep =
+        deps.rebalance?.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+      inflight = runJob({ clients: () => deps.getClients(), jobs: store, cache: deps.cache, now, sleep }).finally(
+        () => {
+          inflight = null;
+        },
+      );
+    };
+
+    const interestPaidSince = async (since: number): Promise<InterestRowLike[]> => {
+      const rows: InterestRowLike[] = [];
+      for (let page = 1; page <= INTEREST_MAX_PAGES; page += 1) {
+        const { body } = await deps
+          .getClients()
+          .crossEx.listCrossexHistoryMarginInterests({ page, limit: INTEREST_PAGE_SIZE });
+        const list = body ?? [];
+        rows.push(...list.filter((r) => Number(r.createTime) >= since));
+        if (list.length < INTEREST_PAGE_SIZE || list.some((r) => Number(r.createTime) < since)) break;
+      }
+      return rows;
+    };
+
+    const loadView = async (fresh: boolean) => {
+      const crossEx = () => deps.getClients().crossEx;
+      const since = now() - THIRTY_DAYS_MS;
+      const [account, rates, paid, coins, rules, fees, tickers] = await Promise.all([
+        deps.cache.get('account', TTL.live, async () => (await crossEx().getCrossexAccount()).body, { fresh }),
+        orEmpty(deps.cache.get('interest:rate', TTL.static, async () => (await crossEx().getCrossexInterestRate()).body)),
+        orEmpty(deps.cache.get('interest:paid', TTL.historyOrders, () => interestPaidSince(since))),
+        deps.cache.get('transfer:coins', TTL.static, async () => (await crossEx().listCrossexTransferCoins()).body),
+        deps.cache.get('rules:all', TTL.static, async () => (await crossEx().listCrossexRuleSymbols()).body),
+        deps.cache.get('fees', TTL.static, async () => (await crossEx().getCrossexFee()).body),
+        deps.cache.get(
+          'spot:usdc',
+          TTL.live,
+          async () => (await deps.getClients().spot.listTickers({ currencyPair: SPOT_PAIR })).body,
+        ),
+      ]);
+      const buckets = bucketsFrom(account.value, rates.value, paid.value);
+      const gateFees = fees.value.find((f) => f.exchangeType === 'GATE');
+      const special = gateFees?.specialFeeList?.find((s) => s.symbol === SPOT_SYMBOL);
+      const ask = Number(tickers.value[0]?.lowestAsk);
+      const plan = planFor(buckets, account.value, {
+        usdcTransfer: coins.value.find((c) => c.coin === 'USDC') ?? null,
+        spotRule: rules.value.find((r) => r.symbol === SPOT_SYMBOL) ?? null,
+        spotTakerRate: Number(special?.takerFeeRate ?? gateFees?.spotTakerFee ?? 0),
+        ask: Number.isFinite(ask) ? ask : null,
+      });
+      const stale = [account, rates, paid, coins, rules, fees, tickers].some((r) => r.stale);
+      return { buckets, plan, job: jobs?.read() ?? null, stale };
+    };
+
+    const haltedOr409 = (store: JobFile, id: string, reply: FastifyReply): Job | null => {
+      const job = store.read();
+      if (!job || job.id !== id) {
+        conflict(reply, `unknown rebalance ${id}`);
+        return null;
+      }
+      if (job.status !== 'halted') {
+        conflict(reply, `rebalance ${job.id} is ${job.status}`);
+        return null;
+      }
+      return job;
+    };
+
+    app.get('/rebalance', async (_req, reply) => {
+      const { buckets, plan, job, stale } = await loadView(false);
+      return reply.ok({ buckets, plan, job }, { stale });
+    });
+
+    app.post('/rebalance', async (_req, reply) => {
+      const store = requireJobs();
+      const { plan } = await loadView(true);
+      const current = store.read();
+      if (current && (current.status === 'running' || current.status === 'halted')) {
+        return conflict(reply, `rebalance ${current.id} is ${current.status}`);
+      }
+      const working = deps.engine!.store.listPairs({ activeOnly: true });
+      if (working.length > 0) return conflict(reply, `deal ${working[0].id} is still working`);
+      if (!plan.route) return conflict(reply, 'no route');
+      const job = newJob(plan.route, plan.amount, now());
+      store.write(job);
+      start(store);
+      return reply.code(202).ok({ id: job.id });
+    });
+
+    app.post('/rebalance/:id/resume', async (req, reply) => {
+      const store = requireJobs();
+      const job = haltedOr409(store, (req.params as { id: string }).id, reply);
+      if (!job) return reply;
+      job.status = 'running';
+      job.haltReason = null;
+      job.steps[job.stepIndex].startedAt = now();
+      store.write(job);
+      start(store);
+      return reply.ok(job);
+    });
+
+    app.post('/rebalance/:id/abandon', async (req, reply) => {
+      const store = requireJobs();
+      const job = haltedOr409(store, (req.params as { id: string }).id, reply);
+      if (!job) return reply;
+      job.status = 'abandoned';
+      store.write(job);
+      return reply.ok(job);
+    });
+  };
+}

--- a/src/server/routes/version.ts
+++ b/src/server/routes/version.ts
@@ -58,6 +58,9 @@ export function versionRoutes(deps: AppDeps) {
       if ((deps.engine?.store.listPairs({ activeOnly: true }).length ?? 0) > 0) {
         return refuse('a deal is still working — wait for it to finish, then update', true);
       }
+      if (deps.rebalance?.jobs.read()?.status === 'running') {
+        return refuse('a pay-down is still running — wait for it to finish, then update', true);
+      }
       if (borosExecutionsPending() > 0) {
         return refuse(
           'a Boros order may still be settling — wait a few minutes, then update',

--- a/tests/live/rebalance.test.ts
+++ b/tests/live/rebalance.test.ts
@@ -42,7 +42,7 @@ describe.skipIf(process.env.REBALANCE !== '1')('live rebalance — loop route wi
     jobs.write(job);
     console.log(`  ▸ job ${job.id} written to ${dataDir}`);
 
-    await runJob({ clients: () => clients, jobs, cache: new TtlCache(), now: Date.now, sleep });
+    await runJob({ clients: () => clients, jobs, cache: new TtlCache(), now: Date.now, sleep, log: console.error });
 
     console.log(`  ▸ job ${job.id}: ${job.status}${job.haltReason ? ` (${job.haltReason})` : ''} fundsAt=${job.fundsAt}`);
     for (const step of job.steps) {

--- a/tests/live/rebalance.test.ts
+++ b/tests/live/rebalance.test.ts
@@ -1,0 +1,64 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { CrossexAccountAsset } from 'gate-api';
+import { describe, expect, it } from 'vitest';
+import { TtlCache } from '../../src/server/cache';
+import { JobFile, newJob } from '../../src/server/rebalanceJob';
+import { runJob } from '../../src/server/rebalanceRunner';
+import { budget } from './env';
+import { assertAck, assertCredentials, assertLiveTestsEnabled } from './guards';
+
+const AMOUNT = 12;
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+describe.skipIf(process.env.REBALANCE !== '1')('live rebalance — loop route with 12 USDT', () => {
+  it('buys USDC, moves it to spot, then to Hyperliquid', async () => {
+    assertLiveTestsEnabled();
+    assertAck();
+    const clients = assertCredentials();
+
+    const assets = async (): Promise<CrossexAccountAsset[]> =>
+      (await clients.crossEx.getCrossexAccount()).body.assets ?? [];
+    const row = (list: CrossexAccountAsset[], coin: string, venue: string) =>
+      list.find((a) => a.coin === coin && a.exchangeType === venue);
+
+    const before = await assets();
+    const liability = Number(row(before, 'USDC', 'HYPERLIQUID')?.liability ?? 0);
+    const cash = Number(row(before, 'USDT', 'CROSSEX')?.balance ?? 0);
+    if (!(liability > AMOUNT)) {
+      throw new Error(`USDC/HYPERLIQUID liability ${liability} is not above ${AMOUNT}. Nothing to pay down.`);
+    }
+    if (!(cash > AMOUNT)) {
+      throw new Error(`USDT/CROSSEX balance ${cash} is not above ${AMOUNT}. Not enough cash to buy USDC.`);
+    }
+    const balanceBefore = Number(row(before, 'USDC', 'HYPERLIQUID')?.balance ?? 0);
+
+    budget.beforeOrder(AMOUNT, 'rebalance loop');
+
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rebalance-live-'));
+    const jobs = new JobFile(dataDir);
+    const job = newJob('loop', AMOUNT, Date.now());
+    jobs.write(job);
+    console.log(`  ▸ job ${job.id} written to ${dataDir}`);
+
+    await runJob({ clients: () => clients, jobs, cache: new TtlCache(), now: Date.now, sleep });
+
+    console.log(`  ▸ job ${job.id}: ${job.status}${job.haltReason ? ` (${job.haltReason})` : ''} fundsAt=${job.fundsAt}`);
+    for (const step of job.steps) {
+      console.log(`  ▸ ${step.name}: status=${step.status} venueId=${step.venueId} qty=${step.qty}`);
+    }
+
+    expect(job.status).toBe('done');
+    expect(job.steps).toHaveLength(3);
+    for (const step of job.steps) {
+      expect(step.status).toBe('done');
+      expect(step.venueId).not.toBeNull();
+    }
+
+    const balanceAfter = Number(row(await assets(), 'USDC', 'HYPERLIQUID')?.balance ?? 0);
+    const landed = job.steps[2].qty ?? 0;
+    console.log(`  ▸ USDC/HYPERLIQUID balance ${balanceBefore} → ${balanceAfter} (step 3 qty ${landed})`);
+    expect(Math.abs(balanceAfter - balanceBefore - landed)).toBeLessThanOrEqual(0.01);
+  }, 400_000);
+});

--- a/tests/live/rebalance.test.ts
+++ b/tests/live/rebalance.test.ts
@@ -5,14 +5,17 @@ import type { CrossexAccountAsset } from 'gate-api';
 import { describe, expect, it } from 'vitest';
 import { TtlCache } from '../../src/server/cache';
 import { JobFile, newJob } from '../../src/server/rebalanceJob';
-import { runJob } from '../../src/server/rebalanceRunner';
+import { HL_TRANSFER_TIMEOUT_MS, runJob } from '../../src/server/rebalanceRunner';
 import { budget } from './env';
 import { assertAck, assertCredentials, assertLiveTestsEnabled } from './guards';
 
 const AMOUNT = 12;
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
-describe.skipIf(process.env.REBALANCE !== '1')('live rebalance — loop route with 12 USDT', () => {
+const row = (list: CrossexAccountAsset[], coin: string, venue: string) =>
+  list.find((a) => a.coin === coin && a.exchangeType === venue);
+
+describe.skipIf(process.env.REBALANCE !== '1')('live rebalance — 12 USDT down to Hyperliquid, 12 USDC back', () => {
   it('buys USDC, moves it to spot, then to Hyperliquid', async () => {
     assertLiveTestsEnabled();
     assertAck();
@@ -20,8 +23,6 @@ describe.skipIf(process.env.REBALANCE !== '1')('live rebalance — loop route wi
 
     const assets = async (): Promise<CrossexAccountAsset[]> =>
       (await clients.crossEx.getCrossexAccount()).body.assets ?? [];
-    const row = (list: CrossexAccountAsset[], coin: string, venue: string) =>
-      list.find((a) => a.coin === coin && a.exchangeType === venue);
 
     const before = await assets();
     const liability = Number(row(before, 'USDC', 'HYPERLIQUID')?.liability ?? 0);
@@ -38,7 +39,7 @@ describe.skipIf(process.env.REBALANCE !== '1')('live rebalance — loop route wi
 
     const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rebalance-live-'));
     const jobs = new JobFile(dataDir);
-    const job = newJob('loop', AMOUNT, Date.now());
+    const job = newJob('payDown', 'loop', AMOUNT, Date.now());
     jobs.write(job);
     console.log(`  ▸ job ${job.id} written to ${dataDir}`);
 
@@ -61,4 +62,49 @@ describe.skipIf(process.env.REBALANCE !== '1')('live rebalance — loop route wi
     console.log(`  ▸ USDC/HYPERLIQUID balance ${balanceBefore} → ${balanceAfter} (step 3 qty ${landed})`);
     expect(Math.abs(balanceAfter - balanceBefore - landed)).toBeLessThanOrEqual(0.01);
   }, 400_000);
+
+  it('pull: moves USDC from Hyperliquid to spot, then to Gate, then sells it for USDT', async (ctx) => {
+    assertLiveTestsEnabled();
+    assertAck();
+    const clients = assertCredentials();
+
+    const assets = async (): Promise<CrossexAccountAsset[]> =>
+      (await clients.crossEx.getCrossexAccount()).body.assets ?? [];
+
+    const before = await assets();
+    const usdc = row(before, 'USDC', 'HYPERLIQUID');
+    const cap = Math.min(Number(usdc?.availableBalance ?? 0), Number(usdc?.equity ?? 0));
+    if (!(cap >= AMOUNT)) {
+      ctx.skip(`USDC/HYPERLIQUID pull cap ${cap} is below ${AMOUNT} USDC. Nothing to pull.`);
+    }
+    const cashBefore = Number(row(before, 'USDT', 'CROSSEX')?.balance ?? 0);
+
+    budget.beforeOrder(AMOUNT, 'rebalance pull');
+
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rebalance-live-'));
+    const jobs = new JobFile(dataDir);
+    const job = newJob('pull', 'loop', AMOUNT, Date.now());
+    jobs.write(job);
+    console.log(`  ▸ job ${job.id} written to ${dataDir}`);
+
+    await runJob({ clients: () => clients, jobs, cache: new TtlCache(), now: Date.now, sleep, log: console.error });
+
+    console.log(`  ▸ job ${job.id}: ${job.status}${job.haltReason ? ` (${job.haltReason})` : ''} fundsAt=${job.fundsAt}`);
+    for (const step of job.steps) {
+      console.log(`  ▸ ${step.name}: status=${step.status} venueId=${step.venueId} qty=${step.qty}`);
+    }
+
+    expect(job.status).toBe('done');
+    expect(job.fundsAt).toBe('CROSSEX');
+    expect(job.steps).toHaveLength(3);
+    for (const step of job.steps) {
+      expect(step.status).toBe('done');
+      expect(step.venueId).not.toBeNull();
+    }
+
+    const cashAfter = Number(row(await assets(), 'USDT', 'CROSSEX')?.balance ?? 0);
+    const sold = job.steps[2].qty ?? 0;
+    console.log(`  ▸ USDT/CROSSEX balance ${cashBefore} → ${cashAfter} (step 3 qty ${sold})`);
+    expect(Math.abs(cashAfter - cashBefore - sold)).toBeLessThanOrEqual(0.01);
+  }, HL_TRANSFER_TIMEOUT_MS + 200_000);
 });

--- a/tests/server/credentials-put.test.ts
+++ b/tests/server/credentials-put.test.ts
@@ -9,6 +9,7 @@ import type { FastifyInstance } from 'fastify';
 import nock from 'nock';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { makeClients, type Clients } from '../../src/core/clients';
+import { JobFile, newJob } from '../../src/server/rebalanceJob';
 import { rewriteEnvFile } from '../../src/server/routes/credentials';
 import { Store } from '../../src/engine/db';
 import { gateVenue } from '../../src/engine/venueGate';
@@ -130,6 +131,24 @@ describe('PUT /api/credentials', () => {
     gate().get('/api/v4/crossex/accounts').query(true).reply(200, fixture('account.json'));
     const ok = await put({ key: NEW_KEY, secret: NEW_SECRET });
     expect(ok.statusCode).toBe(200);
+  });
+
+  it('refuses with 409 while a pay-down is still running', async () => {
+    await app.close();
+    const jobs = new JobFile(mkdtempSync(path.join(tmpdir(), 'rebalance-')));
+    app = makeTestApp({
+      getClients: () => current,
+      credentials: { envPath, setClients: (c) => (current = c) },
+      rebalance: { jobs },
+    });
+    await app.ready();
+    jobs.write(newJob('loop', 12, Date.now()));
+
+    const res = await put({ key: NEW_KEY, secret: NEW_SECRET });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toMatch(/pay-down is still running/);
+    expect(readFileSync(envPath, 'utf8')).toContain(`GATE_API_KEY=${TEST_KEY}`);
   });
 
   it('validates the body shape', async () => {

--- a/tests/server/credentials-put.test.ts
+++ b/tests/server/credentials-put.test.ts
@@ -142,7 +142,7 @@ describe('PUT /api/credentials', () => {
       rebalance: { jobs },
     });
     await app.ready();
-    jobs.write(newJob('loop', 12, Date.now()));
+    jobs.write(newJob('payDown', 'loop', 12, Date.now()));
 
     const res = await put({ key: NEW_KEY, secret: NEW_SECRET });
 

--- a/tests/server/rebalance-job.test.ts
+++ b/tests/server/rebalance-job.test.ts
@@ -1,0 +1,507 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import nock from 'nock';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { makeClients } from '../../src/core/clients';
+import { Store } from '../../src/engine/db';
+import { gateVenue } from '../../src/engine/venueGate';
+import { newJob, type Job, type Step } from '../../src/server/rebalanceJob';
+import { LOOKUP_RETRY_MS, STEP_TIMEOUT_MS, tagFor } from '../../src/server/rebalanceRunner';
+import { gate, HOST, makeTestApp, mockGateGet, mockGatePost, TEST_KEY, TEST_SECRET } from './helpers/gate-nock';
+
+const API = '/api/v4';
+const AMOUNT = 300;
+const BOUGHT = '299.97';
+
+let t: number;
+let hold: Promise<void> | null;
+let apps: FastifyInstance[];
+
+const sleep = async (ms: number): Promise<void> => {
+  t += ms;
+  if (hold) await hold;
+};
+
+beforeEach(() => {
+  t = Date.now();
+  hold = null;
+  apps = [];
+});
+
+afterEach(async () => {
+  await reset();
+});
+
+async function reset(): Promise<void> {
+  for (const app of apps) await app.close();
+  apps = [];
+  nock.cleanAll();
+}
+
+async function waitFor(pred: () => boolean, what: string, ms = 5000): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!pred()) {
+    if (Date.now() > deadline) throw new Error(`${what} did not happen within ${ms} ms`);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function boot(over: { store?: Store; sleep?: (ms: number) => Promise<void>; job?: Job } = {}) {
+  const dataDir = mkdtempSync(path.join(tmpdir(), 'rebalance-'));
+  if (over.job) writeFileSync(path.join(dataDir, 'rebalance.json'), JSON.stringify(over.job));
+  const getClients = () => makeClients({ key: TEST_KEY, secret: TEST_SECRET });
+  const app = makeTestApp({
+    getClients,
+    rebalance: { dataDir, sleep: over.sleep ?? sleep },
+    engine: { store: over.store ?? new Store(':memory:'), venue: gateVenue(getClients), clock: { now: () => t } },
+  });
+  apps.push(app);
+  return {
+    file: () => JSON.parse(readFileSync(path.join(dataDir, 'rebalance.json'), 'utf8')) as Job,
+    post: (url = '/api/rebalance') => app.inject({ method: 'POST', url, headers: HOST, payload: {} }),
+    view: async () => (await app.inject({ method: 'GET', url: '/api/rebalance', headers: HOST })).json(),
+  };
+}
+
+const asset = (coin: string, venue: string, over: Record<string, string> = {}) => ({
+  coin,
+  exchange_type: venue,
+  balance: '0',
+  upnl: '0',
+  equity: '0',
+  liability: '0',
+  borrowing_initial_margin: '0',
+  ...over,
+});
+
+const account = (usdcOnHl: Record<string, string> = { equity: '-300', liability: '300', borrowing_initial_margin: '30' }) => ({
+  user_id: '1',
+  available_margin: '900',
+  margin_balance: '900',
+  account_mode: 'CROSS_EXCHANGE',
+  assets: [asset('USDT', 'CROSSEX', { balance: '1200', equity: '1200' }), asset('USDC', 'HYPERLIQUID', usdcOnHl), asset('USDC', 'GATE')],
+});
+
+function mockView(opts: { ask?: string; account?: unknown; disabled?: number } = {}): void {
+  gate().persist().get(`${API}/crossex/accounts`).query(true).reply(200, opts.account ?? account());
+  mockGateGet('/interest_rate', {
+    body: [{ coin: 'USDC', exchange_type: 'HYPERLIQUID', hour_interest_rate: '0.000005', time: String(t) }],
+  });
+  mockGateGet('/history_margin_interests', {
+    body: [{ liability_coin: 'USDC', exchange_type: 'HYPERLIQUID', interest: '0.01', create_time: String(t - 1000) }],
+  });
+  mockGateGet('/transfers/coin', {
+    body: [{ coin: 'USDC', min_trans_amount: 11, est_fee: 0.05, precision: 5, is_disabled: opts.disabled ?? 0 }],
+  });
+  mockGateGet('/rule/symbols', {
+    body: [{ symbol: 'GATE_SPOT_USDC_USDT', exchange_type: 'GATE', business_type: 'SPOT', state: 'live' }],
+  });
+  mockGateGet('/fee', { fixture: 'fee.json' });
+  gate()
+    .persist()
+    .get(`${API}/spot/tickers`)
+    .query(true)
+    .reply(200, [{ currency_pair: 'USDC_USDT', lowest_ask: opts.ask ?? '1.0001', highest_bid: '1', last: '1' }]);
+}
+
+const orderBody = (state: string, executedQty: string, orderId = 'o1') => ({
+  order_id: orderId,
+  text: 't',
+  state,
+  executed_qty: executedQty,
+});
+const transferRow = (id: string, status: string, over: Record<string, string> = {}) => ({
+  id,
+  status,
+  coin: 'USDC',
+  amount: '299.97000',
+  ...over,
+});
+const quoteBody = (quoteId: string, toAmount: string) => ({
+  quote_id: quoteId,
+  valid_ms: '5000',
+  from_coin: 'USDT',
+  to_coin: 'USDC',
+  from_amount: String(AMOUNT),
+  to_amount: toAmount,
+  price: '0.998',
+});
+
+function mockLoopAfterBuy(): nock.Scope {
+  const poll = mockGateGet('/orders/o1', { body: orderBody('FILLED', BOUGHT) });
+  mockGatePost('/transfers', { body: { tx_id: 'x1', text: 't' } });
+  mockGateGet('/transfers', { body: [transferRow('x1', 'SUCCESS', { actual_receive: BOUGHT })] });
+  mockGatePost('/transfers', { body: { tx_id: 'x2', text: 't' } });
+  mockGateGet('/transfers', { body: [transferRow('x1', 'SUCCESS'), transferRow('x2', 'PENDING')] });
+  mockGateGet('/transfers', {
+    body: [transferRow('x1', 'SUCCESS'), transferRow('x2', 'SUCCESS', { actual_receive: '299.92' })],
+  });
+  return poll;
+}
+
+function haltedLoopJob(stepIndex: number, patch: Partial<Step> = {}): Job {
+  const job = newJob('loop', AMOUNT, t);
+  job.status = 'halted';
+  job.haltReason = 'server restarted';
+  job.stepIndex = stepIndex;
+  job.fundsAt = (['CROSSEX', 'GATE', 'SPOT'] as const)[stepIndex];
+  const venueIds = ['o1', 'x1'];
+  for (let i = 0; i < stepIndex; i += 1) {
+    Object.assign(job.steps[i], {
+      text: tagFor(job.id, i),
+      venueId: venueIds[i],
+      qty: Number(BOUGHT),
+      status: 'done',
+      startedAt: t,
+      doneAt: t,
+    });
+  }
+  Object.assign(job.steps[stepIndex], { text: tagFor(job.id, stepIndex), status: 'running', startedAt: t, ...patch });
+  return job;
+}
+
+function holdRunner(): () => void {
+  let release: () => void = () => undefined;
+  hold = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return release;
+}
+
+const busyDeal = () => {
+  const store = new Store(':memory:');
+  store.createPair({
+    id: 'deal-409',
+    mode: 'OPENING',
+    a: { contract: 'GATE_FUTURE_ETH_USDT', side: 'BUY', lot: '0.001', minSize: '0', minNotional: '0', tick: '0.01' },
+    b: null,
+    targetQty: '0.05',
+    limitPrice: '2500',
+    pricePolicy: 'fixed',
+    deadlineAt: null,
+    makerNotBefore: 0,
+    hedgeNotBefore: 0,
+    pocRejects: 0,
+    hedgeRejectStreak: 0,
+    maxClip: null,
+    clipBandBp: null,
+    haltReason: null,
+    reportJson: null,
+    createdAt: Date.now(),
+  });
+  return store;
+};
+
+describe('POST /api/rebalance', () => {
+  it('starts: 202 with the id, rebalance.json running, and the order POST leaves within 2 s', async () => {
+    const release = holdRunner();
+    mockView();
+    const orders = mockGatePost('/orders', { body: orderBody('OPEN', '0') });
+    mockGateGet('/orders/o1', { body: orderBody('OPEN', '0') });
+    mockGateGet('/orders/o1', { body: orderBody('REJECT', '0') });
+    const h = boot();
+
+    const res = await h.post();
+
+    expect(res.statusCode).toBe(202);
+    const { id } = res.json().data;
+    expect(id).toBeTypeOf('string');
+    expect(h.file()).toMatchObject({ id, status: 'running', route: 'loop', amount: AMOUNT, stepIndex: 0 });
+    await waitFor(() => orders.isDone(), 'the order POST', 2000);
+    expect(h.file().status).toBe('running');
+
+    release();
+    await waitFor(() => h.file().status === 'halted', 'the halt');
+  });
+
+  it('refuses: 409 for a running job, a working deal, no route, and one of two concurrent POSTs', async () => {
+    mockView();
+    let h = boot({ store: busyDeal() });
+    let res = await h.post();
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toEqual({
+      ok: false,
+      error: { category: 'validation', message: 'deal deal-409 is still working', retryable: true },
+    });
+
+    await reset();
+    mockView({ disabled: 1, account: account({ equity: '0', liability: '0' }) });
+    h = boot();
+    res = await h.post();
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toBe('no route');
+
+    await reset();
+    const release = holdRunner();
+    mockView();
+    const orders = mockGatePost('/orders', { body: orderBody('OPEN', '0') });
+    mockGateGet('/orders/o1', { body: orderBody('OPEN', '0') });
+    mockGateGet('/orders/o1', { body: orderBody('REJECT', '0') });
+    h = boot();
+    const [first, second] = await Promise.all([h.post(), h.post()]);
+    expect([first.statusCode, second.statusCode].sort()).toEqual([202, 409]);
+    const { id } = h.file();
+    const refused = first.statusCode === 409 ? first : second;
+    expect(refused.json().error.message).toBe(`rebalance ${id} is running`);
+    res = await h.post();
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toBe(`rebalance ${id} is running`);
+    await waitFor(() => orders.isDone(), 'the order POST', 2000);
+    expect(orders.isDone()).toBe(true);
+
+    release();
+    await waitFor(() => h.file().status === 'halted', 'the halt');
+    res = await h.post();
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toBe(`rebalance ${id} is halted`);
+  });
+
+  it('completes loop: three steps done with venue ids within 5 s of the last SUCCESS', async () => {
+    mockView();
+    const orders = mockGatePost('/orders', { body: orderBody('OPEN', '0') });
+    mockLoopAfterBuy();
+    const h = boot();
+
+    const res = await h.post();
+    expect(res.statusCode).toBe(202);
+    await waitFor(() => h.file().status === 'done', 'done');
+
+    const { job } = (await h.view()).data;
+    expect(job).toMatchObject({ status: 'done', route: 'loop', amount: AMOUNT, stepIndex: 2, fundsAt: 'HYPERLIQUID', haltReason: null });
+    expect(job.steps.map((s: Step) => s.name)).toEqual(['Buy USDC', 'To spot', 'To Hyperliquid']);
+    expect(job.steps.map((s: Step) => s.status)).toEqual(['done', 'done', 'done']);
+    expect(job.steps.map((s: Step) => s.venueId)).toEqual(['o1', 'x1', 'x2']);
+    expect(job.steps.map((s: Step) => s.qty)).toEqual([299.97, 299.97, 299.92]);
+    for (const step of job.steps as Step[]) {
+      expect(step.startedAt).toBeTypeOf('number');
+      expect(step.doneAt).toBeTypeOf('number');
+      expect(step.text).toBe(tagFor(job.id, job.steps.indexOf(step)));
+    }
+    expect(orders.isDone()).toBe(true);
+    expect(nock.pendingMocks()).toEqual([]);
+  });
+
+  it('convert: quotes and sends when convert is cheaper; halted below the floor with no order sent', async () => {
+    mockView({ ask: '1.003' });
+    const quotes = mockGatePost('/convert/quote', { body: quoteBody('q1', '299.4') });
+    const orders = mockGatePost('/convert/orders', { body: { order_id: 'c1', text: 'q1' } });
+    let h = boot();
+
+    let res = await h.post();
+    expect(res.statusCode).toBe(202);
+    await waitFor(() => h.file().status === 'done', 'done');
+
+    let { job } = (await h.view()).data;
+    expect(job).toMatchObject({ status: 'done', route: 'convert', amount: AMOUNT, fundsAt: 'HYPERLIQUID' });
+    expect(job.steps).toHaveLength(1);
+    expect(job.steps[0]).toMatchObject({
+      name: 'Convert',
+      text: tagFor(job.id, 0),
+      quoteId: 'q1',
+      venueId: 'c1',
+      qty: 299.4,
+      balanceBefore: 0,
+      status: 'done',
+    });
+    expect(quotes.isDone()).toBe(true);
+    expect(orders.isDone()).toBe(true);
+
+    await reset();
+    mockView({ ask: '1.003' });
+    mockGatePost('/convert/quote', { body: quoteBody('q2', '299.0') });
+    const unsent = mockGatePost('/convert/orders', { body: { order_id: 'c2', text: 'q2' } });
+    h = boot();
+
+    res = await h.post();
+    expect(res.statusCode).toBe(202);
+    await waitFor(() => h.file().status === 'halted', 'the halt');
+
+    job = (await h.view()).data.job;
+    expect(job).toMatchObject({ status: 'halted', haltReason: 'quote worse than 30 bps', fundsAt: 'CROSSEX' });
+    expect(job.steps[0]).toMatchObject({ quoteId: null, venueId: null, status: 'running' });
+    expect(unsent.isDone()).toBe(false);
+  });
+
+  it('halts: on a rejected order, a failed transfer, a labelled 400 at send, and a 600 s timeout', async () => {
+    mockView();
+    mockGatePost('/orders', { body: orderBody('OPEN', '0') });
+    mockGateGet('/orders/o1', { body: orderBody('REJECT', '0') });
+    let h = boot();
+    await h.post();
+    await waitFor(() => h.file().status === 'halted', 'the halt');
+    expect(h.file()).toMatchObject({ haltReason: 'order REJECT with nothing filled', fundsAt: 'CROSSEX', stepIndex: 0 });
+
+    await reset();
+    mockView();
+    mockGatePost('/orders', { body: orderBody('OPEN', '0') });
+    mockGateGet('/orders/o1', { body: orderBody('FILLED', BOUGHT) });
+    mockGatePost('/transfers', { body: { tx_id: 'x1', text: 't' } });
+    mockGateGet('/transfers', { body: [transferRow('x1', 'FAILED', { fail_reason: 'insufficient balance' })] });
+    h = boot();
+    await h.post();
+    await waitFor(() => h.file().status === 'halted', 'the halt');
+    expect(h.file()).toMatchObject({ haltReason: 'insufficient balance', fundsAt: 'GATE', stepIndex: 1 });
+    expect(h.file().steps[0].status).toBe('done');
+
+    await reset();
+    mockView();
+    mockGatePost('/orders', {
+      status: 400,
+      body: { label: 'TRADE_INVALID_QUOTE_ORDER_QTY', message: 'quote qty is required' },
+    });
+    h = boot();
+    await h.post();
+    await waitFor(() => h.file().status === 'halted', 'the halt');
+    expect(h.file().haltReason).toContain('TRADE_INVALID_QUOTE_ORDER_QTY');
+    expect(h.file()).toMatchObject({ fundsAt: 'CROSSEX', stepIndex: 0 });
+    expect(h.file().steps[0].venueId).toBeNull();
+
+    await reset();
+    mockView();
+    mockGatePost('/orders', { body: orderBody('OPEN', '0') });
+    gate().persist().get(`${API}/crossex/orders/o1`).query(true).reply(200, orderBody('OPEN', '0'));
+    h = boot({
+      sleep: async (ms) => {
+        t += ms * 100;
+      },
+    });
+    const startedAt = t;
+    await h.post();
+    await waitFor(() => h.file().status === 'halted', 'the halt');
+    expect(h.file()).toMatchObject({ haltReason: 'timeout', fundsAt: 'CROSSEX' });
+    expect(t - startedAt).toBeGreaterThan(STEP_TIMEOUT_MS);
+  });
+
+  it('halts on boot: a running job in rebalance.json is halted with server restarted before the first GET', async () => {
+    mockView();
+    const job = newJob('loop', AMOUNT, t);
+    Object.assign(job.steps[0], { text: tagFor(job.id, 0), venueId: 'o1', status: 'running', startedAt: t });
+    const h = boot({ job });
+
+    const { data } = await h.view();
+
+    expect(data.job).toMatchObject({ id: job.id, status: 'halted', haltReason: 'server restarted', stepIndex: 0 });
+    expect(data.job.steps[0]).toMatchObject({ venueId: 'o1', status: 'running' });
+    expect(h.file()).toMatchObject({ status: 'halted', haltReason: 'server restarted' });
+  });
+});
+
+describe('POST /api/rebalance/:id/resume and /abandon', () => {
+  it('resume and abandon: resume runs a halted job at its step, abandon ends it, both refuse a done job', async () => {
+    mockView();
+    const job = haltedLoopJob(1, { venueId: 'x1' });
+    mockGateGet('/transfers', { body: [transferRow('x1', 'SUCCESS', { actual_receive: BOUGHT })] });
+    mockGatePost('/transfers', { body: { tx_id: 'x2', text: 't' } });
+    mockGateGet('/transfers', {
+      body: [transferRow('x1', 'SUCCESS'), transferRow('x2', 'SUCCESS', { actual_receive: '299.92' })],
+    });
+    let h = boot({ job });
+
+    let res = await h.post(`/api/rebalance/${job.id}/resume`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data).toMatchObject({ id: job.id, status: 'running', haltReason: null, stepIndex: 1 });
+    expect(res.json().data.steps[1].startedAt).toBe(t);
+    await waitFor(() => h.file().status === 'done', 'done');
+    expect(h.file().steps.map((s) => s.venueId)).toEqual(['o1', 'x1', 'x2']);
+
+    res = await h.post(`/api/rebalance/${job.id}/resume`);
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toBe(`rebalance ${job.id} is done`);
+    res = await h.post(`/api/rebalance/${job.id}/abandon`);
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toBe(`rebalance ${job.id} is done`);
+    res = await h.post('/api/rebalance/nope/resume');
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toBe('unknown rebalance nope');
+
+    await reset();
+    const halted = haltedLoopJob(1, { venueId: 'x1' });
+    h = boot({ job: halted });
+
+    res = await h.post(`/api/rebalance/${halted.id}/abandon`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data).toMatchObject({ id: halted.id, status: 'abandoned', stepIndex: 1 });
+    expect(h.file().status).toBe('abandoned');
+    res = await h.post(`/api/rebalance/${halted.id}/resume`);
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toBe(`rebalance ${halted.id} is abandoned`);
+  });
+
+  it('no double send: a venueId is polled once, a found tag is adopted, a missing tag is sent once after 10 s, a landed quote needs no order', async () => {
+    mockView();
+    let orders = mockGatePost('/orders', { body: orderBody('OPEN', '0') });
+    let poll = mockLoopAfterBuy();
+    let job = haltedLoopJob(0, { venueId: 'o1' });
+    let h = boot({ job });
+    let res = await h.post(`/api/rebalance/${job.id}/resume`);
+    expect(res.statusCode).toBe(200);
+    await waitFor(() => h.file().status === 'done', 'done');
+    expect(poll.isDone()).toBe(true);
+    expect(orders.isDone()).toBe(false);
+    expect(h.file().steps[0].venueId).toBe('o1');
+
+    await reset();
+    mockView();
+    orders = mockGatePost('/orders', { body: orderBody('OPEN', '0') });
+    job = haltedLoopJob(0);
+    const lookup = mockGateGet(`/orders/${tagFor(job.id, 0)}`, { body: orderBody('FILLED', BOUGHT, 'o1') });
+    poll = mockLoopAfterBuy();
+    h = boot({ job });
+    res = await h.post(`/api/rebalance/${job.id}/resume`);
+    expect(res.statusCode).toBe(200);
+    await waitFor(() => h.file().status === 'done', 'done');
+    expect(lookup.isDone()).toBe(true);
+    expect(poll.isDone()).toBe(true);
+    expect(orders.isDone()).toBe(false);
+    expect(h.file().steps[0].venueId).toBe('o1');
+
+    await reset();
+    mockView();
+    job = haltedLoopJob(0);
+    const seen: number[] = [];
+    gate()
+      .get(`${API}/crossex/orders/${tagFor(job.id, 0)}`)
+      .query(true)
+      .times(2)
+      .reply(() => {
+        seen.push(t);
+        return [404, { label: 'ORDER_NOT_FOUND', message: 'order not found' }];
+      });
+    orders = mockGatePost('/orders', { body: orderBody('OPEN', '0') });
+    mockLoopAfterBuy();
+    h = boot({ job });
+    res = await h.post(`/api/rebalance/${job.id}/resume`);
+    expect(res.statusCode).toBe(200);
+    await waitFor(() => h.file().status === 'done', 'done');
+    expect(seen).toHaveLength(2);
+    expect(seen[1] - seen[0]).toBe(LOOKUP_RETRY_MS);
+    expect(orders.isDone()).toBe(true);
+    expect(h.file().steps[0].venueId).toBe('o1');
+
+    await reset();
+    mockView({ account: account({ balance: '399.4', equity: '99.4', liability: '300', borrowing_initial_margin: '30' }) });
+    const quotes = mockGatePost('/convert/quote', { body: quoteBody('q9', '299.4') });
+    const convertOrders = mockGatePost('/convert/orders', { body: { order_id: 'c9', text: 'q9' } });
+    job = newJob('convert', AMOUNT, t);
+    job.status = 'halted';
+    job.haltReason = 'server restarted';
+    Object.assign(job.steps[0], {
+      text: tagFor(job.id, 0),
+      quoteId: 'q1',
+      qty: 299.4,
+      balanceBefore: 100,
+      status: 'running',
+      startedAt: t,
+    });
+    h = boot({ job });
+    res = await h.post(`/api/rebalance/${job.id}/resume`);
+    expect(res.statusCode).toBe(200);
+    await waitFor(() => h.file().status === 'done', 'done');
+    expect(h.file()).toMatchObject({ status: 'done', fundsAt: 'HYPERLIQUID' });
+    expect(h.file().steps[0]).toMatchObject({ quoteId: 'q1', venueId: null, qty: 299.4, status: 'done' });
+    expect(quotes.isDone()).toBe(false);
+    expect(convertOrders.isDone()).toBe(false);
+  });
+});

--- a/tests/server/rebalance-job.test.ts
+++ b/tests/server/rebalance-job.test.ts
@@ -5,8 +5,10 @@ import type { FastifyInstance } from 'fastify';
 import nock from 'nock';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { makeClients } from '../../src/core/clients';
+import { PULL_FEE_USD, PULL_WAIT_SECONDS } from '../../src/core/rebalance/plan';
 import { Store } from '../../src/engine/db';
 import { gateVenue } from '../../src/engine/venueGate';
+import { TtlCache } from '../../src/server/cache';
 import { JobFile, newJob, type Job, type Step } from '../../src/server/rebalanceJob';
 import { LOOKUP_RETRY_MS, STEP_TIMEOUT_MS, tagFor } from '../../src/server/rebalanceRunner';
 import type { AppDeps } from '../../src/server/app';
@@ -50,7 +52,13 @@ async function waitFor(pred: () => boolean, what: string, ms = 5000): Promise<vo
 }
 
 function boot(
-  over: { store?: Store; sleep?: (ms: number) => Promise<void>; job?: Job; credentials?: AppDeps['credentials'] } = {},
+  over: {
+    store?: Store;
+    sleep?: (ms: number) => Promise<void>;
+    job?: Job;
+    credentials?: AppDeps['credentials'];
+    cache?: TtlCache;
+  } = {},
 ) {
   const dataDir = mkdtempSync(path.join(tmpdir(), 'rebalance-'));
   if (over.job) writeFileSync(path.join(dataDir, 'rebalance.json'), JSON.stringify(over.job));
@@ -60,13 +68,14 @@ function boot(
     rebalance: { jobs: new JobFile(dataDir), sleep: over.sleep ?? sleep },
     engine: { store: over.store ?? new Store(':memory:'), venue: gateVenue(getClients), clock: { now: () => t } },
     credentials: over.credentials,
+    ...(over.cache ? { cache: over.cache } : {}),
   });
   apps.push(app);
   return {
     file: () => JSON.parse(readFileSync(path.join(dataDir, 'rebalance.json'), 'utf8')) as Job,
     post: (url = '/api/rebalance', payload: Record<string, unknown> = {}) =>
       app.inject({ method: 'POST', url, headers: HOST, payload }),
-    view: async () => (await app.inject({ method: 'GET', url: '/api/rebalance', headers: HOST })).json(),
+    view: async (query = '') => (await app.inject({ method: 'GET', url: `/api/rebalance${query}`, headers: HOST })).json(),
   };
 }
 
@@ -147,7 +156,7 @@ function mockLoopAfterBuy(): nock.Scope {
 }
 
 function haltedLoopJob(stepIndex: number, patch: Partial<Step> = {}): Job {
-  const job = newJob('loop', AMOUNT, t);
+  const job = newJob('payDown', 'loop', AMOUNT, t);
   job.status = 'halted';
   job.haltReason = 'server restarted';
   job.stepIndex = stepIndex;
@@ -166,6 +175,16 @@ function haltedLoopJob(stepIndex: number, patch: Partial<Step> = {}): Job {
   Object.assign(job.steps[stepIndex], { text: tagFor(job.id, stepIndex), status: 'running', startedAt: t, ...patch });
   return job;
 }
+
+const PULL_AMOUNT = 12;
+
+const pullAccount = () => account({ balance: '50', available_balance: '50', equity: '50', liability: '0' });
+
+const isTransfer = (b: Record<string, unknown>, from: string, to: string, amount: string): boolean =>
+  b.coin === 'USDC' && b.from === from && b.to === to && b.amount === amount && typeof b.text === 'string';
+
+const isSell = (b: Record<string, unknown>): boolean =>
+  b.symbol === 'GATE_SPOT_USDC_USDT' && b.side === 'SELL' && b.type === 'MARKET' && b.qty === '11.00' && !('quote_qty' in b);
 
 function holdRunner(): () => void {
   let release: () => void = () => undefined;
@@ -242,7 +261,7 @@ describe('POST /api/rebalance', () => {
   });
 
   it('refuses: 409 for a running job, a working deal, no route, a changed plan, and one of two concurrent POSTs; 403 before the disclaimer', async () => {
-    const stored = newJob('loop', AMOUNT, t);
+    const stored = newJob('payDown', 'loop', AMOUNT, t);
     let h = boot({ job: stored });
     let res = await h.post();
     expect(res.statusCode).toBe(409);
@@ -315,7 +334,15 @@ describe('POST /api/rebalance', () => {
     await waitFor(() => h.file().status === 'done', 'done');
 
     const { job } = (await h.view()).data;
-    expect(job).toMatchObject({ status: 'done', route: 'loop', amount: AMOUNT, stepIndex: 2, fundsAt: 'HYPERLIQUID', haltReason: null });
+    expect(job).toMatchObject({
+      direction: 'payDown',
+      status: 'done',
+      route: 'loop',
+      amount: AMOUNT,
+      stepIndex: 2,
+      fundsAt: 'HYPERLIQUID',
+      haltReason: null,
+    });
     expect(job.steps.map((s: Step) => s.name)).toEqual(['Buy USDC', 'To spot', 'To Hyperliquid']);
     expect(job.steps.map((s: Step) => s.status)).toEqual(['done', 'done', 'done']);
     expect(job.steps.map((s: Step) => s.venueId)).toEqual(['o1', 'x1', 'x2']);
@@ -423,7 +450,7 @@ describe('POST /api/rebalance', () => {
 
   it('halts on boot: a running job in rebalance.json is halted with server restarted before the first GET', async () => {
     mockView();
-    const job = newJob('loop', AMOUNT, t);
+    const job = newJob('payDown', 'loop', AMOUNT, t);
     Object.assign(job.steps[0], { text: tagFor(job.id, 0), venueId: 'o1', status: 'running', startedAt: t });
     const h = boot({ job });
 
@@ -432,6 +459,176 @@ describe('POST /api/rebalance', () => {
     expect(data.job).toMatchObject({ id: job.id, status: 'halted', haltReason: 'server restarted', stepIndex: 0 });
     expect(data.job.steps[0]).toMatchObject({ venueId: 'o1', status: 'running' });
     expect(h.file()).toMatchObject({ status: 'halted', haltReason: 'server restarted' });
+  });
+
+  it('pull: 202 with direction pull, two transfers then a market sell sized by what landed, qty from executedAmount, funds at CROSSEX', async () => {
+    const cache = new TtlCache();
+    mockView({ account: pullAccount() });
+    const pulls = gate()
+      .post(`${API}/crossex/transfers`, (b) => isTransfer(b, 'CROSSEX_HYPERLIQUID', 'SPOT', '12.00000'))
+      .query(true)
+      .reply(200, { tx_id: 'p1', text: 't' });
+    mockGateGet('/transfers', { body: [transferRow('p1', 'PENDING', { amount: '12.00000' })] });
+    mockGateGet('/transfers', { body: [transferRow('p1', 'SUCCESS', { amount: '12.00000', actual_receive: '11' })] });
+    const toGate = gate()
+      .post(`${API}/crossex/transfers`, (b) => isTransfer(b, 'SPOT', 'CROSSEX_GATE', '11.00000'))
+      .query(true)
+      .reply(200, { tx_id: 'p2', text: 't' });
+    mockGateGet('/transfers', {
+      body: [
+        transferRow('p1', 'SUCCESS', { amount: '12.00000', actual_receive: '11' }),
+        transferRow('p2', 'SUCCESS', { amount: '11.00000', actual_receive: '11' }),
+      ],
+    });
+    const sells = gate()
+      .post(`${API}/crossex/orders`, isSell)
+      .query(true)
+      .reply(200, orderBody('OPEN', '0', 's1'));
+    mockGateGet('/orders/s1', { body: orderBody('OPEN', '0', 's1') });
+    mockGateGet('/orders/s1', { body: { ...orderBody('FILLED', '11', 's1'), executed_amount: '10.9989' } });
+    let h = boot({ cache });
+
+    const before = (await h.view('?direction=pull&amount=12')).data;
+    expect(before.plan).toMatchObject({
+      direction: 'pull',
+      amount: PULL_AMOUNT,
+      route: 'loop',
+      price: 1,
+      receives: 10.98,
+      borrowAfterUsd: 0,
+      shortfall: null,
+      savesPerDayUsd: 0,
+      marginFreedUsd: 0,
+    });
+    expect(before.plan.routes.loop).toMatchObject({ waitSeconds: PULL_WAIT_SECONDS, available: true, reason: null });
+    expect(before.plan.routes.loop.costUsd).toBeCloseTo(PULL_AMOUNT * 0.001 + PULL_FEE_USD, 9);
+    expect(before.plan.routes.convert).toMatchObject({ available: false, reason: 'convert runs one way only' });
+    expect(before.job).toBeNull();
+
+    const res = await h.post('/api/rebalance', { direction: 'pull', amount: PULL_AMOUNT, route: 'loop' });
+    expect(res.statusCode).toBe(202);
+    expect(h.file()).toMatchObject({
+      id: res.json().data.id,
+      direction: 'pull',
+      route: 'loop',
+      amount: PULL_AMOUNT,
+      status: 'running',
+      fundsAt: 'HYPERLIQUID',
+    });
+    expect(h.file().steps.map((s) => s.name)).toEqual(['Pull from Hyperliquid', 'To Gate', 'Sell USDC']);
+    await waitFor(() => h.file().status === 'done', 'done');
+
+    expect(pulls.isDone()).toBe(true);
+    expect(toGate.isDone()).toBe(true);
+    expect(sells.isDone()).toBe(true);
+    const { value } = await cache.get('account', 60_000, async () => 'fresh');
+    expect(value).toBe('fresh');
+
+    const { job } = (await h.view()).data;
+    expect(job).toMatchObject({ direction: 'pull', status: 'done', stepIndex: 2, fundsAt: 'CROSSEX', haltReason: null });
+    expect(job.steps.map((s: Step) => s.status)).toEqual(['done', 'done', 'done']);
+    expect(job.steps.map((s: Step) => s.venueId)).toEqual(['p1', 'p2', 's1']);
+    expect(job.steps.map((s: Step) => s.qty)).toEqual([11, 11, 10.9989]);
+    for (const step of job.steps as Step[]) {
+      expect(step.text).toBe(tagFor(job.id, job.steps.indexOf(step)));
+      expect(step.doneAt).toBeTypeOf('number');
+    }
+    expect(nock.pendingMocks()).toEqual([]);
+
+    await reset();
+    mockView();
+    h = boot();
+    const empty = (await h.view('?direction=pull')).data.plan;
+    expect(empty).toMatchObject({ direction: 'pull', amount: 0, route: null, receives: 0, price: null });
+    expect(empty.routes.loop).toMatchObject({ available: false, reason: 'nothing to move' });
+    expect(empty.routes.convert).toMatchObject({ available: false, reason: 'convert runs one way only' });
+    const refused = await h.post('/api/rebalance', { direction: 'pull' });
+    expect(refused.statusCode).toBe(409);
+    expect(refused.json().error.message).toBe('no route');
+  });
+
+  it('pull halts and resumes like pay-down: a FAILED pull halts with funds at HYPERLIQUID, abandon ends it, and a resumed Sell USDC with a tag only adopts the order and sends nothing', async () => {
+    mockView({ account: pullAccount() });
+    mockGatePost('/transfers', { body: { tx_id: 'p1', text: 't' } });
+    mockGateGet('/transfers', { body: [transferRow('p1', 'FAILED', { amount: '12.00000', fail_reason: 'withdraw paused' })] });
+    let h = boot();
+    let res = await h.post('/api/rebalance', { direction: 'pull', amount: PULL_AMOUNT });
+    expect(res.statusCode).toBe(202);
+    await waitFor(() => h.file().status === 'halted', 'the halt');
+    expect(h.file()).toMatchObject({ direction: 'pull', haltReason: 'withdraw paused', fundsAt: 'HYPERLIQUID', stepIndex: 0 });
+    expect(h.file().steps[0]).toMatchObject({ name: 'Pull from Hyperliquid', venueId: null, text: null, status: 'running' });
+    const { id } = h.file();
+    res = await h.post(`/api/rebalance/${id}/abandon`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data).toMatchObject({ id, direction: 'pull', status: 'abandoned' });
+
+    await reset();
+    mockView({ account: pullAccount() });
+    const job = newJob('pull', 'loop', PULL_AMOUNT, t);
+    job.status = 'halted';
+    job.haltReason = 'server restarted';
+    job.stepIndex = 2;
+    job.fundsAt = 'GATE';
+    for (const i of [0, 1]) {
+      Object.assign(job.steps[i], {
+        text: tagFor(job.id, i),
+        venueId: `p${i + 1}`,
+        qty: 11,
+        status: 'done',
+        startedAt: t,
+        doneAt: t,
+      });
+    }
+    Object.assign(job.steps[2], { text: tagFor(job.id, 2), status: 'running', startedAt: t });
+    const lookup = mockGateGet(`/orders/${tagFor(job.id, 2)}`, {
+      body: { ...orderBody('FILLED', '11', 's1'), executed_amount: '10.9989' },
+    });
+    const poll = mockGateGet('/orders/s1', { body: { ...orderBody('FILLED', '11', 's1'), executed_amount: '10.9989' } });
+    const sells = mockGatePost('/orders', { body: orderBody('OPEN', '0', 's1') });
+    h = boot({ job });
+
+    res = await h.post(`/api/rebalance/${job.id}/resume`);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data).toMatchObject({ id: job.id, direction: 'pull', status: 'running', stepIndex: 2 });
+    await waitFor(() => h.file().status === 'done', 'done');
+    expect(lookup.isDone()).toBe(true);
+    expect(poll.isDone()).toBe(true);
+    expect(sells.isDone()).toBe(false);
+    expect(h.file()).toMatchObject({ status: 'done', fundsAt: 'CROSSEX' });
+    expect(h.file().steps[2]).toMatchObject({ name: 'Sell USDC', venueId: 's1', qty: 10.9989, status: 'done' });
+  });
+});
+
+describe('GET /api/rebalance', () => {
+  it('amount param: caps plan.amount at the query amount, floors it, ignores a bad value, and carries price, receives, borrowAfterUsd', async () => {
+    mockView();
+    const h = boot();
+    const planAt = async (query: string) => (await h.view(query)).data.plan;
+
+    const full = await planAt('');
+    expect(full).toMatchObject({ direction: 'payDown', amount: AMOUNT, route: 'loop', price: 1.0001, receives: 299.62 });
+    expect(full.borrowAfterUsd).toBeCloseTo(0.38, 9);
+
+    const capped = await planAt('?amount=100.005');
+    expect(capped).toMatchObject({ direction: 'payDown', amount: 100, route: 'loop', price: 1.0001, receives: 99.84 });
+    expect(capped.borrowAfterUsd).toBeCloseTo(200.16, 9);
+
+    expect((await planAt('?amount=5000')).amount).toBe(AMOUNT);
+    expect((await planAt('?amount=abc')).amount).toBe(AMOUNT);
+    expect((await planAt('?amount=0')).amount).toBe(AMOUNT);
+    expect((await planAt('?direction=payDown&amount=50')).amount).toBe(50);
+  });
+
+  it('old job file: a rebalance.json without direction reads as payDown and is written back with it', async () => {
+    mockView();
+    const { direction: _direction, ...legacy } = newJob('payDown', 'loop', AMOUNT, t);
+    const h = boot({ job: legacy as Job });
+
+    const { data } = await h.view();
+
+    expect(data.job).toMatchObject({ id: legacy.id, direction: 'payDown', status: 'halted', haltReason: 'server restarted' });
+    expect(data.job.steps.map((s: Step) => s.name)).toEqual(['Buy USDC', 'To spot', 'To Hyperliquid']);
+    expect(h.file().direction).toBe('payDown');
   });
 });
 
@@ -533,7 +730,7 @@ describe('POST /api/rebalance/:id/resume and /abandon', () => {
     mockView({ account: account({ balance: '399.4', equity: '99.4', liability: '300', borrowing_initial_margin: '30' }) });
     const quotes = mockGatePost('/convert/quote', { body: quoteBody('q9', '299.4') });
     const convertOrders = mockGatePost('/convert/orders', { body: { order_id: 'c9', text: 'q9' } });
-    job = newJob('convert', AMOUNT, t);
+    job = newJob('payDown', 'convert', AMOUNT, t);
     job.status = 'halted';
     job.haltReason = 'server restarted';
     Object.assign(job.steps[0], {

--- a/tests/server/rebalance-job.test.ts
+++ b/tests/server/rebalance-job.test.ts
@@ -502,7 +502,7 @@ describe('POST /api/rebalance', () => {
     });
     expect(before.plan.routes.loop).toMatchObject({ waitSeconds: PULL_WAIT_SECONDS, available: true, reason: null });
     expect(before.plan.routes.loop.costUsd).toBeCloseTo(PULL_AMOUNT * 0.001 + PULL_FEE_USD, 9);
-    expect(before.plan.routes.convert).toMatchObject({ available: false, reason: 'convert runs one way only' });
+    expect(before.plan.routes.convert).toMatchObject({ available: false, reason: 'Convert runs only from USDT to USDC.' });
     expect(before.job).toBeNull();
 
     const res = await h.post('/api/rebalance', { direction: 'pull', amount: PULL_AMOUNT, route: 'loop' });
@@ -541,7 +541,7 @@ describe('POST /api/rebalance', () => {
     const empty = (await h.view('?direction=pull')).data.plan;
     expect(empty).toMatchObject({ direction: 'pull', amount: 0, route: null, receives: 0, price: null });
     expect(empty.routes.loop).toMatchObject({ available: false, reason: 'nothing to move' });
-    expect(empty.routes.convert).toMatchObject({ available: false, reason: 'convert runs one way only' });
+    expect(empty.routes.convert).toMatchObject({ available: false, reason: 'Convert runs only from USDT to USDC.' });
     const refused = await h.post('/api/rebalance', { direction: 'pull' });
     expect(refused.statusCode).toBe(409);
     expect(refused.json().error.message).toBe('no route');

--- a/tests/server/rebalance-job.test.ts
+++ b/tests/server/rebalance-job.test.ts
@@ -107,7 +107,7 @@ function mockView(opts: { ask?: string; account?: unknown; disabled?: number } =
     body: [{ liability_coin: 'USDC', exchange_type: 'HYPERLIQUID', interest: '0.01', create_time: String(t - 1000) }],
   });
   mockGateGet('/transfers/coin', {
-    body: [{ coin: 'USDC', min_trans_amount: 11, est_fee: 0.05, precision: 5, is_disabled: opts.disabled ?? 0 }],
+    body: [{ coin: 'USDC', min_trans_amount: '11', est_fee: '1', precision: 5, is_disabled: opts.disabled ?? 0 }],
   });
   mockGateGet('/rule/symbols', {
     body: [{ symbol: 'GATE_SPOT_USDC_USDT', exchange_type: 'GATE', business_type: 'SPOT', state: 'live' }],
@@ -564,6 +564,12 @@ describe('POST /api/rebalance', () => {
     expect(before.plan.routes.loop).toMatchObject({ available: true, reason: null });
     expect(before.plan.routes.loop.costUsd).toBeCloseTo(12 * 0.001 + PULL_FEE_USD, 9);
     expect(before.plan.routes.convert.costUsd).toBeCloseTo(0.024, 9);
+    // Gate sends min_trans_amount as the string "11"; the reason must add, not concatenate.
+    const small = (await h.view('?direction=pull&amount=11.5')).data.plan;
+    expect(small.routes.loop.reason).toBe(
+      'Too small to pull. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Pull at least 12 USDC.',
+    );
+    expect(small.route).toBe('convert');
 
     const res = await h.post('/api/rebalance', { direction: 'pull', amount: 12, route: 'convert' });
     expect(res.statusCode).toBe(202);

--- a/tests/server/rebalance-job.test.ts
+++ b/tests/server/rebalance-job.test.ts
@@ -7,8 +7,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { makeClients } from '../../src/core/clients';
 import { Store } from '../../src/engine/db';
 import { gateVenue } from '../../src/engine/venueGate';
-import { newJob, type Job, type Step } from '../../src/server/rebalanceJob';
+import { JobFile, newJob, type Job, type Step } from '../../src/server/rebalanceJob';
 import { LOOKUP_RETRY_MS, STEP_TIMEOUT_MS, tagFor } from '../../src/server/rebalanceRunner';
+import type { AppDeps } from '../../src/server/app';
 import { gate, HOST, makeTestApp, mockGateGet, mockGatePost, TEST_KEY, TEST_SECRET } from './helpers/gate-nock';
 
 const API = '/api/v4';
@@ -48,19 +49,23 @@ async function waitFor(pred: () => boolean, what: string, ms = 5000): Promise<vo
   }
 }
 
-function boot(over: { store?: Store; sleep?: (ms: number) => Promise<void>; job?: Job } = {}) {
+function boot(
+  over: { store?: Store; sleep?: (ms: number) => Promise<void>; job?: Job; credentials?: AppDeps['credentials'] } = {},
+) {
   const dataDir = mkdtempSync(path.join(tmpdir(), 'rebalance-'));
   if (over.job) writeFileSync(path.join(dataDir, 'rebalance.json'), JSON.stringify(over.job));
   const getClients = () => makeClients({ key: TEST_KEY, secret: TEST_SECRET });
   const app = makeTestApp({
     getClients,
-    rebalance: { dataDir, sleep: over.sleep ?? sleep },
+    rebalance: { jobs: new JobFile(dataDir), sleep: over.sleep ?? sleep },
     engine: { store: over.store ?? new Store(':memory:'), venue: gateVenue(getClients), clock: { now: () => t } },
+    credentials: over.credentials,
   });
   apps.push(app);
   return {
     file: () => JSON.parse(readFileSync(path.join(dataDir, 'rebalance.json'), 'utf8')) as Job,
-    post: (url = '/api/rebalance') => app.inject({ method: 'POST', url, headers: HOST, payload: {} }),
+    post: (url = '/api/rebalance', payload: Record<string, unknown> = {}) =>
+      app.inject({ method: 'POST', url, headers: HOST, payload }),
     view: async () => (await app.inject({ method: 'GET', url: '/api/rebalance', headers: HOST })).json(),
   };
 }
@@ -214,12 +219,38 @@ describe('POST /api/rebalance', () => {
 
     release();
     await waitFor(() => h.file().status === 'halted', 'the halt');
+
+    await reset();
+    mockView();
+    mockGatePost('/orders', { body: orderBody('OPEN', '0') });
+    mockGateGet('/orders/o1', { body: orderBody('REJECT', '0') });
+    const capped = boot();
+    const smaller = await capped.post('/api/rebalance', { amount: 100.005, route: 'loop' });
+    expect(smaller.statusCode).toBe(202);
+    expect(capped.file()).toMatchObject({ amount: 100, route: 'loop' });
+    await waitFor(() => capped.file().status === 'halted', 'the halt');
+
+    await reset();
+    mockView();
+    mockGatePost('/orders', { body: orderBody('OPEN', '0') });
+    mockGateGet('/orders/o1', { body: orderBody('REJECT', '0') });
+    const larger = boot();
+    const capped2 = await larger.post('/api/rebalance', { amount: 5000 });
+    expect(capped2.statusCode).toBe(202);
+    expect(larger.file().amount).toBe(AMOUNT);
+    await waitFor(() => larger.file().status === 'halted', 'the halt');
   });
 
-  it('refuses: 409 for a running job, a working deal, no route, and one of two concurrent POSTs', async () => {
-    mockView();
-    let h = boot({ store: busyDeal() });
+  it('refuses: 409 for a running job, a working deal, no route, a changed plan, and one of two concurrent POSTs; 403 before the disclaimer', async () => {
+    const stored = newJob('loop', AMOUNT, t);
+    let h = boot({ job: stored });
     let res = await h.post();
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toBe(`rebalance ${stored.id} is halted`);
+
+    await reset();
+    h = boot({ store: busyDeal() });
+    res = await h.post();
     expect(res.statusCode).toBe(409);
     expect(res.json()).toEqual({
       ok: false,
@@ -227,11 +258,26 @@ describe('POST /api/rebalance', () => {
     });
 
     await reset();
+    const envPath = path.join(mkdtempSync(path.join(tmpdir(), 'disc-')), '.env');
+    h = boot({ credentials: { envPath, setClients: () => {} } });
+    res = await h.post();
+    expect(res.statusCode).toBe(403);
+    expect(res.json().error.label).toBe('DISCLAIMER_NOT_ACCEPTED');
+
+    await reset();
     mockView({ disabled: 1, account: account({ equity: '0', liability: '0' }) });
     h = boot();
     res = await h.post();
     expect(res.statusCode).toBe(409);
     expect(res.json().error.message).toBe('no route');
+
+    await reset();
+    mockView();
+    h = boot();
+    res = await h.post('/api/rebalance', { route: 'convert' });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toBe('plan changed: now loop');
+    expect(() => h.file()).toThrow();
 
     await reset();
     const release = holdRunner();
@@ -332,6 +378,7 @@ describe('POST /api/rebalance', () => {
     await h.post();
     await waitFor(() => h.file().status === 'halted', 'the halt');
     expect(h.file()).toMatchObject({ haltReason: 'order REJECT with nothing filled', fundsAt: 'CROSSEX', stepIndex: 0 });
+    expect(h.file().steps[0]).toMatchObject({ venueId: null, text: null });
 
     await reset();
     mockView();
@@ -413,8 +460,10 @@ describe('POST /api/rebalance/:id/resume and /abandon', () => {
     expect(res.statusCode).toBe(409);
     expect(res.json().error.message).toBe(`rebalance ${job.id} is done`);
     res = await h.post('/api/rebalance/nope/resume');
-    expect(res.statusCode).toBe(409);
+    expect(res.statusCode).toBe(400);
     expect(res.json().error.message).toBe('unknown rebalance nope');
+    res = await h.post('/api/rebalance/nope/abandon');
+    expect(res.statusCode).toBe(400);
 
     await reset();
     const halted = haltedLoopJob(1, { venueId: 'x1' });

--- a/tests/server/rebalance-job.test.ts
+++ b/tests/server/rebalance-job.test.ts
@@ -176,15 +176,15 @@ function haltedLoopJob(stepIndex: number, patch: Partial<Step> = {}): Job {
   return job;
 }
 
-const PULL_AMOUNT = 12;
+const PULL_AMOUNT = 1200;
 
-const pullAccount = () => account({ balance: '50', available_balance: '50', equity: '50', liability: '0' });
+const pullAccount = () => account({ balance: '5000', available_balance: '5000', equity: '5000', liability: '0' });
 
 const isTransfer = (b: Record<string, unknown>, from: string, to: string, amount: string): boolean =>
   b.coin === 'USDC' && b.from === from && b.to === to && b.amount === amount && typeof b.text === 'string';
 
 const isSell = (b: Record<string, unknown>): boolean =>
-  b.symbol === 'GATE_SPOT_USDC_USDT' && b.side === 'SELL' && b.type === 'MARKET' && b.qty === '11.00' && !('quote_qty' in b);
+  b.symbol === 'GATE_SPOT_USDC_USDT' && b.side === 'SELL' && b.type === 'MARKET' && b.qty === '1199.00' && !('quote_qty' in b);
 
 function holdRunner(): () => void {
   let release: () => void = () => undefined;
@@ -465,19 +465,19 @@ describe('POST /api/rebalance', () => {
     const cache = new TtlCache();
     mockView({ account: pullAccount() });
     const pulls = gate()
-      .post(`${API}/crossex/transfers`, (b) => isTransfer(b, 'CROSSEX_HYPERLIQUID', 'SPOT', '12.00000'))
+      .post(`${API}/crossex/transfers`, (b) => isTransfer(b, 'CROSSEX_HYPERLIQUID', 'SPOT', '1200.00000'))
       .query(true)
       .reply(200, { tx_id: 'p1', text: 't' });
-    mockGateGet('/transfers', { body: [transferRow('p1', 'PENDING', { amount: '12.00000' })] });
-    mockGateGet('/transfers', { body: [transferRow('p1', 'SUCCESS', { amount: '12.00000', actual_receive: '11' })] });
+    mockGateGet('/transfers', { body: [transferRow('p1', 'PENDING', { amount: '1200.00000' })] });
+    mockGateGet('/transfers', { body: [transferRow('p1', 'SUCCESS', { amount: '1200.00000', actual_receive: '1199' })] });
     const toGate = gate()
-      .post(`${API}/crossex/transfers`, (b) => isTransfer(b, 'SPOT', 'CROSSEX_GATE', '11.00000'))
+      .post(`${API}/crossex/transfers`, (b) => isTransfer(b, 'SPOT', 'CROSSEX_GATE', '1199.00000'))
       .query(true)
       .reply(200, { tx_id: 'p2', text: 't' });
     mockGateGet('/transfers', {
       body: [
-        transferRow('p1', 'SUCCESS', { amount: '12.00000', actual_receive: '11' }),
-        transferRow('p2', 'SUCCESS', { amount: '11.00000', actual_receive: '11' }),
+        transferRow('p1', 'SUCCESS', { amount: '1200.00000', actual_receive: '1199' }),
+        transferRow('p2', 'SUCCESS', { amount: '1199.00000', actual_receive: '1199' }),
       ],
     });
     const sells = gate()
@@ -485,16 +485,16 @@ describe('POST /api/rebalance', () => {
       .query(true)
       .reply(200, orderBody('OPEN', '0', 's1'));
     mockGateGet('/orders/s1', { body: orderBody('OPEN', '0', 's1') });
-    mockGateGet('/orders/s1', { body: { ...orderBody('FILLED', '11', 's1'), executed_amount: '10.9989' } });
+    mockGateGet('/orders/s1', { body: { ...orderBody('FILLED', '1199', 's1'), executed_amount: '1197.8011' } });
     let h = boot({ cache });
 
-    const before = (await h.view('?direction=pull&amount=12')).data;
+    const before = (await h.view(`?direction=pull&amount=${PULL_AMOUNT}`)).data;
     expect(before.plan).toMatchObject({
       direction: 'pull',
       amount: PULL_AMOUNT,
       route: 'loop',
       price: 1,
-      receives: 10.98,
+      receives: 1197.8,
       borrowAfterUsd: 0,
       shortfall: null,
       savesPerDayUsd: 0,
@@ -502,7 +502,8 @@ describe('POST /api/rebalance', () => {
     });
     expect(before.plan.routes.loop).toMatchObject({ waitSeconds: PULL_WAIT_SECONDS, available: true, reason: null });
     expect(before.plan.routes.loop.costUsd).toBeCloseTo(PULL_AMOUNT * 0.001 + PULL_FEE_USD, 9);
-    expect(before.plan.routes.convert).toMatchObject({ available: false, reason: 'Convert runs only from USDT to USDC.' });
+    expect(before.plan.routes.convert).toMatchObject({ available: true, reason: null, waitSeconds: 0 });
+    expect(before.plan.routes.convert.costUsd).toBeCloseTo(PULL_AMOUNT * 0.002, 9);
     expect(before.job).toBeNull();
 
     const res = await h.post('/api/rebalance', { direction: 'pull', amount: PULL_AMOUNT, route: 'loop' });
@@ -528,7 +529,7 @@ describe('POST /api/rebalance', () => {
     expect(job).toMatchObject({ direction: 'pull', status: 'done', stepIndex: 2, fundsAt: 'CROSSEX', haltReason: null });
     expect(job.steps.map((s: Step) => s.status)).toEqual(['done', 'done', 'done']);
     expect(job.steps.map((s: Step) => s.venueId)).toEqual(['p1', 'p2', 's1']);
-    expect(job.steps.map((s: Step) => s.qty)).toEqual([11, 11, 10.9989]);
+    expect(job.steps.map((s: Step) => s.qty)).toEqual([1199, 1199, 1197.8011]);
     for (const step of job.steps as Step[]) {
       expect(step.text).toBe(tagFor(job.id, job.steps.indexOf(step)));
       expect(step.doneAt).toBeTypeOf('number');
@@ -541,16 +542,79 @@ describe('POST /api/rebalance', () => {
     const empty = (await h.view('?direction=pull')).data.plan;
     expect(empty).toMatchObject({ direction: 'pull', amount: 0, route: null, receives: 0, price: null });
     expect(empty.routes.loop).toMatchObject({ available: false, reason: 'nothing to move' });
-    expect(empty.routes.convert).toMatchObject({ available: false, reason: 'Convert runs only from USDT to USDC.' });
+    expect(empty.routes.convert).toMatchObject({ available: false, reason: 'nothing to move' });
     const refused = await h.post('/api/rebalance', { direction: 'pull' });
     expect(refused.statusCode).toBe(409);
     expect(refused.json().error.message).toBe('no route');
   });
 
+  it('pull convert: a small pull picks convert, quotes USDC to USDT, sends, funds at CROSSEX; a resumed quote lands on the USDT balance', async () => {
+    mockView({ account: pullAccount() });
+    const isPullQuote = (b: Record<string, unknown>): boolean =>
+      b.exchange_type === 'HYPERLIQUID' && b.from_coin === 'USDC' && b.to_coin === 'USDT' && b.from_amount === '12';
+    const quotes = gate()
+      .post(`${API}/crossex/convert/quote`, isPullQuote)
+      .query(true)
+      .reply(200, { ...quoteBody('q3', '11.98'), from_coin: 'USDC', to_coin: 'USDT', from_amount: '12', price: '0.9981' });
+    const orders = mockGatePost('/convert/orders', { body: { order_id: 'c3', text: 'q3' } });
+    let h = boot();
+
+    const before = (await h.view('?direction=pull&amount=12')).data;
+    expect(before.plan).toMatchObject({ direction: 'pull', amount: 12, route: 'convert', price: 0.998, receives: 11.97 });
+    expect(before.plan.routes.loop).toMatchObject({ available: true, reason: null });
+    expect(before.plan.routes.loop.costUsd).toBeCloseTo(12 * 0.001 + PULL_FEE_USD, 9);
+    expect(before.plan.routes.convert.costUsd).toBeCloseTo(0.024, 9);
+
+    const res = await h.post('/api/rebalance', { direction: 'pull', amount: 12, route: 'convert' });
+    expect(res.statusCode).toBe(202);
+    expect(h.file()).toMatchObject({ direction: 'pull', route: 'convert', amount: 12, fundsAt: 'HYPERLIQUID' });
+    expect(h.file().steps.map((s) => s.name)).toEqual(['Convert']);
+    await waitFor(() => h.file().status === 'done', 'done');
+
+    expect(quotes.isDone()).toBe(true);
+    expect(orders.isDone()).toBe(true);
+    const { job } = (await h.view()).data;
+    expect(job).toMatchObject({ direction: 'pull', route: 'convert', status: 'done', fundsAt: 'CROSSEX', haltReason: null });
+    expect(job.steps[0]).toMatchObject({
+      name: 'Convert',
+      text: tagFor(job.id, 0),
+      quoteId: 'q3',
+      venueId: 'c3',
+      qty: 11.98,
+      balanceBefore: 1200,
+      status: 'done',
+    });
+
+    await reset();
+    const landed = pullAccount();
+    landed.assets[0].balance = '1211.98';
+    mockView({ account: landed });
+    const unsent = mockGatePost('/convert/orders', { body: { order_id: 'c4', text: 'q4' } });
+    const resumed = newJob('pull', 'convert', 12, t);
+    resumed.status = 'halted';
+    resumed.haltReason = 'server restarted';
+    Object.assign(resumed.steps[0], {
+      text: tagFor(resumed.id, 0),
+      quoteId: 'q4',
+      qty: 11.98,
+      balanceBefore: 1200,
+      status: 'running',
+      startedAt: t,
+    });
+    h = boot({ job: resumed });
+
+    const again = await h.post(`/api/rebalance/${resumed.id}/resume`);
+    expect(again.statusCode).toBe(200);
+    await waitFor(() => h.file().status === 'done', 'done');
+    expect(unsent.isDone()).toBe(false);
+    expect(h.file()).toMatchObject({ status: 'done', fundsAt: 'CROSSEX' });
+    expect(h.file().steps[0]).toMatchObject({ quoteId: 'q4', venueId: null, qty: 11.98, status: 'done' });
+  });
+
   it('pull halts and resumes like pay-down: a FAILED pull halts with funds at HYPERLIQUID, abandon ends it, and a resumed Sell USDC with a tag only adopts the order and sends nothing', async () => {
     mockView({ account: pullAccount() });
     mockGatePost('/transfers', { body: { tx_id: 'p1', text: 't' } });
-    mockGateGet('/transfers', { body: [transferRow('p1', 'FAILED', { amount: '12.00000', fail_reason: 'withdraw paused' })] });
+    mockGateGet('/transfers', { body: [transferRow('p1', 'FAILED', { amount: '1200.00000', fail_reason: 'withdraw paused' })] });
     let h = boot();
     let res = await h.post('/api/rebalance', { direction: 'pull', amount: PULL_AMOUNT });
     expect(res.statusCode).toBe(202);

--- a/tests/server/rebalance.test.ts
+++ b/tests/server/rebalance.test.ts
@@ -68,7 +68,7 @@ describe('GET /api/rebalance', () => {
         .query((q) => q.from === String(t - 30 * DAY_MS) && q.to === String(t) && q.page === '1' && q.limit === '100')
         .reply(200, [interestRow('5', t - 31 * DAY_MS), interestRow('0.02', t - 2000), interestRow('0.01', t - 1000)]),
       mockGateGet('/transfers/coin', {
-        body: [{ coin: 'USDC', min_trans_amount: 11, est_fee: 0.05, precision: 5, is_disabled: 0 }],
+        body: [{ coin: 'USDC', min_trans_amount: '11', est_fee: '1', precision: 5, is_disabled: 0 }],
       }),
       mockGateGet('/rule/symbols', {
         body: [{ symbol: 'GATE_SPOT_USDC_USDT', exchange_type: 'GATE', business_type: 'SPOT', state: 'live' }],

--- a/tests/server/rebalance.test.ts
+++ b/tests/server/rebalance.test.ts
@@ -91,7 +91,7 @@ describe('GET /api/rebalance', () => {
     expect(buckets).toHaveLength(3);
     const usdc = buckets.find((b: { coin: string; venue: string }) => b.coin === 'USDC' && b.venue === 'HYPERLIQUID');
     expect(Object.keys(usdc).sort()).toEqual(
-      ['coin', 'venue', 'cash', 'upnl', 'equity', 'borrow', 'interestPaid30dUsd', 'interestPerDayUsd'].sort(),
+      ['coin', 'venue', 'cash', 'upnl', 'equity', 'borrow', 'imHeldUsd', 'mmHeldUsd', 'interestPaid30dUsd', 'interestPerDayUsd'].sort(),
     );
     expect(usdc).toMatchObject({ cash: 0, upnl: 0, equity: -300, borrow: 300, interestPerDayUsd: 0 });
     expect(usdc.interestPaid30dUsd).toBeCloseTo(0.03, 6);

--- a/tests/server/rebalance.test.ts
+++ b/tests/server/rebalance.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { makeClients } from '../../src/core/clients';
 import { Store } from '../../src/engine/db';
 import { gateVenue } from '../../src/engine/venueGate';
+import { JobFile } from '../../src/server/rebalanceJob';
 import { gate, HOST, makeTestApp, mockGateGet, TEST_KEY, TEST_SECRET } from './helpers/gate-nock';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -52,7 +53,7 @@ describe('GET /api/rebalance', () => {
     app = makeTestApp({
       getClients,
       rebalance: {
-        dataDir: mkdtempSync(path.join(tmpdir(), 'rebalance-')),
+        jobs: new JobFile(mkdtempSync(path.join(tmpdir(), 'rebalance-'))),
         sleep: async () => undefined,
       },
       engine: { store: new Store(':memory:'), venue: gateVenue(getClients), clock: { now: () => t } },
@@ -62,9 +63,10 @@ describe('GET /api/rebalance', () => {
       mockGateGet('/interest_rate', {
         body: [{ coin: 'USDC', exchange_type: 'HYPERLIQUID', hour_interest_rate: '0.000005', time: String(t) }],
       }),
-      mockGateGet('/history_margin_interests', {
-        body: [interestRow('0.01', t - 1000), interestRow('0.02', t - 2000), interestRow('5', t - 31 * DAY_MS)],
-      }),
+      gate()
+        .get('/api/v4/crossex/history_margin_interests')
+        .query((q) => q.from === String(t - 30 * DAY_MS) && q.to === String(t) && q.page === '1' && q.limit === '100')
+        .reply(200, [interestRow('5', t - 31 * DAY_MS), interestRow('0.02', t - 2000), interestRow('0.01', t - 1000)]),
       mockGateGet('/transfers/coin', {
         body: [{ coin: 'USDC', min_trans_amount: 11, est_fee: 0.05, precision: 5, is_disabled: 0 }],
       }),
@@ -96,7 +98,6 @@ describe('GET /api/rebalance', () => {
     expect(buckets.find((b: { coin: string }) => b.coin === 'USDT')).toMatchObject({ venue: 'CROSSEX', cash: 1200 });
 
     expect(plan.amount).toBe(300);
-    expect(plan.deficit).toBe(300);
     expect(plan.shortfall).toBeNull();
     expect(plan.routes.loop).toMatchObject({ waitSeconds: 150, available: true, reason: null });
     expect(plan.routes.loop.costUsd).toBeCloseTo(0.38, 6);

--- a/tests/server/rebalance.test.ts
+++ b/tests/server/rebalance.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { makeClients } from '../../src/core/clients';
+import { Store } from '../../src/engine/db';
+import { gateVenue } from '../../src/engine/venueGate';
+import { gate, HOST, makeTestApp, mockGateGet, TEST_KEY, TEST_SECRET } from './helpers/gate-nock';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const asset = (coin: string, venue: string, over: Record<string, string> = {}) => ({
+  coin,
+  exchange_type: venue,
+  balance: '0',
+  upnl: '0',
+  equity: '0',
+  liability: '0',
+  borrowing_initial_margin: '0',
+  ...over,
+});
+
+const account = {
+  user_id: '1',
+  available_margin: '900',
+  margin_balance: '900',
+  account_mode: 'CROSS_EXCHANGE',
+  assets: [
+    asset('USDT', 'CROSSEX', { balance: '1200', equity: '1200' }),
+    asset('USDC', 'HYPERLIQUID', { equity: '-300', liability: '300', borrowing_initial_margin: '30' }),
+    asset('USDC', 'GATE'),
+  ],
+};
+
+const interestRow = (interest: string, createTime: number) => ({
+  liability_coin: 'USDC',
+  exchange_type: 'HYPERLIQUID',
+  interest,
+  create_time: String(createTime),
+});
+
+describe('GET /api/rebalance', () => {
+  let app: FastifyInstance;
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  it('returns the buckets, the plan with both routes, and a null job', async () => {
+    const t = Date.now();
+    const getClients = () => makeClients({ key: TEST_KEY, secret: TEST_SECRET });
+    app = makeTestApp({
+      getClients,
+      rebalance: {
+        dataDir: mkdtempSync(path.join(tmpdir(), 'rebalance-')),
+        sleep: async () => undefined,
+      },
+      engine: { store: new Store(':memory:'), venue: gateVenue(getClients), clock: { now: () => t } },
+    });
+    const scopes = [
+      mockGateGet('/accounts', { body: account }),
+      mockGateGet('/interest_rate', {
+        body: [{ coin: 'USDC', exchange_type: 'HYPERLIQUID', hour_interest_rate: '0.000005', time: String(t) }],
+      }),
+      mockGateGet('/history_margin_interests', {
+        body: [interestRow('0.01', t - 1000), interestRow('0.02', t - 2000), interestRow('5', t - 31 * DAY_MS)],
+      }),
+      mockGateGet('/transfers/coin', {
+        body: [{ coin: 'USDC', min_trans_amount: 11, est_fee: 0.05, precision: 5, is_disabled: 0 }],
+      }),
+      mockGateGet('/rule/symbols', {
+        body: [{ symbol: 'GATE_SPOT_USDC_USDT', exchange_type: 'GATE', business_type: 'SPOT', state: 'live' }],
+      }),
+      mockGateGet('/fee', { fixture: 'fee.json' }),
+      gate()
+        .get('/api/v4/spot/tickers')
+        .query(true)
+        .reply(200, [{ currency_pair: 'USDC_USDT', lowest_ask: '1.0001', highest_bid: '1', last: '1.0001' }]),
+    ];
+
+    const res = await app.inject({ method: 'GET', url: '/api/rebalance', headers: HOST });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.ok).toBe(true);
+    expect(body.meta.stale).toBeUndefined();
+    const { buckets, plan, job } = body.data;
+
+    expect(buckets).toHaveLength(3);
+    const usdc = buckets.find((b: { coin: string; venue: string }) => b.coin === 'USDC' && b.venue === 'HYPERLIQUID');
+    expect(Object.keys(usdc).sort()).toEqual(
+      ['coin', 'venue', 'cash', 'upnl', 'equity', 'borrow', 'interestPaid30dUsd', 'interestPerDayUsd'].sort(),
+    );
+    expect(usdc).toMatchObject({ cash: 0, upnl: 0, equity: -300, borrow: 300, interestPerDayUsd: 0 });
+    expect(usdc.interestPaid30dUsd).toBeCloseTo(0.03, 6);
+    expect(buckets.find((b: { coin: string }) => b.coin === 'USDT')).toMatchObject({ venue: 'CROSSEX', cash: 1200 });
+
+    expect(plan.amount).toBe(300);
+    expect(plan.deficit).toBe(300);
+    expect(plan.shortfall).toBeNull();
+    expect(plan.routes.loop).toMatchObject({ waitSeconds: 150, available: true, reason: null });
+    expect(plan.routes.loop.costUsd).toBeCloseTo(0.38, 6);
+    expect(plan.routes.convert).toMatchObject({ waitSeconds: 0, available: true, reason: null });
+    expect(plan.routes.convert.costUsd).toBeCloseTo(0.6, 6);
+    expect(plan.route).toBe('loop');
+    expect(plan.savesPerDayUsd).toBeTypeOf('number');
+    expect(plan.marginFreedUsd).toBe(30);
+
+    expect(job).toBeNull();
+    for (const scope of scopes) expect(scope.isDone()).toBe(true);
+  });
+});

--- a/tests/server/version.test.ts
+++ b/tests/server/version.test.ts
@@ -332,7 +332,7 @@ describe('POST /api/version/update', () => {
     const jobs = new JobFile(mkdtempSync(path.join(tmpdir(), 'rebalance-')));
     app = makeTestApp({ install: INSTALLED, rebalance: { jobs } });
     await app.ready();
-    jobs.write(newJob('loop', 12, Date.now()));
+    jobs.write(newJob('payDown', 'loop', 12, Date.now()));
 
     const res = await post();
 

--- a/tests/server/version.test.ts
+++ b/tests/server/version.test.ts
@@ -13,6 +13,7 @@ import type { FetchLike } from '../../src/core/boros/client';
 import { makeClients } from '../../src/core/clients';
 import { Store } from '../../src/engine/db';
 import { gateVenue } from '../../src/engine/venueGate';
+import { JobFile, newJob } from '../../src/server/rebalanceJob';
 import { endUpdateWindow, isUpdating, startUpdate } from '../../src/server/updater';
 import { COMMIT_URL, compareVersions, VERSION_URL } from '../../src/server/version';
 import { HOST, makeTestApp, TEST_KEY, TEST_SECRET } from './helpers/gate-nock';
@@ -324,6 +325,20 @@ describe('POST /api/version/update', () => {
     expect(res.statusCode).toBe(409);
     expect(res.json().error).toMatchObject({ category: 'validation', retryable: true });
     expect(res.json().error.message).toMatch(/deal is still working/);
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it('refuses while a pay-down is still running, and names it', async () => {
+    const jobs = new JobFile(mkdtempSync(path.join(tmpdir(), 'rebalance-')));
+    app = makeTestApp({ install: INSTALLED, rebalance: { jobs } });
+    await app.ready();
+    jobs.write(newJob('loop', 12, Date.now()));
+
+    const res = await post();
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toMatch(/pay-down is still running/);
+    expect(res.json().error.retryable).toBe(true);
     expect(mocks.spawn).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/cache.test.ts
+++ b/tests/unit/cache.test.ts
@@ -69,6 +69,20 @@ describe('TtlCache', () => {
     expect(f).toHaveBeenCalledTimes(2); // busted → refetched
   });
 
+  it('a bust during an inflight fetch is not undone when that fetch resolves', async () => {
+    const cache = new TtlCache();
+    let resolve!: (v: string) => void;
+    const slow = new Promise<string>((res) => (resolve = res));
+    const fetch = vi.fn().mockReturnValueOnce(slow).mockResolvedValueOnce('v2');
+    const first = cache.get('account', 10_000, fetch);
+    cache.bust('account');
+    resolve('v1');
+    expect((await first).value).toBe('v1');
+    const second = await cache.get('account', 10_000, fetch);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(second).toEqual({ value: 'v2', stale: false });
+  });
+
   it('caps entry count (no unbounded growth)', async () => {
     const cache = new TtlCache();
     for (let i = 0; i < 700; i++) await cache.get(`k${i}`, 10_000, async () => i);

--- a/tests/unit/rebalance-plan.test.ts
+++ b/tests/unit/rebalance-plan.test.ts
@@ -377,31 +377,31 @@ describe('planFor loop unavailable', () => {
   it('when the USDC transfer isDisabled is 1', () => {
     const p = plan(s, { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 } });
     expect(p.routes.loop.available).toBe(false);
-    expect(p.routes.loop.reason).toBe('USDC transfers are disabled on CrossEx');
+    expect(p.routes.loop.reason).toBe('Gate has paused USDC transfers on CrossEx. Try again later.');
   });
 
   it('when the USDC transfer row is missing', () => {
     const p = plan(s, { ...OPEN, usdcTransfer: null });
     expect(p.routes.loop.available).toBe(false);
-    expect(p.routes.loop.reason).toBe('USDC transfers are disabled on CrossEx');
+    expect(p.routes.loop.reason).toBe('Gate has paused USDC transfers on CrossEx. Try again later.');
   });
 
   it('when the spot rule is not live', () => {
     const p = plan(s, { ...OPEN, spotRule: { state: 'suspended' } });
     expect(p.routes.loop.available).toBe(false);
-    expect(p.routes.loop.reason).toBe(`${SPOT_SYMBOL} is not live`);
-    expect(p.routes.loop.reason).toBe('GATE_SPOT_USDC_USDT is not live');
+    expect(p.routes.loop.reason).toBe('The USDC/USDT spot market on Gate is not trading right now.');
+    expect(p.routes.loop.reason).toBe('The USDC/USDT spot market on Gate is not trading right now.');
   });
 
   it('when the spot rule is missing', () => {
     const p = plan(s, { ...OPEN, spotRule: null });
     expect(p.routes.loop.available).toBe(false);
-    expect(p.routes.loop.reason).toBe('GATE_SPOT_USDC_USDT is not live');
+    expect(p.routes.loop.reason).toBe('The USDC/USDT spot market on Gate is not trading right now.');
   });
 
   it('when there is no spot ask', () => {
-    expect(plan(s, { ...OPEN, ask: null }).routes.loop.reason).toBe('no spot price for USDC_USDT');
-    expect(plan(s, { ...OPEN, ask: 0 }).routes.loop.reason).toBe('no spot price for USDC_USDT');
+    expect(plan(s, { ...OPEN, ask: null }).routes.loop.reason).toBe('No price for USDC/USDT on Gate spot right now.');
+    expect(plan(s, { ...OPEN, ask: 0 }).routes.loop.reason).toBe('No price for USDC/USDT on Gate spot right now.');
     expect(plan(s, { ...OPEN, ask: 0 }).routes.loop.available).toBe(false);
   });
 
@@ -409,7 +409,7 @@ describe('planFor loop unavailable', () => {
     const p = plan({ usdcEquity: -500, usdtCash: 11, margin: 2000 });
     expect(p.amount).toBe(11);
     expect(p.routes.loop.available).toBe(false);
-    expect(p.routes.loop.reason).toBe('loop buys 10.99 USDC, below the 11 USDC transfer minimum');
+    expect(p.routes.loop.reason).toBe('Too small for the spot loop. Gate needs at least 11 USDC per transfer.');
   });
 
   it('is available when 12 USDT buys 11.99 USDC', () => {
@@ -423,9 +423,9 @@ describe('planFor loop unavailable', () => {
     const nothing = plan({ usdcEquity: 50, usdtCash: 1000, margin: 2000 }, { ...OPEN, usdcTransfer: null, spotRule: null });
     expect(nothing.routes.loop.reason).toBe('nothing to move');
     const disabled = plan(s, { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 }, spotRule: null, ask: null });
-    expect(disabled.routes.loop.reason).toBe('USDC transfers are disabled on CrossEx');
+    expect(disabled.routes.loop.reason).toBe('Gate has paused USDC transfers on CrossEx. Try again later.');
     const notLive = plan(s, { ...OPEN, spotRule: { state: 'paused' }, ask: null });
-    expect(notLive.routes.loop.reason).toBe('GATE_SPOT_USDC_USDT is not live');
+    expect(notLive.routes.loop.reason).toBe('The USDC/USDT spot market on Gate is not trading right now.');
   });
 
   it('leaves convert available when only loop is unavailable', () => {
@@ -466,7 +466,7 @@ describe('planFor pull', () => {
       expect(p.amount).toBe(0);
       expect(p.route).toBeNull();
       expect(p.routes.loop).toMatchObject({ available: false, reason: 'nothing to move' });
-      expect(p.routes.convert).toMatchObject({ available: false, reason: 'convert runs one way only' });
+      expect(p.routes.convert).toMatchObject({ available: false, reason: 'Convert runs only from USDT to USDC.' });
     }
   });
 
@@ -486,7 +486,7 @@ describe('planFor pull', () => {
 
   it('marks convert unavailable because it runs one way only', () => {
     const p = plan(s, OPEN, PULL);
-    expect(p.routes.convert).toEqual({ costUsd: 0, waitSeconds: 0, available: false, reason: 'convert runs one way only' });
+    expect(p.routes.convert).toEqual({ costUsd: 0, waitSeconds: 0, available: false, reason: 'Convert runs only from USDT to USDC.' });
   });
 
   it('picks the loop with the bid as the price and the sold USDT as receives', () => {
@@ -515,23 +515,23 @@ describe('planFor pull', () => {
 
   it('is unavailable when the USDC transfer is disabled or missing', () => {
     const disabled = plan(s, { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 } }, PULL);
-    expect(disabled.routes.loop).toMatchObject({ available: false, reason: 'USDC transfers are disabled on CrossEx' });
+    expect(disabled.routes.loop).toMatchObject({ available: false, reason: 'Gate has paused USDC transfers on CrossEx. Try again later.' });
     const missing = plan(s, { ...OPEN, usdcTransfer: null }, PULL);
-    expect(missing.routes.loop).toMatchObject({ available: false, reason: 'USDC transfers are disabled on CrossEx' });
+    expect(missing.routes.loop).toMatchObject({ available: false, reason: 'Gate has paused USDC transfers on CrossEx. Try again later.' });
     expect(missing.route).toBeNull();
   });
 
   it('is unavailable when the spot rule is not live or missing', () => {
     expect(plan(s, { ...OPEN, spotRule: { state: 'suspended' } }, PULL).routes.loop.reason).toBe(
-      'GATE_SPOT_USDC_USDT is not live',
+      'The USDC/USDT spot market on Gate is not trading right now.',
     );
-    expect(plan(s, { ...OPEN, spotRule: null }, PULL).routes.loop.reason).toBe('GATE_SPOT_USDC_USDT is not live');
+    expect(plan(s, { ...OPEN, spotRule: null }, PULL).routes.loop.reason).toBe('The USDC/USDT spot market on Gate is not trading right now.');
   });
 
   it('is unavailable when there is no spot bid, even with an ask', () => {
     for (const bid of [null, 0]) {
       const p = plan(s, { ...OPEN, bid }, PULL);
-      expect(p.routes.loop).toMatchObject({ available: false, reason: 'no spot price for USDC_USDT' });
+      expect(p.routes.loop).toMatchObject({ available: false, reason: 'No price for USDC/USDT on Gate spot right now.' });
       expect(p.route).toBeNull();
       expect(p.price).toBeNull();
       expect(p.receives).toBe(0);
@@ -542,7 +542,7 @@ describe('planFor pull', () => {
     const p = plan({ ...s, usdcEquity: 11.5, usdcCash: 11.5 }, OPEN, PULL);
     expect(p.amount).toBe(11.5);
     expect(p.routes.loop.available).toBe(false);
-    expect(p.routes.loop.reason).toBe('pull lands 10.5 USDC after the $1 fee, below the 11 USDC transfer minimum');
+    expect(p.routes.loop.reason).toBe('Too small to pull. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Pull at least 12 USDC.');
     const enough = plan({ ...s, usdcEquity: 12, usdcCash: 12 }, OPEN, PULL);
     expect(enough.routes.loop.available).toBe(true);
   });
@@ -551,8 +551,8 @@ describe('planFor pull', () => {
     const nothing = plan({ ...s, usdcEquity: 0 }, { ...OPEN, usdcTransfer: null, bid: null }, PULL);
     expect(nothing.routes.loop.reason).toBe('nothing to move');
     const disabled = plan(s, { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 }, spotRule: null, bid: null }, PULL);
-    expect(disabled.routes.loop.reason).toBe('USDC transfers are disabled on CrossEx');
+    expect(disabled.routes.loop.reason).toBe('Gate has paused USDC transfers on CrossEx. Try again later.');
     const notLive = plan(s, { ...OPEN, spotRule: { state: 'paused' }, bid: null }, PULL);
-    expect(notLive.routes.loop.reason).toBe('GATE_SPOT_USDC_USDT is not live');
+    expect(notLive.routes.loop.reason).toBe('The USDC/USDT spot market on Gate is not trading right now.');
   });
 });

--- a/tests/unit/rebalance-plan.test.ts
+++ b/tests/unit/rebalance-plan.test.ts
@@ -466,7 +466,7 @@ describe('planFor pull', () => {
       expect(p.amount).toBe(0);
       expect(p.route).toBeNull();
       expect(p.routes.loop).toMatchObject({ available: false, reason: 'nothing to move' });
-      expect(p.routes.convert).toMatchObject({ available: false, reason: 'Convert runs only from USDT to USDC.' });
+      expect(p.routes.convert).toMatchObject({ available: false, reason: 'nothing to move' });
     }
   });
 
@@ -484,33 +484,45 @@ describe('planFor pull', () => {
     expect(p.routes.loop.costUsd).toBeCloseTo(PULL_FEE_USD, 9);
   });
 
-  it('marks convert unavailable because it runs one way only', () => {
+  it('quotes convert as amount x 0.002, instant, and picks it for a small pull', () => {
     const p = plan(s, OPEN, PULL);
-    expect(p.routes.convert).toEqual({ costUsd: 0, waitSeconds: 0, available: false, reason: 'Convert runs only from USDT to USDC.' });
+    expect(p.routes.convert).toMatchObject({ waitSeconds: 0, available: true, reason: null });
+    expect(p.routes.convert.costUsd).toBeCloseTo(0.1, 9);
+    expect(p.routes.loop.costUsd).toBeCloseTo(1.005, 9);
+    expect(p.route).toBe('convert');
+    expect(p.price).toBe(0.998);
+    expect(p.receives).toBe(49.9);
+    expect(p.shortfall).toBeNull();
+    expect(p.borrowAfterUsd).toBe(0);
   });
 
-  it('picks the loop with the bid as the price and the sold USDT as receives', () => {
-    const p = plan(s, OPEN, PULL);
+  it('picks the loop for a big pull, where the $1 fee beats 20 bps, with the bid as the price and the sold USDT as receives', () => {
+    const p = plan({ ...s, usdcEquity: 5000, usdcCash: 5000 }, OPEN, PULL);
+    expect(p.routes.loop.costUsd).toBeCloseTo(1.5, 9);
+    expect(p.routes.convert.costUsd).toBeCloseTo(10, 9);
     expect(p.route).toBe('loop');
     expect(p.price).toBe(0.9999);
-    expect(p.receives).toBe(48.99);
+    expect(p.receives).toBe(4998.5);
     expect(p.shortfall).toBeNull();
     expect(p.borrowAfterUsd).toBe(0);
     expect(p.savesPerDayUsd).toBe(0);
     expect(p.marginFreedUsd).toBe(0);
   });
 
-  it('matches the live run: 12 USDC at bid 1 lands 11 and receives 11 USDT', () => {
+  it('matches the live runs: the loop for 12 USDC at bid 1 costs the $1 fee, and convert at 2 cents wins', () => {
     const p = plan({ ...s, usdcEquity: 12, usdcCash: 12 }, { ...OPEN, bid: 1 }, PULL);
     expect(p.amount).toBe(12);
-    expect(p.route).toBe('loop');
+    expect(p.routes.loop).toMatchObject({ available: true, reason: null });
     expect(p.routes.loop.costUsd).toBeCloseTo(1, 9);
-    expect(p.receives).toBe(11);
+    expect(p.routes.convert.costUsd).toBeCloseTo(0.024, 9);
+    expect(p.route).toBe('convert');
+    expect(p.receives).toBe(11.97);
   });
 
-  it('takes the spot taker fee out of receives', () => {
-    const p = plan(s, { ...OPEN, bid: 1, spotTakerRate: 0.001 }, PULL);
-    expect(p.receives).toBe(48.95);
+  it('takes the spot taker fee out of the loop receives', () => {
+    const p = plan({ ...s, usdcEquity: 5000, usdcCash: 5000 }, { ...OPEN, bid: 1, spotTakerRate: 0.001 }, PULL);
+    expect(p.route).toBe('loop');
+    expect(p.receives).toBe(4994);
   });
 
   it('is unavailable when the USDC transfer is disabled or missing', () => {
@@ -518,7 +530,7 @@ describe('planFor pull', () => {
     expect(disabled.routes.loop).toMatchObject({ available: false, reason: 'Gate has paused USDC transfers on CrossEx. Try again later.' });
     const missing = plan(s, { ...OPEN, usdcTransfer: null }, PULL);
     expect(missing.routes.loop).toMatchObject({ available: false, reason: 'Gate has paused USDC transfers on CrossEx. Try again later.' });
-    expect(missing.route).toBeNull();
+    expect(missing.route).toBe('convert');
   });
 
   it('is unavailable when the spot rule is not live or missing', () => {
@@ -532,9 +544,9 @@ describe('planFor pull', () => {
     for (const bid of [null, 0]) {
       const p = plan(s, { ...OPEN, bid }, PULL);
       expect(p.routes.loop).toMatchObject({ available: false, reason: 'No price for USDC/USDT on Gate spot right now.' });
-      expect(p.route).toBeNull();
-      expect(p.price).toBeNull();
-      expect(p.receives).toBe(0);
+      expect(p.route).toBe('convert');
+      expect(p.price).toBe(0.998);
+      expect(p.receives).toBe(49.9);
     }
   });
 
@@ -543,6 +555,7 @@ describe('planFor pull', () => {
     expect(p.amount).toBe(11.5);
     expect(p.routes.loop.available).toBe(false);
     expect(p.routes.loop.reason).toBe('Too small to pull. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Pull at least 12 USDC.');
+    expect(p.route).toBe('convert');
     const enough = plan({ ...s, usdcEquity: 12, usdcCash: 12 }, OPEN, PULL);
     expect(enough.routes.loop.available).toBe(true);
   });

--- a/tests/unit/rebalance-plan.test.ts
+++ b/tests/unit/rebalance-plan.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect } from 'vitest';
+import {
+  bucketsFrom,
+  planFor,
+  DEFICIT,
+  SURPLUS,
+  SPOT_SYMBOL,
+  LOOP_WAIT_SECONDS,
+  type AccountLike,
+  type AssetLike,
+  type PlanInputs,
+  type RateLike,
+} from '../../src/core/rebalance/plan';
+
+type Figures = Partial<Record<'balance' | 'upnl' | 'equity' | 'liability' | 'borrowingInitialMargin', number>>;
+
+function asset(coin: string, exchangeType: string, f: Figures = {}): AssetLike {
+  return {
+    coin,
+    exchangeType,
+    balance: String(f.balance ?? 0),
+    upnl: String(f.upnl ?? 0),
+    equity: String(f.equity ?? 0),
+    liability: String(f.liability ?? 0),
+    borrowingInitialMargin: String(f.borrowingInitialMargin ?? 0),
+  };
+}
+
+const USDC_RATE: RateLike[] = [{ coin: DEFICIT.coin, exchangeType: DEFICIT.venue, hourInterestRate: '0.00001' }];
+
+const OPEN: PlanInputs = {
+  usdcTransfer: { isDisabled: 0, minTransAmount: 11 },
+  spotRule: { state: 'live' },
+  spotTakerRate: 0,
+  ask: 1.0001,
+};
+
+interface Scenario {
+  usdcEquity: number;
+  usdcBorrow?: number;
+  usdcIm?: number;
+  usdtCash: number;
+  margin: number;
+}
+
+function accountFor(s: Scenario): AccountLike {
+  return {
+    availableMargin: String(s.margin),
+    assets: [
+      asset(DEFICIT.coin, DEFICIT.venue, {
+        equity: s.usdcEquity,
+        liability: s.usdcBorrow ?? Math.max(0, -s.usdcEquity),
+        borrowingInitialMargin: s.usdcIm ?? 0,
+      }),
+      asset(SURPLUS.coin, SURPLUS.venue, { balance: s.usdtCash, equity: s.usdtCash }),
+    ],
+  };
+}
+
+function plan(s: Scenario, inputs: PlanInputs = OPEN) {
+  const account = accountFor(s);
+  return planFor(bucketsFrom(account, USDC_RATE, []), account, inputs);
+}
+
+describe('bucketsFrom interest', () => {
+  it('maps one row per asset: cash from balance, borrow from liability', () => {
+    const account: AccountLike = {
+      availableMargin: '100',
+      assets: [
+        asset('USDC', 'HYPERLIQUID', { balance: -50, upnl: 10, equity: -40, liability: 50 }),
+        asset('USDT', 'CROSSEX', { balance: 200, upnl: 0, equity: 200 }),
+      ],
+    };
+    const buckets = bucketsFrom(account, USDC_RATE, []);
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0]).toMatchObject({ coin: 'USDC', venue: 'HYPERLIQUID', cash: -50, upnl: 10, equity: -40, borrow: 50 });
+    expect(buckets[1]).toMatchObject({ coin: 'USDT', venue: 'CROSSEX', cash: 200, upnl: 0, equity: 200, borrow: 0 });
+  });
+
+  it('charges interest per day when equity is below -10000', () => {
+    const account = accountFor({ usdcEquity: -10001, usdtCash: 0, margin: 0 });
+    const [usdc] = bucketsFrom(account, USDC_RATE, []);
+    expect(usdc.interestPerDayUsd).toBeCloseTo(10001 * 0.00001 * 24, 9);
+  });
+
+  it('charges no interest at exactly -10000', () => {
+    const account = accountFor({ usdcEquity: -10000, usdtCash: 0, margin: 0 });
+    const [usdc] = bucketsFrom(account, USDC_RATE, []);
+    expect(usdc.interestPerDayUsd).toBe(0);
+  });
+
+  it('uses rate 0 when no rate row matches the coin and venue', () => {
+    const account = accountFor({ usdcEquity: -20000, usdtCash: 0, margin: 0 });
+    const other: RateLike[] = [{ coin: 'USDC', exchangeType: 'GATE', hourInterestRate: '0.5' }];
+    const [usdc] = bucketsFrom(account, other, []);
+    expect(usdc.interestPerDayUsd).toBe(0);
+  });
+
+  it('sums interest paid over rows with the same coin and venue', () => {
+    const account = accountFor({ usdcEquity: -500, usdtCash: 0, margin: 0 });
+    const rows = [
+      { liabilityCoin: 'USDC', exchangeType: 'HYPERLIQUID', interest: '1.5' },
+      { liabilityCoin: 'USDC', exchangeType: 'HYPERLIQUID', interest: '2.25' },
+      { liabilityCoin: 'USDC', exchangeType: 'GATE', interest: '9' },
+      { liabilityCoin: 'USDT', exchangeType: 'CROSSEX', interest: '4' },
+    ];
+    const [usdc, usdt] = bucketsFrom(account, USDC_RATE, rows);
+    expect(usdc.interestPaid30dUsd).toBeCloseTo(3.75, 9);
+    expect(usdt.interestPaid30dUsd).toBe(4);
+  });
+
+  it('reads interest paid as 0 with no rows', () => {
+    const account = accountFor({ usdcEquity: -500, usdtCash: 0, margin: 0 });
+    const [usdc] = bucketsFrom(account, USDC_RATE, []);
+    expect(usdc.interestPaid30dUsd).toBe(0);
+  });
+});
+
+describe('planFor amount', () => {
+  it('equals the deficit when the deficit is the smallest', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 1000, margin: 2000 });
+    expect(p.deficit).toBe(500);
+    expect(p.amount).toBe(500);
+  });
+
+  it('equals the USDT cash when cash is the smallest', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 300.456, margin: 2000 });
+    expect(p.amount).toBe(300.45);
+  });
+
+  it('equals the available margin when margin is the smallest', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 1000, margin: 120 });
+    expect(p.amount).toBe(120);
+  });
+
+  it('floors the amount to 0.01', () => {
+    const p = plan({ usdcEquity: -12.999, usdtCash: 1000, margin: 2000 });
+    expect(p.amount).toBe(12.99);
+  });
+
+  it('is 0 when USDC on Hyperliquid has no deficit', () => {
+    const p = plan({ usdcEquity: 50, usdtCash: 1000, margin: 2000 });
+    expect(p.deficit).toBe(0);
+    expect(p.amount).toBe(0);
+  });
+
+  it('is 0 when the USDC bucket is absent', () => {
+    const account: AccountLike = { availableMargin: '2000', assets: [asset('USDT', 'CROSSEX', { balance: 1000 })] };
+    const p = planFor(bucketsFrom(account, USDC_RATE, []), account, OPEN);
+    expect(p.deficit).toBe(0);
+    expect(p.amount).toBe(0);
+  });
+
+  it('never goes below 0 when the USDT cash is negative', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: -3.456, margin: 2000 });
+    expect(p.amount).toBe(0);
+  });
+
+  it('carries savesPerDayUsd and marginFreedUsd scaled by amount over borrow', () => {
+    const p = plan({ usdcEquity: -20000, usdcBorrow: 20000, usdcIm: 4000, usdtCash: 5000, margin: 50000 });
+    expect(p.amount).toBe(5000);
+    expect(p.savesPerDayUsd).toBeCloseTo((20000 * 0.00001 * 24 * 5000) / 20000, 9);
+    expect(p.marginFreedUsd).toBeCloseTo((5000 * 4000) / 20000, 9);
+  });
+
+  it('reads savesPerDayUsd and marginFreedUsd as 0 when the borrow is 0', () => {
+    const p = plan({ usdcEquity: -500, usdcBorrow: 0, usdcIm: 0, usdtCash: 1000, margin: 2000 });
+    expect(p.savesPerDayUsd).toBe(0);
+    expect(p.marginFreedUsd).toBe(0);
+  });
+});
+
+describe('planFor shortfall', () => {
+  it('is null when the deficit is the smallest', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 1000, margin: 2000 });
+    expect(p.shortfall).toBeNull();
+  });
+
+  it('is null when the deficit is 0', () => {
+    const p = plan({ usdcEquity: 50, usdtCash: 0, margin: 0 });
+    expect(p.shortfall).toBeNull();
+  });
+
+  it('names cash with the remaining deficit when cash is the smallest', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 300, margin: 2000 });
+    expect(p.shortfall).toEqual({ reason: 'cash', remaining: 200 });
+  });
+
+  it('names margin with the remaining deficit when margin is the smallest', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 1000, margin: 120 });
+    expect(p.shortfall).toEqual({ reason: 'margin', remaining: 380 });
+  });
+
+  it('names cash when cash and margin tie as the smallest', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 300, margin: 300 });
+    expect(p.shortfall).toEqual({ reason: 'cash', remaining: 200 });
+  });
+
+  it('floors remaining to 0.01', () => {
+    const p = plan({ usdcEquity: -500.129, usdtCash: 300, margin: 2000 });
+    expect(p.amount).toBe(300);
+    expect(p.shortfall).toEqual({ reason: 'cash', remaining: 200.12 });
+  });
+});
+
+describe('planFor route', () => {
+  it('quotes loop at 150 s and convert at 0 s with the formula costs', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 1000, margin: 2000 });
+    expect(p.routes.loop.waitSeconds).toBe(LOOP_WAIT_SECONDS);
+    expect(p.routes.loop.waitSeconds).toBe(150);
+    expect(p.routes.convert.waitSeconds).toBe(0);
+    expect(p.routes.loop.costUsd).toBeCloseTo(500 * 0.0001 + 0.05, 9);
+    expect(p.routes.convert.costUsd).toBeCloseTo(500 * 0.002, 9);
+  });
+
+  it('adds the spot taker fee to the loop cost', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 1000, margin: 2000 }, { ...OPEN, spotTakerRate: 0.001 });
+    expect(p.routes.loop.costUsd).toBeCloseTo(500 * 0.0001 + 500 * 0.001 + 0.05, 9);
+  });
+
+  it('picks loop when both are available and loop is cheaper', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 1000, margin: 2000 });
+    expect(p.routes.loop.available).toBe(true);
+    expect(p.routes.convert.available).toBe(true);
+    expect(p.route).toBe('loop');
+  });
+
+  it('picks convert when both are available and convert is cheaper', () => {
+    const p = plan({ usdcEquity: -20, usdtCash: 1000, margin: 2000 });
+    expect(p.routes.loop.available).toBe(true);
+    expect(p.routes.convert.available).toBe(true);
+    expect(p.routes.convert.costUsd).toBeLessThan(p.routes.loop.costUsd);
+    expect(p.route).toBe('convert');
+  });
+
+  it('picks convert when the costs are equal', () => {
+    const p = plan({ usdcEquity: -25, usdtCash: 1000, margin: 2000 }, { ...OPEN, ask: 1 });
+    expect(p.routes.loop.costUsd).toBe(p.routes.convert.costUsd);
+    expect(p.route).toBe('convert');
+  });
+
+  it('picks the one available route', () => {
+    const p = plan(
+      { usdcEquity: -500, usdtCash: 1000, margin: 2000 },
+      { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 } },
+    );
+    expect(p.routes.loop.available).toBe(false);
+    expect(p.routes.convert.available).toBe(true);
+    expect(p.route).toBe('convert');
+  });
+
+  it('is null when amount is 0 and both routes say nothing to move', () => {
+    const p = plan({ usdcEquity: 50, usdtCash: 1000, margin: 2000 });
+    expect(p.route).toBeNull();
+    expect(p.routes.loop).toMatchObject({ available: false, reason: 'nothing to move' });
+    expect(p.routes.convert).toMatchObject({ available: false, reason: 'nothing to move' });
+  });
+
+  it('reads reason null on an available route', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 1000, margin: 2000 });
+    expect(p.routes.loop.reason).toBeNull();
+    expect(p.routes.convert.reason).toBeNull();
+  });
+});
+
+describe('planFor loop unavailable', () => {
+  const s: Scenario = { usdcEquity: -500, usdtCash: 1000, margin: 2000 };
+
+  it('when the USDC transfer isDisabled is 1', () => {
+    const p = plan(s, { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 } });
+    expect(p.routes.loop.available).toBe(false);
+    expect(p.routes.loop.reason).toBe('USDC transfers are disabled on CrossEx');
+  });
+
+  it('when the USDC transfer row is missing', () => {
+    const p = plan(s, { ...OPEN, usdcTransfer: null });
+    expect(p.routes.loop.available).toBe(false);
+    expect(p.routes.loop.reason).toBe('USDC transfers are disabled on CrossEx');
+  });
+
+  it('when the spot rule is not live', () => {
+    const p = plan(s, { ...OPEN, spotRule: { state: 'suspended' } });
+    expect(p.routes.loop.available).toBe(false);
+    expect(p.routes.loop.reason).toBe(`${SPOT_SYMBOL} is not live`);
+    expect(p.routes.loop.reason).toBe('GATE_SPOT_USDC_USDT is not live');
+  });
+
+  it('when the spot rule is missing', () => {
+    const p = plan(s, { ...OPEN, spotRule: null });
+    expect(p.routes.loop.available).toBe(false);
+    expect(p.routes.loop.reason).toBe('GATE_SPOT_USDC_USDT is not live');
+  });
+
+  it('when there is no spot ask', () => {
+    expect(plan(s, { ...OPEN, ask: null }).routes.loop.reason).toBe('no spot price for USDC_USDT');
+    expect(plan(s, { ...OPEN, ask: 0 }).routes.loop.reason).toBe('no spot price for USDC_USDT');
+    expect(plan(s, { ...OPEN, ask: 0 }).routes.loop.available).toBe(false);
+  });
+
+  it('when the bought USDC is below the transfer minimum', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 11, margin: 2000 });
+    expect(p.amount).toBe(11);
+    expect(p.routes.loop.available).toBe(false);
+    expect(p.routes.loop.reason).toBe('loop buys 10.99 USDC, below the 11 USDC transfer minimum');
+  });
+
+  it('is available when 12 USDT buys 11.99 USDC', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 12, margin: 2000 });
+    expect(p.amount).toBe(12);
+    expect(p.routes.loop.available).toBe(true);
+    expect(p.routes.loop.reason).toBeNull();
+  });
+
+  it('reports the first cause only', () => {
+    const nothing = plan({ usdcEquity: 50, usdtCash: 1000, margin: 2000 }, { ...OPEN, usdcTransfer: null, spotRule: null });
+    expect(nothing.routes.loop.reason).toBe('nothing to move');
+    const disabled = plan(s, { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 }, spotRule: null, ask: null });
+    expect(disabled.routes.loop.reason).toBe('USDC transfers are disabled on CrossEx');
+    const notLive = plan(s, { ...OPEN, spotRule: { state: 'paused' }, ask: null });
+    expect(notLive.routes.loop.reason).toBe('GATE_SPOT_USDC_USDT is not live');
+  });
+
+  it('leaves convert available when only loop is unavailable', () => {
+    const p = plan(s, { ...OPEN, ask: null });
+    expect(p.routes.convert.available).toBe(true);
+    expect(p.route).toBe('convert');
+  });
+});

--- a/tests/unit/rebalance-plan.test.ts
+++ b/tests/unit/rebalance-plan.test.ts
@@ -6,23 +6,39 @@ import {
   SURPLUS,
   SPOT_SYMBOL,
   LOOP_WAIT_SECONDS,
+  PULL_FEE_USD,
+  PULL_WAIT_SECONDS,
   type AccountLike,
   type AssetLike,
   type PlanInputs,
+  type PlanRequest,
   type RateLike,
 } from '../../src/core/rebalance/plan';
 
-type Figures = Partial<Record<'balance' | 'upnl' | 'equity' | 'liability' | 'borrowingInitialMargin', number>>;
+type Figures = Partial<
+  Record<
+    | 'balance'
+    | 'availableBalance'
+    | 'upnl'
+    | 'equity'
+    | 'liability'
+    | 'borrowingInitialMargin'
+    | 'borrowingMaintenanceMargin',
+    number
+  >
+>;
 
 function asset(coin: string, exchangeType: string, f: Figures = {}): AssetLike {
   return {
     coin,
     exchangeType,
     balance: String(f.balance ?? 0),
+    availableBalance: String(f.availableBalance ?? f.balance ?? 0),
     upnl: String(f.upnl ?? 0),
     equity: String(f.equity ?? 0),
     liability: String(f.liability ?? 0),
     borrowingInitialMargin: String(f.borrowingInitialMargin ?? 0),
+    borrowingMaintenanceMargin: String(f.borrowingMaintenanceMargin ?? 0),
   };
 }
 
@@ -33,12 +49,17 @@ const OPEN: PlanInputs = {
   spotRule: { state: 'live' },
   spotTakerRate: 0,
   ask: 1.0001,
+  bid: 0.9999,
 };
+
+const PULL: PlanRequest = { direction: 'pull' };
 
 interface Scenario {
   usdcEquity: number;
   usdcBorrow?: number;
   usdcIm?: number;
+  usdcCash?: number;
+  usdcAvailable?: number;
   usdtCash: number;
   margin: number;
 }
@@ -48,6 +69,8 @@ function accountFor(s: Scenario): AccountLike {
     availableMargin: String(s.margin),
     assets: [
       asset(DEFICIT.coin, DEFICIT.venue, {
+        balance: s.usdcCash ?? 0,
+        availableBalance: s.usdcAvailable ?? s.usdcCash ?? 0,
         equity: s.usdcEquity,
         liability: s.usdcBorrow ?? Math.max(0, -s.usdcEquity),
         borrowingInitialMargin: s.usdcIm ?? 0,
@@ -57,9 +80,9 @@ function accountFor(s: Scenario): AccountLike {
   };
 }
 
-function plan(s: Scenario, inputs: PlanInputs = OPEN) {
+function plan(s: Scenario, inputs: PlanInputs = OPEN, request?: PlanRequest) {
   const account = accountFor(s);
-  return planFor(bucketsFrom(account, USDC_RATE, []), account, inputs);
+  return planFor(bucketsFrom(account, USDC_RATE, []), account, inputs, request);
 }
 
 describe('bucketsFrom interest', () => {
@@ -116,6 +139,35 @@ describe('bucketsFrom interest', () => {
   });
 });
 
+describe('bucketsFrom held margin', () => {
+  it('reads imHeldUsd and mmHeldUsd from the asset borrowing margins', () => {
+    const account: AccountLike = {
+      availableMargin: '100',
+      assets: [
+        asset('USDC', 'HYPERLIQUID', {
+          equity: -300,
+          liability: 300,
+          borrowingInitialMargin: 60,
+          borrowingMaintenanceMargin: 30,
+        }),
+        asset('USDT', 'CROSSEX', { balance: 1200, equity: 1200 }),
+      ],
+    };
+    const [usdc, usdt] = bucketsFrom(account, USDC_RATE, []);
+    expect(usdc).toMatchObject({ borrow: 300, imHeldUsd: 60, mmHeldUsd: 30 });
+    expect(usdt).toMatchObject({ imHeldUsd: 0, mmHeldUsd: 0 });
+  });
+
+  it('reads held margin as 0 when the asset margin is not a number', () => {
+    const account: AccountLike = {
+      availableMargin: '100',
+      assets: [{ ...asset('USDC', 'HYPERLIQUID'), borrowingInitialMargin: '', borrowingMaintenanceMargin: 'n/a' }],
+    };
+    const [usdc] = bucketsFrom(account, USDC_RATE, []);
+    expect(usdc).toMatchObject({ imHeldUsd: 0, mmHeldUsd: 0 });
+  });
+});
+
 describe('planFor amount', () => {
   it('equals the deficit when the deficit is the smallest', () => {
     const p = plan({ usdcEquity: -500, usdtCash: 1000, margin: 2000 });
@@ -164,6 +216,65 @@ describe('planFor amount', () => {
     const p = plan({ usdcEquity: -500, usdcBorrow: 0, usdcIm: 0, usdtCash: 1000, margin: 2000 });
     expect(p.savesPerDayUsd).toBe(0);
     expect(p.marginFreedUsd).toBe(0);
+  });
+});
+
+describe('planFor requested amount', () => {
+  const s: Scenario = { usdcEquity: -500, usdtCash: 1000, margin: 2000 };
+
+  it('reads as payDown for the full deficit when no request is given', () => {
+    const p = plan(s);
+    expect(p.direction).toBe('payDown');
+    expect(p.amount).toBe(500);
+  });
+
+  it('equals the requested amount when it is the smallest', () => {
+    const p = plan(s, OPEN, { requested: 120 });
+    expect(p.amount).toBe(120);
+  });
+
+  it('floors the requested amount to 0.01', () => {
+    expect(plan(s, OPEN, { requested: 120.005 }).amount).toBe(120);
+  });
+
+  it('caps a requested amount above the deficit at the deficit', () => {
+    expect(plan(s, OPEN, { requested: 5000 }).amount).toBe(500);
+  });
+
+  it('caps a requested amount at the cash and keeps the cash shortfall', () => {
+    const p = plan({ usdcEquity: -500, usdtCash: 300, margin: 2000 }, OPEN, { requested: 100 });
+    expect(p.amount).toBe(100);
+    expect(p.shortfall).toEqual({ reason: 'cash', remaining: 400 });
+  });
+
+  it('carries the loop price, receives, and borrowAfterUsd', () => {
+    const p = plan(s, OPEN, { requested: 120 });
+    expect(p.route).toBe('loop');
+    expect(p.price).toBe(1.0001);
+    expect(p.receives).toBe(119.93);
+    expect(p.borrowAfterUsd).toBeCloseTo(500 - 119.93, 9);
+  });
+
+  it('takes the spot taker fee out of receives on the loop', () => {
+    const p = plan(s, { ...OPEN, spotTakerRate: 0.001 }, { requested: 120 });
+    expect(p.route).toBe('loop');
+    expect(p.receives).toBe(119.81);
+  });
+
+  it('carries the convert price, receives, and borrowAfterUsd', () => {
+    const p = plan({ usdcEquity: -20, usdtCash: 1000, margin: 2000 });
+    expect(p.route).toBe('convert');
+    expect(p.price).toBeCloseTo(0.998, 9);
+    expect(p.receives).toBe(19.96);
+    expect(p.borrowAfterUsd).toBeCloseTo(0.04, 9);
+  });
+
+  it('reads price null, receives 0, and the full deficit as borrowAfterUsd when no route is available', () => {
+    const p = plan(s, { ...OPEN, usdcTransfer: null }, { requested: 0 });
+    expect(p.route).toBeNull();
+    expect(p.price).toBeNull();
+    expect(p.receives).toBe(0);
+    expect(p.borrowAfterUsd).toBe(500);
   });
 });
 
@@ -321,5 +432,127 @@ describe('planFor loop unavailable', () => {
     const p = plan(s, { ...OPEN, ask: null });
     expect(p.routes.convert.available).toBe(true);
     expect(p.route).toBe('convert');
+  });
+});
+
+describe('planFor pull', () => {
+  const s: Scenario = { usdcEquity: 50, usdcCash: 50, usdtCash: 1000, margin: 2000 };
+
+  it('reads as pull with the bucket equity as the amount', () => {
+    const p = plan(s, OPEN, PULL);
+    expect(p.direction).toBe('pull');
+    expect(p.amount).toBe(50);
+  });
+
+  it('equals the requested amount when it is the smallest', () => {
+    expect(plan(s, OPEN, { ...PULL, requested: 20 }).amount).toBe(20);
+  });
+
+  it('equals the available balance when it is the smallest', () => {
+    expect(plan({ ...s, usdcAvailable: 30 }, OPEN, PULL).amount).toBe(30);
+  });
+
+  it('equals the equity when it is the smallest', () => {
+    expect(plan({ ...s, usdcAvailable: 80 }, OPEN, PULL).amount).toBe(50);
+  });
+
+  it('floors the amount to 0.01', () => {
+    expect(plan({ ...s, usdcEquity: 50.129, usdcAvailable: 100 }, OPEN, PULL).amount).toBe(50.12);
+  });
+
+  it('is 0 when the equity is 0 or below, with both routes unavailable', () => {
+    for (const usdcEquity of [0, -300]) {
+      const p = plan({ ...s, usdcEquity, usdcAvailable: 100 }, OPEN, PULL);
+      expect(p.amount).toBe(0);
+      expect(p.route).toBeNull();
+      expect(p.routes.loop).toMatchObject({ available: false, reason: 'nothing to move' });
+      expect(p.routes.convert).toMatchObject({ available: false, reason: 'convert runs one way only' });
+    }
+  });
+
+  it('quotes the loop as amount x (1 - bid) + amount x taker + the pull fee, with the pull wait', () => {
+    const p = plan(s, OPEN, PULL);
+    expect(p.routes.loop.costUsd).toBeCloseTo(50 * 0.0001 + PULL_FEE_USD, 9);
+    expect(p.routes.loop.waitSeconds).toBe(PULL_WAIT_SECONDS);
+    expect(p.routes.loop.waitSeconds).toBe(400);
+    const withFee = plan(s, { ...OPEN, spotTakerRate: 0.001 }, PULL);
+    expect(withFee.routes.loop.costUsd).toBeCloseTo(50 * 0.0001 + 50 * 0.001 + PULL_FEE_USD, 9);
+  });
+
+  it('charges no spread when the bid is above 1', () => {
+    const p = plan(s, { ...OPEN, bid: 1.0002 }, PULL);
+    expect(p.routes.loop.costUsd).toBeCloseTo(PULL_FEE_USD, 9);
+  });
+
+  it('marks convert unavailable because it runs one way only', () => {
+    const p = plan(s, OPEN, PULL);
+    expect(p.routes.convert).toEqual({ costUsd: 0, waitSeconds: 0, available: false, reason: 'convert runs one way only' });
+  });
+
+  it('picks the loop with the bid as the price and the sold USDT as receives', () => {
+    const p = plan(s, OPEN, PULL);
+    expect(p.route).toBe('loop');
+    expect(p.price).toBe(0.9999);
+    expect(p.receives).toBe(48.99);
+    expect(p.shortfall).toBeNull();
+    expect(p.borrowAfterUsd).toBe(0);
+    expect(p.savesPerDayUsd).toBe(0);
+    expect(p.marginFreedUsd).toBe(0);
+  });
+
+  it('matches the live run: 12 USDC at bid 1 lands 11 and receives 11 USDT', () => {
+    const p = plan({ ...s, usdcEquity: 12, usdcCash: 12 }, { ...OPEN, bid: 1 }, PULL);
+    expect(p.amount).toBe(12);
+    expect(p.route).toBe('loop');
+    expect(p.routes.loop.costUsd).toBeCloseTo(1, 9);
+    expect(p.receives).toBe(11);
+  });
+
+  it('takes the spot taker fee out of receives', () => {
+    const p = plan(s, { ...OPEN, bid: 1, spotTakerRate: 0.001 }, PULL);
+    expect(p.receives).toBe(48.95);
+  });
+
+  it('is unavailable when the USDC transfer is disabled or missing', () => {
+    const disabled = plan(s, { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 } }, PULL);
+    expect(disabled.routes.loop).toMatchObject({ available: false, reason: 'USDC transfers are disabled on CrossEx' });
+    const missing = plan(s, { ...OPEN, usdcTransfer: null }, PULL);
+    expect(missing.routes.loop).toMatchObject({ available: false, reason: 'USDC transfers are disabled on CrossEx' });
+    expect(missing.route).toBeNull();
+  });
+
+  it('is unavailable when the spot rule is not live or missing', () => {
+    expect(plan(s, { ...OPEN, spotRule: { state: 'suspended' } }, PULL).routes.loop.reason).toBe(
+      'GATE_SPOT_USDC_USDT is not live',
+    );
+    expect(plan(s, { ...OPEN, spotRule: null }, PULL).routes.loop.reason).toBe('GATE_SPOT_USDC_USDT is not live');
+  });
+
+  it('is unavailable when there is no spot bid, even with an ask', () => {
+    for (const bid of [null, 0]) {
+      const p = plan(s, { ...OPEN, bid }, PULL);
+      expect(p.routes.loop).toMatchObject({ available: false, reason: 'no spot price for USDC_USDT' });
+      expect(p.route).toBeNull();
+      expect(p.price).toBeNull();
+      expect(p.receives).toBe(0);
+    }
+  });
+
+  it('is unavailable when the pull lands below the transfer minimum after the fee', () => {
+    const p = plan({ ...s, usdcEquity: 11.5, usdcCash: 11.5 }, OPEN, PULL);
+    expect(p.amount).toBe(11.5);
+    expect(p.routes.loop.available).toBe(false);
+    expect(p.routes.loop.reason).toBe('pull lands 10.5 USDC after the $1 fee, below the 11 USDC transfer minimum');
+    const enough = plan({ ...s, usdcEquity: 12, usdcCash: 12 }, OPEN, PULL);
+    expect(enough.routes.loop.available).toBe(true);
+  });
+
+  it('reports the first cause only', () => {
+    const nothing = plan({ ...s, usdcEquity: 0 }, { ...OPEN, usdcTransfer: null, bid: null }, PULL);
+    expect(nothing.routes.loop.reason).toBe('nothing to move');
+    const disabled = plan(s, { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 }, spotRule: null, bid: null }, PULL);
+    expect(disabled.routes.loop.reason).toBe('USDC transfers are disabled on CrossEx');
+    const notLive = plan(s, { ...OPEN, spotRule: { state: 'paused' }, bid: null }, PULL);
+    expect(notLive.routes.loop.reason).toBe('GATE_SPOT_USDC_USDT is not live');
   });
 });

--- a/tests/unit/rebalance-plan.test.ts
+++ b/tests/unit/rebalance-plan.test.ts
@@ -119,7 +119,6 @@ describe('bucketsFrom interest', () => {
 describe('planFor amount', () => {
   it('equals the deficit when the deficit is the smallest', () => {
     const p = plan({ usdcEquity: -500, usdtCash: 1000, margin: 2000 });
-    expect(p.deficit).toBe(500);
     expect(p.amount).toBe(500);
   });
 
@@ -140,14 +139,12 @@ describe('planFor amount', () => {
 
   it('is 0 when USDC on Hyperliquid has no deficit', () => {
     const p = plan({ usdcEquity: 50, usdtCash: 1000, margin: 2000 });
-    expect(p.deficit).toBe(0);
     expect(p.amount).toBe(0);
   });
 
   it('is 0 when the USDC bucket is absent', () => {
     const account: AccountLike = { availableMargin: '2000', assets: [asset('USDT', 'CROSSEX', { balance: 1000 })] };
     const p = planFor(bucketsFrom(account, USDC_RATE, []), account, OPEN);
-    expect(p.deficit).toBe(0);
     expect(p.amount).toBe(0);
   });
 

--- a/tests/unit/rebalance-runner.test.ts
+++ b/tests/unit/rebalance-runner.test.ts
@@ -1,0 +1,560 @@
+import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { TtlCache } from '../../src/server/cache';
+import { JobFile, newJob, type Job, type RouteName } from '../../src/server/rebalanceJob';
+import {
+  LOOKUP_RETRY_MS,
+  POLL_MS,
+  QUOTE_FLOOR,
+  runJob,
+  STEP_TIMEOUT_MS,
+  tagFor,
+} from '../../src/server/rebalanceRunner';
+import { clientsWith } from '../helpers/fake-clients';
+
+type Handler = (arg?: any) => Promise<unknown>;
+
+function fakeClock() {
+  let t = 1_000_000;
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+function seq(...items: unknown[]): Handler {
+  let i = 0;
+  return async () => {
+    const item = items[Math.min(i, items.length - 1)];
+    i += 1;
+    return typeof item === 'function' ? item() : item;
+  };
+}
+
+const gateError = (status: number, label: string, message: string) => () => {
+  throw Object.assign(new Error(message), { response: { status, data: { label, message } } });
+};
+
+const created = (orderId: string) => ({ body: { orderId, text: 't' } });
+const order = (state: string, executedQty: string, orderId = 'o1') => ({ body: { orderId, state, executedQty } });
+const tx = (txId: string) => ({ body: { txId, text: 't' } });
+const row = (id: string, status: string, extra: Record<string, string> = {}) => ({
+  id,
+  status,
+  amount: '11.99000',
+  ...extra,
+});
+const rows = (...list: unknown[]) => ({ body: list });
+const account = (usdcOnHl: string) => ({
+  body: {
+    assets: [
+      { coin: 'USDT', exchangeType: 'CROSSEX', balance: '1200' },
+      { coin: 'USDC', exchangeType: 'HYPERLIQUID', balance: usdcOnHl },
+    ],
+  },
+});
+const quote = (quoteId: string, toAmount: string) => ({
+  body: { quoteId, validMs: '5000', fromAmount: '12', toAmount, price: '0.998' },
+});
+
+function happyLoop(): Record<string, Handler> {
+  const x1 = row('x1', 'SUCCESS', { actualReceive: '11.99' });
+  return {
+    createCrossexOrder: seq(created('o1')),
+    getCrossexOrder: seq(order('OPEN', '0'), order('FILLED', '11.99')),
+    createCrossexTransfer: seq(tx('x1'), tx('x2')),
+    listCrossexTransfers: seq(
+      rows(),
+      rows(row('x1', 'PENDING')),
+      rows(x1),
+      rows(x1, row('x2', 'PENDING')),
+      rows(x1, row('x2', 'SUCCESS', { actualReceive: '11.94' })),
+    ),
+  };
+}
+
+function harness(
+  clock: ReturnType<typeof fakeClock>,
+  route: RouteName,
+  handlers: Record<string, Handler>,
+  edit?: (job: Job) => void,
+) {
+  const calls: Record<string, any[]> = {};
+  const crossEx: Record<string, Handler> = {};
+  for (const [name, fn] of Object.entries(handlers)) {
+    crossEx[name] = async (arg?: unknown) => {
+      (calls[name] ??= []).push(arg);
+      return fn(arg);
+    };
+  }
+  const dir = fs.mkdtempSync(path.join(tmpdir(), 'rebalance-'));
+  const jobs = new JobFile(dir);
+  const job = newJob(route, 12, clock.now());
+  edit?.(job);
+  jobs.write(job);
+  const cache = new TtlCache();
+  const deps = { clients: () => clientsWith(crossEx), jobs, cache, now: clock.now, sleep: clock.sleep };
+  const count = (name: string) => calls[name]?.length ?? 0;
+  return { dir, job, jobs, cache, calls, count, deps, run: () => runJob(deps) };
+}
+
+const doneStep = (name: string, tag: string, venueId: string, qty: number, at: number) => ({
+  name,
+  text: tag,
+  quoteId: null,
+  venueId,
+  qty,
+  balanceBefore: null,
+  status: 'done' as const,
+  startedAt: at,
+  doneAt: at,
+});
+
+function resumeAtLastTransfer(job: Job, at: number, patch: Partial<Job['steps'][number]>): void {
+  job.steps[0] = doneStep('Buy USDC', tagFor(job.id, 0), 'o1', 11.99, at);
+  job.steps[1] = doneStep('To spot', tagFor(job.id, 1), 'x1', 11.99, at);
+  job.steps[2] = { ...job.steps[2], text: tagFor(job.id, 2), status: 'running', startedAt: at, ...patch };
+  job.stepIndex = 2;
+  job.fundsAt = 'SPOT';
+}
+
+describe('runJob loop route', () => {
+  it('runs to done with three venue ids and the qty chain 12 → 11.99 → 11.99 → 11.94', async () => {
+    const clock = fakeClock();
+    const h = harness(clock, 'loop', happyLoop());
+    await h.cache.get('account', 60_000, async () => 'old');
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(job.haltReason).toBeNull();
+    expect(job.amount).toBe(12);
+    expect(job.stepIndex).toBe(2);
+    expect(job.fundsAt).toBe('HYPERLIQUID');
+    expect(job.steps.map((s) => s.venueId)).toEqual(['o1', 'x1', 'x2']);
+    expect(job.steps.map((s) => s.qty)).toEqual([11.99, 11.99, 11.94]);
+    expect(job.steps.map((s) => s.status)).toEqual(['done', 'done', 'done']);
+    for (const s of job.steps) {
+      expect(s.startedAt).toBeTypeOf('number');
+      expect(s.doneAt).toBeTypeOf('number');
+      expect(s.quoteId).toBeNull();
+      expect(s.balanceBefore).toBeNull();
+    }
+
+    expect(h.calls.createCrossexOrder[0].crossexOrderRequest).toEqual({
+      symbol: 'GATE_SPOT_USDC_USDT',
+      side: 'BUY',
+      type: 'MARKET',
+      quoteQty: '12',
+      text: tagFor(job.id, 0),
+    });
+    expect(h.calls.createCrossexTransfer.map((a) => a.crossexTransferRequest)).toEqual([
+      { coin: 'USDC', amount: '11.99000', from: 'CROSSEX_GATE', to: 'SPOT', text: tagFor(job.id, 1) },
+      { coin: 'USDC', amount: '11.99000', from: 'SPOT', to: 'CROSSEX_HYPERLIQUID', text: tagFor(job.id, 2) },
+    ]);
+    expect(h.calls.listCrossexTransfers[0]).toEqual({ coin: 'USDC', limit: 20 });
+
+    const onDisk = JSON.parse(fs.readFileSync(path.join(h.dir, 'rebalance.json'), 'utf8')) as Job;
+    expect(onDisk.status).toBe('done');
+    expect(onDisk.steps.map((s) => s.venueId)).toEqual(['o1', 'x1', 'x2']);
+
+    const { value } = await h.cache.get('account', 60_000, async () => 'new');
+    expect(value).toBe('new');
+  });
+
+  it('halts when the order ends terminal with nothing filled', async () => {
+    const h = harness(fakeClock(), 'loop', { ...happyLoop(), getCrossexOrder: seq(order('REJECT', '0')) });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('halted');
+    expect(job.haltReason).toBe('order REJECT with nothing filled');
+    expect(job.fundsAt).toBe('CROSSEX');
+    expect(job.stepIndex).toBe(0);
+    expect(job.steps[0].venueId).toBe('o1');
+    expect(job.steps[0].status).toBe('running');
+    expect(h.count('createCrossexTransfer')).toBe(0);
+  });
+
+  it('halts on a FAILED transfer with its failReason and fundsAt GATE', async () => {
+    const h = harness(fakeClock(), 'loop', {
+      ...happyLoop(),
+      listCrossexTransfers: seq(rows(row('x1', 'FAILED', { failReason: 'insufficient balance' }))),
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('halted');
+    expect(job.haltReason).toBe('insufficient balance');
+    expect(job.fundsAt).toBe('GATE');
+    expect(job.stepIndex).toBe(1);
+    expect(job.steps[0].status).toBe('done');
+    expect(job.steps[1].venueId).toBe('x1');
+    expect(h.count('createCrossexTransfer')).toBe(1);
+  });
+
+  it('halts with timeout after 600 s without a terminal state', async () => {
+    const clock = fakeClock();
+    const h = harness(clock, 'loop', { ...happyLoop(), getCrossexOrder: seq(order('OPEN', '0')) });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('halted');
+    expect(job.haltReason).toBe('timeout');
+    expect(job.fundsAt).toBe('CROSSEX');
+    expect(clock.now() - job.steps[0].startedAt!).toBe(STEP_TIMEOUT_MS + POLL_MS);
+    expect(h.count('getCrossexOrder')).toBe(STEP_TIMEOUT_MS / POLL_MS + 1);
+    expect(h.count('createCrossexOrder')).toBe(1);
+  });
+
+  it('halts on a 4xx label at send with the message and the hint', async () => {
+    const h = harness(fakeClock(), 'loop', {
+      ...happyLoop(),
+      createCrossexOrder: seq(gateError(401, 'INVALID_KEY', 'invalid key')),
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('halted');
+    expect(job.haltReason).toBe(
+      'Gate API error (HTTP 401) [INVALID_KEY]: invalid key Check the API key/secret in Settings.',
+    );
+    expect(job.fundsAt).toBe('CROSSEX');
+    expect(job.steps[0].text).toBe(tagFor(job.id, 0));
+    expect(job.steps[0].venueId).toBeNull();
+    expect(h.count('createCrossexOrder')).toBe(1);
+    expect(h.count('getCrossexOrder')).toBe(0);
+  });
+
+  it('halts on a 4xx label without a hint with the message alone', async () => {
+    const h = harness(fakeClock(), 'loop', {
+      ...happyLoop(),
+      createCrossexOrder: seq(gateError(400, 'TRADE_INVALID_QUOTE_ORDER_QTY', 'bad qty')),
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('halted');
+    expect(job.haltReason).toBe('Gate API error (HTTP 400) [TRADE_INVALID_QUOTE_ORDER_QTY]: bad qty');
+    expect(h.count('createCrossexOrder')).toBe(1);
+  });
+
+  it('waits one POLL_MS after a rate-limited poll and reads again with no state change', async () => {
+    const clock = fakeClock();
+    const h = harness(clock, 'loop', {
+      ...happyLoop(),
+      getCrossexOrder: seq(gateError(429, 'TOO_MANY_REQUESTS', 'slow down'), order('FILLED', '11.99')),
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(h.count('getCrossexOrder')).toBe(2);
+    expect(job.steps[0].doneAt! - job.steps[0].startedAt!).toBe(POLL_MS);
+  });
+
+  it('finds the order by tag after a 5xx at send and does not send again', async () => {
+    const clock = fakeClock();
+    const lookups: number[] = [];
+    const h = harness(clock, 'loop', {
+      ...happyLoop(),
+      createCrossexOrder: seq(gateError(500, 'INTERNAL', 'boom')),
+      getCrossexOrder: async (id: string) => {
+        if (id.startsWith('t-')) lookups.push(clock.now());
+        return order('FILLED', '11.99');
+      },
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(h.count('createCrossexOrder')).toBe(1);
+    expect(job.steps[0].venueId).toBe('o1');
+    expect(lookups).toEqual([job.steps[0].startedAt! + POLL_MS]);
+    expect(h.calls.getCrossexOrder[0]).toBe(tagFor(job.id, 0));
+  });
+});
+
+describe('runJob convert route', () => {
+  it('quotes, reads the balance, sends the order, and is done with one step', async () => {
+    const h = harness(fakeClock(), 'convert', {
+      createCrossexConvertQuote: seq(quote('q1', '11.976')),
+      getCrossexAccount: seq(account('100')),
+      createCrossexConvertOrder: seq({ body: { orderId: 'c1', text: 'q1' } }),
+    });
+    await h.cache.get('account', 60_000, async () => 'old');
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(job.steps).toHaveLength(1);
+    expect(job.fundsAt).toBe('HYPERLIQUID');
+    expect(job.steps[0]).toMatchObject({
+      name: 'Convert',
+      text: tagFor(job.id, 0),
+      quoteId: 'q1',
+      venueId: 'c1',
+      qty: 11.976,
+      balanceBefore: 100,
+      status: 'done',
+    });
+    expect(h.calls.createCrossexConvertQuote[0].crossexConvertQuoteRequest).toEqual({
+      exchangeType: 'HYPERLIQUID',
+      fromCoin: 'USDT',
+      toCoin: 'USDC',
+      fromAmount: '12',
+    });
+    expect(h.calls.createCrossexConvertOrder[0].crossexConvertOrderRequest).toEqual({ quoteId: 'q1' });
+    expect(h.count('getCrossexAccount')).toBe(1);
+    const { value } = await h.cache.get('account', 60_000, async () => 'new');
+    expect(value).toBe('new');
+  });
+
+  it('halts on a quote below the floor and sends no order', async () => {
+    const below = String(12 * QUOTE_FLOOR - 0.01);
+    const h = harness(fakeClock(), 'convert', {
+      createCrossexConvertQuote: seq(quote('q1', below)),
+      getCrossexAccount: seq(account('100')),
+      createCrossexConvertOrder: seq({ body: { orderId: 'c1', text: 'q1' } }),
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('halted');
+    expect(job.haltReason).toBe('quote worse than 30 bps');
+    expect(job.fundsAt).toBe('CROSSEX');
+    expect(job.steps[0].quoteId).toBeNull();
+    expect(job.steps[0].venueId).toBeNull();
+    expect(h.count('createCrossexConvertOrder')).toBe(0);
+    expect(h.count('getCrossexAccount')).toBe(0);
+  });
+});
+
+describe('runJob resumed steps send nothing twice', () => {
+  it('a step with a venueId makes one read and no send', async () => {
+    const clock = fakeClock();
+    const h = harness(
+      clock,
+      'loop',
+      {
+        ...happyLoop(),
+        listCrossexTransfers: seq(rows(row('x2', 'SUCCESS', { actualReceive: '11.94' }))),
+      },
+      (job) => resumeAtLastTransfer(job, clock.now(), { venueId: 'x2' }),
+    );
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(job.fundsAt).toBe('HYPERLIQUID');
+    expect(job.steps[2].qty).toBe(11.94);
+    expect(h.count('listCrossexTransfers')).toBe(1);
+    expect(h.count('createCrossexTransfer')).toBe(0);
+    expect(h.count('createCrossexOrder')).toBe(0);
+    expect(h.count('getCrossexOrder')).toBe(0);
+  });
+
+  it('a Buy step with text only, found on lookup, records the id and sends nothing', async () => {
+    const clock = fakeClock();
+    const h = harness(
+      clock,
+      'loop',
+      { ...happyLoop(), getCrossexOrder: seq(order('FILLED', '11.99', 'o1')) },
+      (job) => {
+        job.steps[0].text = tagFor(job.id, 0);
+        job.steps[0].status = 'running';
+        job.steps[0].startedAt = clock.now();
+      },
+    );
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(job.steps[0].venueId).toBe('o1');
+    expect(h.count('createCrossexOrder')).toBe(0);
+    expect(h.calls.getCrossexOrder).toEqual([tagFor(job.id, 0), 'o1']);
+  });
+
+  it('a transfer step with text only, found on lookup, records the id and sends nothing', async () => {
+    const clock = fakeClock();
+    const h = harness(
+      clock,
+      'loop',
+      {
+        ...happyLoop(),
+        listCrossexTransfers: seq(rows(row('x2', 'SUCCESS', { actualReceive: '11.94', text: 'tag2' }))),
+      },
+      (job) => resumeAtLastTransfer(job, clock.now(), { text: 'tag2' }),
+    );
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(job.steps[2].venueId).toBe('x2');
+    expect(job.steps[2].qty).toBe(11.94);
+    expect(h.count('createCrossexTransfer')).toBe(0);
+    expect(h.count('listCrossexTransfers')).toBe(2);
+  });
+
+  it('a Buy step not found twice waits 10 s between lookups, then sends once', async () => {
+    const clock = fakeClock();
+    const lookups: number[] = [];
+    let sentAt = -1;
+    const h = harness(
+      clock,
+      'loop',
+      {
+        ...happyLoop(),
+        createCrossexOrder: async () => {
+          sentAt = clock.now();
+          return created('o1');
+        },
+        getCrossexOrder: async (id: string) => {
+          if (id === 'o1') return order('FILLED', '11.99');
+          lookups.push(clock.now());
+          return gateError(404, 'ORDER_NOT_FOUND', 'order not found')();
+        },
+      },
+      (job) => {
+        job.steps[0].text = tagFor(job.id, 0);
+        job.steps[0].status = 'running';
+        job.steps[0].startedAt = clock.now();
+      },
+    );
+    const t0 = clock.now();
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(job.steps[0].venueId).toBe('o1');
+    expect(h.count('createCrossexOrder')).toBe(1);
+    expect(lookups).toEqual([t0, t0 + LOOKUP_RETRY_MS]);
+    expect(sentAt).toBe(t0 + LOOKUP_RETRY_MS);
+  });
+
+  it('a convert step with a quoteId is done with no send when the balance rose by the quote', async () => {
+    const clock = fakeClock();
+    const h = harness(
+      clock,
+      'convert',
+      {
+        createCrossexConvertQuote: seq(quote('q2', '11.976')),
+        getCrossexAccount: seq(account('111.97')),
+        createCrossexConvertOrder: seq({ body: { orderId: 'c2', text: 'q2' } }),
+      },
+      (job) => {
+        Object.assign(job.steps[0], {
+          text: tagFor(job.id, 0),
+          quoteId: 'q1',
+          qty: 11.976,
+          balanceBefore: 100,
+          status: 'running',
+          startedAt: clock.now(),
+        });
+      },
+    );
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(job.fundsAt).toBe('HYPERLIQUID');
+    expect(job.steps[0]).toMatchObject({ quoteId: 'q1', venueId: null, qty: 11.976, status: 'done' });
+    expect(h.count('getCrossexAccount')).toBe(1);
+    expect(h.count('createCrossexConvertQuote')).toBe(0);
+    expect(h.count('createCrossexConvertOrder')).toBe(0);
+  });
+
+  it('a convert step with a quoteId re-quotes and sends once when the balance did not rise', async () => {
+    const clock = fakeClock();
+    const h = harness(
+      clock,
+      'convert',
+      {
+        createCrossexConvertQuote: seq(quote('q2', '11.97')),
+        getCrossexAccount: seq(account('100')),
+        createCrossexConvertOrder: seq({ body: { orderId: 'c2', text: 'q2' } }),
+      },
+      (job) => {
+        Object.assign(job.steps[0], {
+          text: tagFor(job.id, 0),
+          quoteId: 'q1',
+          qty: 11.976,
+          balanceBefore: 100,
+          status: 'running',
+          startedAt: clock.now(),
+        });
+      },
+    );
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(job.steps[0]).toMatchObject({ quoteId: 'q2', venueId: 'c2', qty: 11.97, balanceBefore: 100 });
+    expect(h.count('getCrossexAccount')).toBe(2);
+    expect(h.count('createCrossexConvertQuote')).toBe(1);
+    expect(h.count('createCrossexConvertOrder')).toBe(1);
+  });
+});
+
+describe('JobFile', () => {
+  const dir = () => fs.mkdtempSync(path.join(tmpdir(), 'rebalance-'));
+
+  it('reads null when no file exists', () => {
+    expect(new JobFile(dir()).read()).toBeNull();
+  });
+
+  it('writes an owner-only file that a new JobFile reads back', () => {
+    const d = dir();
+    const job = newJob('loop', 12, 1_000_000);
+    expect(job.id).toBe((1_000_000).toString(36));
+    expect(job.steps.map((s) => s.name)).toEqual(['Buy USDC', 'To spot', 'To Hyperliquid']);
+    expect(newJob('convert', 5, 7).steps.map((s) => s.name)).toEqual(['Convert']);
+
+    new JobFile(d).write(job);
+
+    const file = path.join(d, 'rebalance.json');
+    if (process.platform !== 'win32') expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    expect(fs.readdirSync(d)).toEqual(['rebalance.json']);
+    const back = new JobFile(d).read()!;
+    expect(back).toEqual({ ...job, updatedAt: back.updatedAt });
+    expect(back.updatedAt).toBeGreaterThan(job.createdAt);
+  });
+
+  it('haltIfRunning halts a running job with the reason and leaves other statuses alone', () => {
+    const d = dir();
+    const jobs = new JobFile(d);
+    jobs.write(newJob('loop', 12, 1_000_000));
+
+    jobs.haltIfRunning('server restarted');
+
+    expect(jobs.read()).toMatchObject({ status: 'halted', haltReason: 'server restarted' });
+    expect(new JobFile(d).read()).toMatchObject({ status: 'halted', haltReason: 'server restarted' });
+
+    const done = { ...newJob('loop', 12, 2_000_000), status: 'done' as const };
+    jobs.write(done);
+    jobs.haltIfRunning('server restarted');
+    expect(jobs.read()).toMatchObject({ status: 'done', haltReason: null });
+
+    expect(() => new JobFile(dir()).haltIfRunning('server restarted')).not.toThrow();
+  });
+});

--- a/tests/unit/rebalance-runner.test.ts
+++ b/tests/unit/rebalance-runner.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { TtlCache } from '../../src/server/cache';
 import { JobFile, newJob, type Job, type RouteName } from '../../src/server/rebalanceJob';
 import {
@@ -40,7 +40,12 @@ const gateError = (status: number, label: string, message: string) => () => {
 };
 
 const created = (orderId: string) => ({ body: { orderId, text: 't' } });
-const order = (state: string, executedQty: string, orderId = 'o1') => ({ body: { orderId, state, executedQty } });
+const order = (state: string, executedQty: string, orderId = 'o1', extra: Record<string, string> = {}) => ({
+  body: { orderId, state, executedQty, ...extra },
+});
+const networkError = () => {
+  throw Object.assign(new Error('timeout of 10000ms exceeded'), { code: 'ECONNABORTED' });
+};
 const tx = (txId: string) => ({ body: { txId, text: 't' } });
 const row = (id: string, status: string, extra: Record<string, string> = {}) => ({
   id,
@@ -92,14 +97,15 @@ function harness(
     };
   }
   const dir = fs.mkdtempSync(path.join(tmpdir(), 'rebalance-'));
-  const jobs = new JobFile(dir);
+  const jobs = new JobFile(dir, clock.now);
   const job = newJob(route, 12, clock.now());
   edit?.(job);
   jobs.write(job);
   const cache = new TtlCache();
-  const deps = { clients: () => clientsWith(crossEx), jobs, cache, now: clock.now, sleep: clock.sleep };
+  const log = vi.fn();
+  const deps = { clients: () => clientsWith(crossEx), jobs, cache, now: clock.now, sleep: clock.sleep, log };
   const count = (name: string) => calls[name]?.length ?? 0;
-  return { dir, job, jobs, cache, calls, count, deps, run: () => runJob(deps) };
+  return { dir, job, jobs, cache, calls, count, deps, log, run: () => runJob(deps) };
 }
 
 const doneStep = (name: string, tag: string, venueId: string, qty: number, at: number) => ({
@@ -109,6 +115,7 @@ const doneStep = (name: string, tag: string, venueId: string, qty: number, at: n
   venueId,
   qty,
   balanceBefore: null,
+  attempt: 0,
   status: 'done' as const,
   startedAt: at,
   doneAt: at,
@@ -157,7 +164,8 @@ describe('runJob loop route', () => {
       { coin: 'USDC', amount: '11.99000', from: 'CROSSEX_GATE', to: 'SPOT', text: tagFor(job.id, 1) },
       { coin: 'USDC', amount: '11.99000', from: 'SPOT', to: 'CROSSEX_HYPERLIQUID', text: tagFor(job.id, 2) },
     ]);
-    expect(h.calls.listCrossexTransfers[0]).toEqual({ coin: 'USDC', limit: 20 });
+    expect(h.calls.listCrossexTransfers[0]).toEqual({ coin: 'USDC', limit: 100 });
+    expect(h.log).not.toHaveBeenCalled();
 
     const onDisk = JSON.parse(fs.readFileSync(path.join(h.dir, 'rebalance.json'), 'utf8')) as Job;
     expect(onDisk.status).toBe('done');
@@ -177,15 +185,141 @@ describe('runJob loop route', () => {
     expect(job.haltReason).toBe('order REJECT with nothing filled');
     expect(job.fundsAt).toBe('CROSSEX');
     expect(job.stepIndex).toBe(0);
-    expect(job.steps[0].venueId).toBe('o1');
+    expect(job.steps[0].venueId).toBeNull();
+    expect(job.steps[0].text).toBeNull();
     expect(job.steps[0].status).toBe('running');
+    expect(h.count('createCrossexTransfer')).toBe(0);
+    expect(h.log).toHaveBeenCalledWith(
+      `rebalance ${job.id} halted at Buy USDC: order REJECT with nothing filled. Funds are in CROSSEX.`,
+    );
+  });
+
+  it('subtracts a USDC fee from the executed qty', async () => {
+    const h = harness(fakeClock(), 'loop', {
+      ...happyLoop(),
+      getCrossexOrder: seq(order('FILLED', '11.99', 'o1', { feeCoin: 'USDC', fee: '0.012' })),
+      listCrossexTransfers: seq(
+        rows(row('x1', 'SUCCESS', { actualReceive: '11.978' })),
+        rows(row('x2', 'SUCCESS', { actualReceive: '11.928' })),
+      ),
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(job.steps[0].qty).toBe(11.978);
+    expect(h.calls.createCrossexTransfer[0].crossexTransferRequest.amount).toBe('11.97800');
+  });
+
+  it('keeps a USDT fee out of the executed qty', async () => {
+    const h = harness(fakeClock(), 'loop', {
+      ...happyLoop(),
+      getCrossexOrder: seq(order('FILLED', '11.99', 'o1', { feeCoin: 'USDT', fee: '0.012' })),
+    });
+
+    await h.run();
+
+    expect(h.jobs.read()!.steps[0].qty).toBe(11.99);
+  });
+
+  it('keeps polling through an ACTIVE state and finishes on FILLED', async () => {
+    const h = harness(fakeClock(), 'loop', {
+      ...happyLoop(),
+      getCrossexOrder: seq(order('ACTIVE', '0'), order('ACTIVE', '0'), order('FILLED', '11.99')),
+    });
+
+    await h.run();
+
+    expect(h.jobs.read()!.status).toBe('done');
+    expect(h.count('getCrossexOrder')).toBe(3);
+  });
+
+  it('treats a 404 on a poll as transient and finishes on the next FILLED', async () => {
+    const h = harness(fakeClock(), 'loop', {
+      ...happyLoop(),
+      getCrossexOrder: seq(gateError(404, 'ORDER_NOT_FOUND', 'order not found'), order('FILLED', '11.99')),
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(job.haltReason).toBeNull();
+    expect(h.count('getCrossexOrder')).toBe(2);
+  });
+
+  it('halts on a transfer SUCCESS that received nothing', async () => {
+    const h = harness(fakeClock(), 'loop', {
+      ...happyLoop(),
+      listCrossexTransfers: seq(rows(row('x1', 'SUCCESS', { actualReceive: '0' }))),
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('halted');
+    expect(job.haltReason).toBe('transfer SUCCESS with nothing received');
+    expect(job.fundsAt).toBe('GATE');
+    expect(job.steps[1].venueId).toBe('x1');
+  });
+
+  it('halts on a CANCELLED transfer and clears its ids for a fresh send', async () => {
+    const h = harness(fakeClock(), 'loop', {
+      ...happyLoop(),
+      listCrossexTransfers: seq(rows(row('x1', 'CANCELLED'))),
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('halted');
+    expect(job.haltReason).toBe('transfer CANCELLED');
+    expect(job.steps[1].venueId).toBeNull();
+    expect(job.steps[1].text).toBeNull();
+  });
+
+  it('halts on a step name it does not know before any venue call', async () => {
+    const h = harness(fakeClock(), 'loop', happyLoop(), (job) => {
+      job.steps[0].name = 'Bogus';
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('halted');
+    expect(job.haltReason).toBe('unknown step Bogus');
+    expect(h.count('createCrossexOrder')).toBe(0);
     expect(h.count('createCrossexTransfer')).toBe(0);
   });
 
-  it('halts on a FAILED transfer with its failReason and fundsAt GATE', async () => {
+  it('adopts a transfer by tag on the next pass when the send response has no txId', async () => {
+    const id = (1_000_000).toString(36);
+    const x1 = row('x1', 'SUCCESS', { actualReceive: '11.99', text: tagFor(id, 1) });
     const h = harness(fakeClock(), 'loop', {
       ...happyLoop(),
-      listCrossexTransfers: seq(rows(row('x1', 'FAILED', { failReason: 'insufficient balance' }))),
+      createCrossexTransfer: seq({ body: { text: 't' } }, tx('x2')),
+      listCrossexTransfers: seq(rows(x1), rows(x1), rows(x1, row('x2', 'SUCCESS', { actualReceive: '11.94' }))),
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.id).toBe(id);
+    expect(job.status).toBe('done');
+    expect(job.steps.map((s) => s.venueId)).toEqual(['o1', 'x1', 'x2']);
+    expect(h.count('createCrossexTransfer')).toBe(2);
+  });
+
+  it('halts on a FAILED transfer with its failReason and fundsAt GATE, and a resume sends one new transfer', async () => {
+    const h = harness(fakeClock(), 'loop', {
+      ...happyLoop(),
+      createCrossexTransfer: seq(tx('x1'), tx('x2'), tx('x3')),
+      listCrossexTransfers: seq(
+        rows(row('x1', 'FAILED', { failReason: 'insufficient balance' })),
+        rows(row('x2', 'SUCCESS', { actualReceive: '11.99' })),
+        rows(row('x3', 'SUCCESS', { actualReceive: '11.94' })),
+      ),
     });
 
     await h.run();
@@ -196,8 +330,25 @@ describe('runJob loop route', () => {
     expect(job.fundsAt).toBe('GATE');
     expect(job.stepIndex).toBe(1);
     expect(job.steps[0].status).toBe('done');
-    expect(job.steps[1].venueId).toBe('x1');
+    expect(job.steps[1].venueId).toBeNull();
+    expect(job.steps[1].text).toBeNull();
     expect(h.count('createCrossexTransfer')).toBe(1);
+    expect(h.log).toHaveBeenCalledWith(
+      `rebalance ${job.id} halted at To spot: insufficient balance. Funds are in GATE.`,
+    );
+
+    job.status = 'running';
+    job.haltReason = null;
+    h.jobs.write(job);
+    await h.run();
+
+    const resumed = h.jobs.read()!;
+    expect(resumed.steps[1].attempt).toBe(1);
+    expect(h.calls.createCrossexTransfer[1].crossexTransferRequest.text).toBe(tagFor(job.id, 1, 1));
+    expect(h.calls.createCrossexTransfer[1].crossexTransferRequest.text).not.toBe(h.calls.createCrossexTransfer[0].crossexTransferRequest.text);
+    expect(resumed.status).toBe('done');
+    expect(resumed.steps.map((s) => s.venueId)).toEqual(['o1', 'x2', 'x3']);
+    expect(h.count('createCrossexTransfer')).toBe(3);
   });
 
   it('halts with timeout after 600 s without a terminal state', async () => {
@@ -210,6 +361,8 @@ describe('runJob loop route', () => {
     expect(job.status).toBe('halted');
     expect(job.haltReason).toBe('timeout');
     expect(job.fundsAt).toBe('CROSSEX');
+    expect(job.steps[0].venueId).toBe('o1');
+    expect(job.steps[0].text).toBe(tagFor(job.id, 0));
     expect(clock.now() - job.steps[0].startedAt!).toBe(STEP_TIMEOUT_MS + POLL_MS);
     expect(h.count('getCrossexOrder')).toBe(STEP_TIMEOUT_MS / POLL_MS + 1);
     expect(h.count('createCrossexOrder')).toBe(1);
@@ -339,8 +492,28 @@ describe('runJob convert route', () => {
     expect(job.fundsAt).toBe('CROSSEX');
     expect(job.steps[0].quoteId).toBeNull();
     expect(job.steps[0].venueId).toBeNull();
+    expect(job.steps[0].balanceBefore).toBe(100);
     expect(h.count('createCrossexConvertOrder')).toBe(0);
-    expect(h.count('getCrossexAccount')).toBe(0);
+    expect(h.count('getCrossexAccount')).toBe(1);
+  });
+
+  it('sends one order when the order call times out and the balance then shows it landed', async () => {
+    const clock = fakeClock();
+    const h = harness(clock, 'convert', {
+      createCrossexConvertQuote: seq(quote('q1', '11.976')),
+      getCrossexAccount: seq(account('100'), account('100'), account('111.976')),
+      createCrossexConvertOrder: seq(networkError, { body: { orderId: 'c1', text: 'q1' } }),
+    });
+
+    await h.run();
+
+    const job = h.jobs.read()!;
+    expect(job.status).toBe('done');
+    expect(job.steps[0]).toMatchObject({ quoteId: 'q1', venueId: null, qty: 11.976, balanceBefore: 100, status: 'done' });
+    expect(h.count('createCrossexConvertOrder')).toBe(1);
+    expect(h.count('createCrossexConvertQuote')).toBe(1);
+    expect(h.count('getCrossexAccount')).toBe(3);
+    expect(job.steps[0].doneAt! - job.steps[0].startedAt!).toBe(POLL_MS + LOOKUP_RETRY_MS);
   });
 });
 
@@ -540,21 +713,58 @@ describe('JobFile', () => {
     expect(back.updatedAt).toBeGreaterThan(job.createdAt);
   });
 
+  it('reads null and says so once when the file is not a job', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      const d = dir();
+      const { steps: _steps, ...noSteps } = newJob('loop', 12, 1_000_000);
+      fs.writeFileSync(path.join(d, 'rebalance.json'), JSON.stringify(noSteps));
+      const jobs = new JobFile(d);
+      expect(jobs.read()).toBeNull();
+      expect(jobs.read()).toBeNull();
+      expect(error).toHaveBeenCalledTimes(1);
+      expect(String(error.mock.calls[0][0])).toContain('treating as no job');
+
+      fs.writeFileSync(path.join(d, 'rebalance.json'), '{not json');
+      expect(new JobFile(d).read()).toBeNull();
+
+      const bogus = newJob('loop', 12, 1_000_000);
+      bogus.steps[1].name = 'Bogus';
+      fs.writeFileSync(path.join(d, 'rebalance.json'), JSON.stringify(bogus));
+      expect(new JobFile(d).read()).toBeNull();
+
+      const wrongIndex = { ...newJob('loop', 12, 1_000_000), stepIndex: 3 };
+      fs.writeFileSync(path.join(d, 'rebalance.json'), JSON.stringify(wrongIndex));
+      expect(new JobFile(d).read()).toBeNull();
+      expect(error).toHaveBeenCalledTimes(4);
+    } finally {
+      error.mockRestore();
+    }
+  });
+
+  it('stamps updatedAt from the clock it was given', () => {
+    const jobs = new JobFile(dir(), () => 42);
+    const job = newJob('loop', 12, 1_000_000);
+    jobs.write(job);
+    expect(job.updatedAt).toBe(42);
+  });
+
   it('haltIfRunning halts a running job with the reason and leaves other statuses alone', () => {
     const d = dir();
     const jobs = new JobFile(d);
     jobs.write(newJob('loop', 12, 1_000_000));
 
-    jobs.haltIfRunning('server restarted');
+    expect(jobs.haltIfRunning('server restarted')).toBe(true);
 
     expect(jobs.read()).toMatchObject({ status: 'halted', haltReason: 'server restarted' });
     expect(new JobFile(d).read()).toMatchObject({ status: 'halted', haltReason: 'server restarted' });
+    expect(jobs.haltIfRunning('server restarted')).toBe(false);
 
     const done = { ...newJob('loop', 12, 2_000_000), status: 'done' as const };
     jobs.write(done);
-    jobs.haltIfRunning('server restarted');
+    expect(jobs.haltIfRunning('server restarted')).toBe(false);
     expect(jobs.read()).toMatchObject({ status: 'done', haltReason: null });
 
-    expect(() => new JobFile(dir()).haltIfRunning('server restarted')).not.toThrow();
+    expect(new JobFile(dir()).haltIfRunning('server restarted')).toBe(false);
   });
 });

--- a/tests/unit/rebalance-runner.test.ts
+++ b/tests/unit/rebalance-runner.test.ts
@@ -98,7 +98,7 @@ function harness(
   }
   const dir = fs.mkdtempSync(path.join(tmpdir(), 'rebalance-'));
   const jobs = new JobFile(dir, clock.now);
-  const job = newJob(route, 12, clock.now());
+  const job = newJob('payDown', route, 12, clock.now());
   edit?.(job);
   jobs.write(job);
   const cache = new TtlCache();
@@ -698,10 +698,10 @@ describe('JobFile', () => {
 
   it('writes an owner-only file that a new JobFile reads back', () => {
     const d = dir();
-    const job = newJob('loop', 12, 1_000_000);
+    const job = newJob('payDown', 'loop', 12, 1_000_000);
     expect(job.id).toBe((1_000_000).toString(36));
     expect(job.steps.map((s) => s.name)).toEqual(['Buy USDC', 'To spot', 'To Hyperliquid']);
-    expect(newJob('convert', 5, 7).steps.map((s) => s.name)).toEqual(['Convert']);
+    expect(newJob('payDown', 'convert', 5, 7).steps.map((s) => s.name)).toEqual(['Convert']);
 
     new JobFile(d).write(job);
 
@@ -717,7 +717,7 @@ describe('JobFile', () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     try {
       const d = dir();
-      const { steps: _steps, ...noSteps } = newJob('loop', 12, 1_000_000);
+      const { steps: _steps, ...noSteps } = newJob('payDown', 'loop', 12, 1_000_000);
       fs.writeFileSync(path.join(d, 'rebalance.json'), JSON.stringify(noSteps));
       const jobs = new JobFile(d);
       expect(jobs.read()).toBeNull();
@@ -728,12 +728,12 @@ describe('JobFile', () => {
       fs.writeFileSync(path.join(d, 'rebalance.json'), '{not json');
       expect(new JobFile(d).read()).toBeNull();
 
-      const bogus = newJob('loop', 12, 1_000_000);
+      const bogus = newJob('payDown', 'loop', 12, 1_000_000);
       bogus.steps[1].name = 'Bogus';
       fs.writeFileSync(path.join(d, 'rebalance.json'), JSON.stringify(bogus));
       expect(new JobFile(d).read()).toBeNull();
 
-      const wrongIndex = { ...newJob('loop', 12, 1_000_000), stepIndex: 3 };
+      const wrongIndex = { ...newJob('payDown', 'loop', 12, 1_000_000), stepIndex: 3 };
       fs.writeFileSync(path.join(d, 'rebalance.json'), JSON.stringify(wrongIndex));
       expect(new JobFile(d).read()).toBeNull();
       expect(error).toHaveBeenCalledTimes(4);
@@ -744,7 +744,7 @@ describe('JobFile', () => {
 
   it('stamps updatedAt from the clock it was given', () => {
     const jobs = new JobFile(dir(), () => 42);
-    const job = newJob('loop', 12, 1_000_000);
+    const job = newJob('payDown', 'loop', 12, 1_000_000);
     jobs.write(job);
     expect(job.updatedAt).toBe(42);
   });
@@ -752,7 +752,7 @@ describe('JobFile', () => {
   it('haltIfRunning halts a running job with the reason and leaves other statuses alone', () => {
     const d = dir();
     const jobs = new JobFile(d);
-    jobs.write(newJob('loop', 12, 1_000_000));
+    jobs.write(newJob('payDown', 'loop', 12, 1_000_000));
 
     expect(jobs.haltIfRunning('server restarted')).toBe(true);
 
@@ -760,7 +760,7 @@ describe('JobFile', () => {
     expect(new JobFile(d).read()).toMatchObject({ status: 'halted', haltReason: 'server restarted' });
     expect(jobs.haltIfRunning('server restarted')).toBe(false);
 
-    const done = { ...newJob('loop', 12, 2_000_000), status: 'done' as const };
+    const done = { ...newJob('payDown', 'loop', 12, 2_000_000), status: 'done' as const };
     jobs.write(done);
     expect(jobs.haltIfRunning('server restarted')).toBe(false);
     expect(jobs.read()).toMatchObject({ status: 'done', haltReason: null });

--- a/version.json
+++ b/version.json
@@ -1,10 +1,8 @@
 {
-  "version": "1.5.0",
+  "version": "1.5.1",
   "highlights": [
-    "Windows only, one time: run the install command below once more. After that, updating is a button press",
-    "Updating is now one button — it installs the new version, restarts, and reloads this page. You can watch it work, and if it cannot start, your old version comes back",
-    "Boros gas takes care of itself. An empty gas pot no longer stops an order, and there is nothing to top up by hand",
-    "Orders that cannot go through now say what to change, and which venue is the problem",
-    "A position's Fixed APY is counted from the day you opened it. The old figure was too high — and the spread beside it now shows what each leg contributes"
+    "The Balances tab now shows when Hyperliquid has borrowed USDC, and what it costs you in held margin and interest",
+    "One hold pays the borrow back by the cheapest route, or brings spare USDC home as USDT",
+    "A progress bar shows each step and how long it should take. A refresh keeps a running move; a restart halts it safely with Resume and Abandon"
   ]
 }

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -33,6 +33,7 @@ import type {
   OpenOrder,
   OpportunitiesResult,
   PositionsResponse,
+  RebalanceDirection,
   RebalanceJob,
   RebalanceView,
   StrategyReturns,
@@ -392,10 +393,14 @@ export function useAlerts() {
   });
 }
 
-export function useRebalance() {
+export function useRebalance({ direction, amount }: { direction: RebalanceDirection; amount: number | null }) {
+  const params = new URLSearchParams();
+  if (direction !== 'payDown') params.set('direction', direction);
+  if (amount !== null) params.set('amount', String(amount));
+  const query = params.toString();
   return useQuery({
-    queryKey: qk.rebalance,
-    queryFn: () => fetchJson<RebalanceView>('/rebalance'),
+    queryKey: [...qk.rebalance, direction, amount ?? ''] as const,
+    queryFn: () => fetchJson<RebalanceView>(`/rebalance${query ? `?${query}` : ''}`),
     refetchInterval: (q) => (q.state.data?.job?.status === 'running' ? 1_000 : 4_000),
     refetchIntervalInBackground: true,
     placeholderData: keepPreviousData,
@@ -405,7 +410,7 @@ export function useRebalance() {
 export function useStartRebalance() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: { amount: number; route: 'loop' | 'convert' }) =>
+    mutationFn: (body: { direction: RebalanceDirection; amount: number; route: 'loop' | 'convert' }) =>
       postJson<{ id: string }>('/rebalance', body),
     onSuccess: () => void qc.invalidateQueries({ queryKey: qk.rebalance }),
   });

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -393,31 +393,20 @@ export function useAlerts() {
 }
 
 export function useRebalance() {
-  const qc = useQueryClient();
-  const settled = useRef<string | null>(null);
-  const query = useQuery({
+  return useQuery({
     queryKey: qk.rebalance,
     queryFn: () => fetchJson<RebalanceView>('/rebalance'),
     refetchInterval: (q) => (q.state.data?.job?.status === 'running' ? 1_000 : 4_000),
     refetchIntervalInBackground: true,
     placeholderData: keepPreviousData,
   });
-
-  const jobId = query.data?.job?.id ?? null;
-  const jobStatus = query.data?.job?.status;
-  useEffect(() => {
-    if (!jobId || jobStatus !== 'done' || settled.current === jobId) return;
-    settled.current = jobId;
-    void qc.invalidateQueries({ queryKey: qk.account });
-  }, [jobId, jobStatus, qc]);
-
-  return query;
 }
 
 export function useStartRebalance() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: () => postJson<{ id: string }>('/rebalance', {}),
+    mutationFn: (body: { amount: number; route: 'loop' | 'convert' }) =>
+      postJson<{ id: string }>('/rebalance', body),
     onSuccess: () => void qc.invalidateQueries({ queryKey: qk.rebalance }),
   });
 }

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -33,6 +33,8 @@ import type {
   OpenOrder,
   OpportunitiesResult,
   PositionsResponse,
+  RebalanceJob,
+  RebalanceView,
   StrategyReturns,
   SymbolDetail,
   SymbolRule,
@@ -70,6 +72,7 @@ export const qk = {
   deal: (id: string) => ['deal', id] as const,
   activeDeals: ['deals', 'active'] as const,
   alerts: ['alerts'] as const,
+  rebalance: ['rebalance'] as const,
 };
 
 export function useCredentials() {
@@ -386,6 +389,44 @@ export function useAlerts() {
     queryFn: () => fetchJson<DealAlert[]>('/alerts?unacked=1'),
     refetchInterval: 10_000,
     refetchIntervalInBackground: true,
+  });
+}
+
+export function useRebalance() {
+  const qc = useQueryClient();
+  const settled = useRef<string | null>(null);
+  const query = useQuery({
+    queryKey: qk.rebalance,
+    queryFn: () => fetchJson<RebalanceView>('/rebalance'),
+    refetchInterval: (q) => (q.state.data?.job?.status === 'running' ? 1_000 : 4_000),
+    refetchIntervalInBackground: true,
+    placeholderData: keepPreviousData,
+  });
+
+  const jobId = query.data?.job?.id ?? null;
+  const jobStatus = query.data?.job?.status;
+  useEffect(() => {
+    if (!jobId || jobStatus !== 'done' || settled.current === jobId) return;
+    settled.current = jobId;
+    void qc.invalidateQueries({ queryKey: qk.account });
+  }, [jobId, jobStatus, qc]);
+
+  return query;
+}
+
+export function useStartRebalance() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => postJson<{ id: string }>('/rebalance', {}),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: qk.rebalance }),
+  });
+}
+
+export function useRebalanceCommand(cmd: 'resume' | 'abandon') {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => postJson<RebalanceJob>(`/rebalance/${encodeURIComponent(id)}/${cmd}`, {}),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: qk.rebalance }),
   });
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -137,6 +137,8 @@ export interface CrossexAccount {
 // GET /api/rebalance · POST /api/rebalance · POST /api/rebalance/:id/{resume,abandon}
 // ---------------------------------------------------------------------------
 
+export type RebalanceDirection = 'payDown' | 'pull';
+
 export interface RebalanceBucket {
   coin: string;
   venue: string;
@@ -144,6 +146,8 @@ export interface RebalanceBucket {
   upnl: number;
   equity: number;
   borrow: number;
+  imHeldUsd: number;
+  mmHeldUsd: number;
   interestPaid30dUsd: number;
   interestPerDayUsd: number;
 }
@@ -156,7 +160,11 @@ export interface RebalanceRoute {
 }
 
 export interface RebalancePlan {
+  direction: RebalanceDirection;
   amount: number;
+  receives: number;
+  price: number | null;
+  borrowAfterUsd: number;
   shortfall: { reason: 'cash' | 'margin'; remaining: number } | null;
   routes: { loop: RebalanceRoute; convert: RebalanceRoute };
   route: 'loop' | 'convert' | null;
@@ -179,6 +187,7 @@ export interface RebalanceStep {
 
 export interface RebalanceJob {
   id: string;
+  direction: RebalanceDirection;
   route: 'loop' | 'convert';
   amount: number;
   status: 'running' | 'halted' | 'done' | 'abandoned';

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -133,6 +133,10 @@ export interface CrossexAccount {
   assets: CrossexAsset[];
 }
 
+// ---------------------------------------------------------------------------
+// GET /api/rebalance · POST /api/rebalance · POST /api/rebalance/:id/{resume,abandon}
+// ---------------------------------------------------------------------------
+
 export interface RebalanceBucket {
   coin: string;
   venue: string;
@@ -153,7 +157,6 @@ export interface RebalanceRoute {
 
 export interface RebalancePlan {
   amount: number;
-  deficit: number;
   shortfall: { reason: 'cash' | 'margin'; remaining: number } | null;
   routes: { loop: RebalanceRoute; convert: RebalanceRoute };
   route: 'loop' | 'convert' | null;
@@ -168,6 +171,7 @@ export interface RebalanceStep {
   venueId: string | null;
   qty: number | null;
   balanceBefore: number | null;
+  attempt: number;
   status: 'pending' | 'running' | 'done';
   startedAt: number | null;
   doneAt: number | null;

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -133,6 +133,65 @@ export interface CrossexAccount {
   assets: CrossexAsset[];
 }
 
+export interface RebalanceBucket {
+  coin: string;
+  venue: string;
+  cash: number;
+  upnl: number;
+  equity: number;
+  borrow: number;
+  interestPaid30dUsd: number;
+  interestPerDayUsd: number;
+}
+
+export interface RebalanceRoute {
+  costUsd: number;
+  waitSeconds: number;
+  available: boolean;
+  reason: string | null;
+}
+
+export interface RebalancePlan {
+  amount: number;
+  deficit: number;
+  shortfall: { reason: 'cash' | 'margin'; remaining: number } | null;
+  routes: { loop: RebalanceRoute; convert: RebalanceRoute };
+  route: 'loop' | 'convert' | null;
+  savesPerDayUsd: number;
+  marginFreedUsd: number;
+}
+
+export interface RebalanceStep {
+  name: string;
+  text: string | null;
+  quoteId: string | null;
+  venueId: string | null;
+  qty: number | null;
+  balanceBefore: number | null;
+  status: 'pending' | 'running' | 'done';
+  startedAt: number | null;
+  doneAt: number | null;
+}
+
+export interface RebalanceJob {
+  id: string;
+  route: 'loop' | 'convert';
+  amount: number;
+  status: 'running' | 'halted' | 'done' | 'abandoned';
+  stepIndex: number;
+  steps: RebalanceStep[];
+  fundsAt: 'CROSSEX' | 'GATE' | 'SPOT' | 'HYPERLIQUID';
+  haltReason: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface RebalanceView {
+  buckets: RebalanceBucket[];
+  plan: RebalancePlan;
+  job: RebalanceJob | null;
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/positions
 // ---------------------------------------------------------------------------

--- a/web/src/panels/BalancesPanel.tsx
+++ b/web/src/panels/BalancesPanel.tsx
@@ -7,6 +7,7 @@ import { MarginBreakdown } from '../components/MarginDonut';
 import { SignedNumber } from '../components/SignedNumber';
 import { TableSkeleton, TilesSkeleton } from '../components/Skeleton';
 import { sig } from '../lib/fmt';
+import { RebalanceSection } from './RebalanceSection';
 
 const ASSET_COLUMNS: Column<CrossexAsset>[] = [
   {
@@ -59,6 +60,8 @@ export function BalancesPanel() {
   return (
     <div className="flex flex-col gap-6">
       <MarginBreakdown acc={acc} />
+
+      <RebalanceSection />
 
       <section aria-label="Assets">
         <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-ink-400">

--- a/web/src/panels/RebalanceSection.test.tsx
+++ b/web/src/panels/RebalanceSection.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
@@ -14,6 +14,15 @@ import { env, server } from '../test/server';
 import { renderWithClient } from '../test/utils';
 import { RebalanceSection } from './RebalanceSection';
 
+const PAY_DOWN_TEXT =
+  "Only cash moves. Unrealised PnL stays where it is. Each USDC paid back lowers the Hyperliquid borrow by one USDC and frees 20% of it as initial margin and 10% as maintenance margin. Margin balance changes only by the route's cost.";
+const PULL_TEXT = "Only cash moves. The most you can pull is the bucket's equity, so a pull never opens a borrow.";
+const LOOP_LINE =
+  'via spot loop · 900.00 USDT → 899.55 USDC @ 1.0005 · costs $0.50 · saves $0.29/day · frees $450.00 margin · borrow after $300.45 · about 2.5 min';
+const PULL_LINE = 'via spot loop · 400.00 USDC → 399.52 USDT @ 0.9988 · costs $0.60 · about 6.7 min';
+const HOLD = 'Hold to move 900.00 USDT → USDC';
+const PULL_HOLD = 'Hold to pull 400.00 USDC → USDT';
+
 const usdc = (over: Partial<RebalanceBucket> = {}): RebalanceBucket => ({
   coin: 'USDC',
   venue: 'HYPERLIQUID',
@@ -21,6 +30,8 @@ const usdc = (over: Partial<RebalanceBucket> = {}): RebalanceBucket => ({
   upnl: 300,
   equity: -900,
   borrow: 1200,
+  imHeldUsd: 240,
+  mmHeldUsd: 120,
   interestPaid30dUsd: 4.2,
   interestPerDayUsd: 0.31,
   ...over,
@@ -33,9 +44,16 @@ const usdt: RebalanceBucket = {
   upnl: 0,
   equity: 5000,
   borrow: 0,
+  imHeldUsd: 0,
+  mmHeldUsd: 0,
   interestPaid30dUsd: 0,
   interestPerDayUsd: 0,
 };
+
+const pullBuckets = [
+  usdc({ cash: 400, upnl: 100, equity: 500, borrow: 0, imHeldUsd: 0, mmHeldUsd: 0, interestPaid30dUsd: 0, interestPerDayUsd: 0 }),
+  usdt,
+];
 
 const route = (over: Partial<RebalanceRoute> = {}): RebalanceRoute => ({
   costUsd: 0.5,
@@ -46,7 +64,11 @@ const route = (over: Partial<RebalanceRoute> = {}): RebalanceRoute => ({
 });
 
 const plan = (over: Partial<RebalancePlan> = {}): RebalancePlan => ({
+  direction: 'payDown',
   amount: 900,
+  receives: 899.55,
+  price: 1.0005,
+  borrowAfterUsd: 300.45,
   shortfall: null,
   routes: { loop: route(), convert: route({ costUsd: 1.8, waitSeconds: 0 }) },
   route: 'loop',
@@ -54,6 +76,38 @@ const plan = (over: Partial<RebalancePlan> = {}): RebalancePlan => ({
   marginFreedUsd: 450,
   ...over,
 });
+
+const pullPlan = (over: Partial<RebalancePlan> = {}): RebalancePlan =>
+  plan({
+    direction: 'pull',
+    amount: 400,
+    receives: 399.52,
+    price: 0.9988,
+    borrowAfterUsd: 0,
+    routes: {
+      loop: route({ costUsd: 0.6, waitSeconds: 400 }),
+      convert: route({ costUsd: 0, waitSeconds: 0, available: false, reason: 'convert runs one way only' }),
+    },
+    savesPerDayUsd: 0,
+    marginFreedUsd: 0,
+    ...over,
+  });
+
+const noRoutePlan = (over: Partial<RebalancePlan> = {}): RebalancePlan =>
+  plan({
+    amount: 0,
+    receives: 0,
+    price: null,
+    borrowAfterUsd: 0,
+    routes: {
+      loop: route({ available: false, reason: 'nothing to move' }),
+      convert: route({ waitSeconds: 0, available: false, reason: 'nothing to move' }),
+    },
+    route: null,
+    savesPerDayUsd: 0,
+    marginFreedUsd: 0,
+    ...over,
+  });
 
 const step = (name: string, over: Partial<RebalanceStep> = {}): RebalanceStep => ({
   name,
@@ -71,6 +125,7 @@ const step = (name: string, over: Partial<RebalanceStep> = {}): RebalanceStep =>
 
 const job = (over: Partial<RebalanceJob> = {}): RebalanceJob => ({
   id: 'rb-1',
+  direction: 'payDown',
   route: 'loop',
   amount: 900,
   status: 'running',
@@ -87,6 +142,19 @@ const job = (over: Partial<RebalanceJob> = {}): RebalanceJob => ({
   ...over,
 });
 
+const haltedJob = () =>
+  job({
+    status: 'halted',
+    haltReason: 'timeout',
+    fundsAt: 'SPOT',
+    updatedAt: 13_000,
+    steps: [
+      step('Buy USDC', { status: 'done', startedAt: 1_000, doneAt: 3_000 }),
+      step('To spot', { status: 'done', startedAt: 3_000, doneAt: 8_000 }),
+      step('To Hyperliquid', { status: 'running', startedAt: 8_000 }),
+    ],
+  });
+
 const view = (over: Partial<RebalanceView> = {}): RebalanceView => ({
   buckets: [usdc(), usdt],
   plan: plan(),
@@ -94,16 +162,27 @@ const view = (over: Partial<RebalanceView> = {}): RebalanceView => ({
   ...over,
 });
 
-function serve(v: RebalanceView) {
-  let gets = 0;
+type Answer = RebalanceView | ((url: URL) => RebalanceView);
+
+function serve(answer: Answer) {
+  const urls: URL[] = [];
   server.use(
-    http.get('/api/rebalance', () => {
-      gets += 1;
-      return HttpResponse.json(env(v));
+    http.get('/api/rebalance', ({ request }) => {
+      const url = new URL(request.url);
+      urls.push(url);
+      return HttpResponse.json(env(typeof answer === 'function' ? answer(url) : answer));
     }),
   );
-  return () => gets;
+  return urls;
 }
+
+const byDirection = (payDown: RebalanceView, pull: RebalanceView) => (url: URL) =>
+  url.searchParams.get('direction') === 'pull' ? pull : payDown;
+
+const borrowAccount = () => byDirection(view(), view({ plan: noRoutePlan({ direction: 'pull' }) }));
+
+const pullAccount = () =>
+  byDirection(view({ buckets: pullBuckets, plan: noRoutePlan() }), view({ buckets: pullBuckets, plan: pullPlan() }));
 
 function refuseStart() {
   server.use(
@@ -119,37 +198,208 @@ function refuseStart() {
   );
 }
 
-const section = () => screen.findByRole('region', { name: 'Pay down' });
+function recordStarts() {
+  const posts: unknown[] = [];
+  server.use(
+    http.post('/api/rebalance', async ({ request }) => {
+      posts.push(await request.json());
+      return HttpResponse.json(env({ id: 'rb-2' }), { status: 202 });
+    }),
+  );
+  return posts;
+}
+
+const section = () => screen.findByRole('region', { name: 'Rebalance' });
+const amountInput = (label: string) => screen.getByRole('textbox', { name: label });
+const toPull = () => userEvent.click(screen.getByRole('radio', { name: 'Hyperliquid USDC → USDT' }));
 
 describe('RebalanceSection', () => {
-  it('shows the three tiles and the cost line with the loop wait', async () => {
+  it('shows the Rebalance header, the borrow pill, and the two tiles', async () => {
     serve(view());
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    expect(screen.getByText('Borrow (USDC)')).toBeInTheDocument();
-    expect(screen.getByText('1,200.00')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Rebalance' })).toBeInTheDocument();
+    expect(screen.getByText('move cash between USDT and Hyperliquid USDC')).toBeInTheDocument();
+    expect(screen.getByText('Borrow $1,200.00 · +$240.00 IM · +$120.00 MM')).toHaveClass('border-amber-500/30');
     expect(screen.getByText('Interest / day')).toBeInTheDocument();
     expect(screen.getByText('$0.31')).toBeInTheDocument();
     expect(screen.getByText('Interest paid · 30 d')).toBeInTheDocument();
     expect(screen.getByText('$4.20')).toBeInTheDocument();
-    expect(
-      screen.getByText('costs $0.50 · saves $0.29/day · frees $450.00 margin · about 2.5 min'),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Pay down 900.00 USDC' })).toBeEnabled();
+    expect(screen.queryByText('Borrow (USDC)')).toBeNull();
   });
 
-  it('says instant for the convert route', async () => {
-    serve(view({ plan: plan({ route: 'convert' }) }));
+  it('floors the borrow pill to cents so it never shows more than the button', async () => {
+    serve(view({ buckets: [usdc({ borrow: 1200.999 }), usdt] }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getByText('Borrow $1,200.99 · +$240.00 IM · +$120.00 MM')).toBeInTheDocument();
+  });
+
+  it('shows the explanation line for each direction', async () => {
+    serve(borrowAccount());
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getByText(PAY_DOWN_TEXT)).toBeInTheDocument();
+
+    await toPull();
+
+    expect(await screen.findByText(PULL_TEXT)).toBeInTheDocument();
+    expect(screen.queryByText(PAY_DOWN_TEXT)).toBeNull();
+  });
+
+  it('defaults the direction to pull when there is no borrow and USDC can be pulled', async () => {
+    const urls = serve(pullAccount());
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(urls[0].searchParams.has('direction')).toBe(false);
+    expect(await screen.findByRole('radio', { name: 'Hyperliquid USDC → USDT', checked: true })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'USDT → Hyperliquid USDC' })).not.toBeChecked();
+    await waitFor(() => expect(urls.at(-1)?.searchParams.get('direction')).toBe('pull'));
+    expect(await screen.findByRole('button', { name: PULL_HOLD })).toBeInTheDocument();
+  });
+
+  it('re-reads the plan and resets the input when the direction toggles', async () => {
+    const urls = serve(pullAccount());
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await screen.findByRole('button', { name: PULL_HOLD });
+    expect(screen.getByRole('radiogroup', { name: 'Direction' })).toBeInTheDocument();
+    const pullInput = amountInput('Amount (USDC) · free 400.00');
+    expect(pullInput).toHaveValue('400.00');
+    expect(screen.getByText(PULL_TEXT)).toBeInTheDocument();
+    expect(screen.getByText(PULL_LINE)).toBeInTheDocument();
+    await userEvent.clear(pullInput);
+    await userEvent.type(pullInput, '77');
+    expect(pullInput).toHaveValue('77');
+
+    await userEvent.click(screen.getByRole('radio', { name: 'USDT → Hyperliquid USDC' }));
+
+    await waitFor(() => expect(urls.at(-1)?.searchParams.has('direction')).toBe(false));
+    expect(screen.getByRole('radio', { name: 'USDT → Hyperliquid USDC' })).toBeChecked();
+    const input = await screen.findByRole('textbox', { name: 'Amount (USDT) · free 5,000.00' });
+    await waitFor(() => expect(input).toHaveValue('0.00'));
+    expect(screen.getByText(PAY_DOWN_TEXT)).toBeInTheDocument();
+    expect(screen.queryByText(PULL_LINE)).toBeNull();
+    expect(screen.getByText('Loop: nothing to move')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
+
+    await toPull();
+
+    await waitFor(() => expect(urls.at(-1)?.searchParams.get('direction')).toBe('pull'));
+    expect(await screen.findByRole('textbox', { name: 'Amount (USDC) · free 400.00' })).toHaveValue('400.00');
+    expect(screen.getByText(PULL_TEXT)).toBeInTheDocument();
+    expect(await screen.findByText(PULL_LINE)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: PULL_HOLD })).toBeInTheDocument();
+  });
+
+  it('prefills the amount and re-reads the plan with the typed amount after 300 ms', async () => {
+    const urls = serve((url) => {
+      const typed = url.searchParams.get('amount');
+      return typed === null ? view() : view({ plan: plan({ amount: Math.min(Number(typed), 900) }) });
+    });
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    const input = amountInput('Amount (USDT) · free 5,000.00');
+    expect(input).toHaveValue('900.00');
+    expect(screen.getByRole('button', { name: HOLD })).toBeEnabled();
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '500');
+
+    expect(input).toHaveValue('500');
+    expect(urls.some((u) => u.searchParams.has('amount'))).toBe(false);
+    await waitFor(() => expect(urls.at(-1)?.searchParams.get('amount')).toBe('500'));
+    expect(await screen.findByRole('button', { name: 'Hold to move 500.00 USDT → USDC' })).toBeEnabled();
+    expect(input).toHaveValue('500');
+    expect(screen.queryByText(/Capped at/)).toBeNull();
+  });
+
+  it('shows Capped at in amber when the typed amount is above the plan amount', async () => {
+    serve((url) => (url.searchParams.get('amount') === '1000' ? view({ plan: plan({ amount: 900 }) }) : view()));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    const input = amountInput('Amount (USDT) · free 5,000.00');
+    await userEvent.clear(input);
+    await userEvent.type(input, '1000');
+
+    expect(await screen.findByText('Capped at 900.00')).toHaveClass('text-amber-300');
+    expect(input).toHaveValue('1000');
+    expect(screen.getByRole('button', { name: HOLD })).toBeEnabled();
+  });
+
+  it('asks for an amount after blur when it is empty, zero, or not a number, and disables the hold', async () => {
+    serve(view());
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    const input = amountInput('Amount (USDT) · free 5,000.00');
+    await userEvent.clear(input);
+    expect(screen.queryByText('Enter an amount')).toBeNull();
+    expect(screen.getByRole('button', { name: HOLD })).toBeDisabled();
+
+    await userEvent.tab();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter an amount');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+
+    await userEvent.type(input, '0');
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter an amount');
+    expect(screen.getByRole('button', { name: HOLD })).toBeDisabled();
+
+    await userEvent.clear(input);
+    await userEvent.type(input, 'abc');
+    expect(screen.getByRole('alert')).toHaveTextContent('Enter an amount');
+    expect(screen.getByRole('button', { name: HOLD })).toBeDisabled();
+
+    await userEvent.clear(input);
+    await userEvent.type(input, '12');
+    expect(screen.queryByRole('alert')).toBeNull();
+    await waitFor(() => expect(screen.getByRole('button', { name: HOLD })).toBeEnabled());
+  });
+
+  it('shows the pull amount label with the smaller of cash and equity', async () => {
+    serve(view({ buckets: [usdc({ cash: 600, upnl: -150, equity: 450, borrow: 0 }), usdt], plan: noRoutePlan() }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(await screen.findByRole('textbox', { name: 'Amount (USDC) · free 450.00' })).toHaveValue('0.00');
+  });
+
+  it('shows the quote line for the spot loop', async () => {
+    serve(view());
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getByText(LOOP_LINE)).toBeInTheDocument();
+  });
+
+  it('shows the quote line for convert', async () => {
+    serve(view({ plan: plan({ route: 'convert', price: 0.998, receives: 898.2 }) }));
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
     expect(
-      screen.getByText('costs $1.80 · saves $0.29/day · frees $450.00 margin · instant'),
+      screen.getByText(
+        'via convert · 900.00 USDT → 898.20 USDC @ 0.9980 · spread $1.80 · saves $0.29/day · frees $450.00 margin · borrow after $300.45 · instant · sends on a fresh quote within 30 bps of this one',
+      ),
     ).toBeInTheDocument();
   });
 
-  it('shows the shortfall line with the cash reason', async () => {
+  it('shows the quote line for a pull', async () => {
+    serve(pullAccount());
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(await screen.findByText(PULL_LINE)).toBeInTheDocument();
+  });
+
+  it('shows the shortfall line in amber under the quote line with the cash reason', async () => {
     serve(view({ plan: plan({ amount: 600, shortfall: { reason: 'cash', remaining: 300 } }) }));
     renderWithClient(<RebalanceSection holdMs={50} />);
 
@@ -158,15 +408,15 @@ describe('RebalanceSection', () => {
       screen.getByText(
         'Only 600.00 USDC can move. 300.00 USDC stays borrowed: unrealised profit cannot move until the position closes',
       ),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Pay down 600.00 USDC' })).toBeInTheDocument();
+    ).toHaveClass('text-amber-300');
+    expect(screen.getByRole('button', { name: 'Hold to move 600.00 USDT → USDC' })).toBeInTheDocument();
   });
 
-  it('shows both route reasons and no cost line when there is no route', async () => {
+  it('shows both route reasons and no quote line or hold when there is no route', async () => {
     serve(
       view({
-        plan: plan({
-          route: null,
+        plan: noRoutePlan({
+          amount: 900,
           routes: {
             loop: route({ available: false, reason: 'USDC transfer is disabled' }),
             convert: route({ available: false, reason: 'convert quote failed' }),
@@ -179,48 +429,94 @@ describe('RebalanceSection', () => {
     await section();
     expect(screen.getByText('Loop: USDC transfer is disabled')).toBeInTheDocument();
     expect(screen.getByText('Convert: convert quote failed')).toBeInTheDocument();
-    expect(screen.queryByText(/costs \$/)).toBeNull();
-    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByText(/^via /)).toBeNull();
+    expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
+    expect(amountInput('Amount (USDT) · free 5,000.00')).toHaveValue('900.00');
   });
 
-  it('renders nothing with borrow 0 and no job', async () => {
-    const gets = serve(view({ buckets: [usdc({ cash: 0, equity: 0, borrow: 0 }), usdt], plan: plan({ amount: 0, route: null }) }));
+  it('sends one POST /api/rebalance with the plan amount and route after a full hold', async () => {
+    serve(view());
+    const posts = recordStarts();
     renderWithClient(<RebalanceSection holdMs={50} />);
 
-    await waitFor(() => expect(gets()).toBe(1));
-    expect(screen.queryByRole('region', { name: 'Pay down' })).toBeNull();
+    const btn = await screen.findByRole('button', { name: HOLD });
+    fireEvent.pointerDown(btn);
+
+    await waitFor(() => expect(posts).toEqual([{ direction: 'payDown', amount: 900, route: 'loop' }]));
+    await new Promise((r) => setTimeout(r, 200));
+    expect(posts).toHaveLength(1);
   });
 
-  it('shows one row per step for a running job', async () => {
-    serve(view({ job: job() }));
+  it('posts direction pull after a full hold in the pull direction', async () => {
+    serve(pullAccount());
+    const posts = recordStarts();
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    fireEvent.pointerDown(await screen.findByRole('button', { name: PULL_HOLD }));
+
+    await waitFor(() => expect(posts).toEqual([{ direction: 'pull', amount: 400, route: 'loop' }]));
+  });
+
+  it('shows the 409 message when the start is refused', async () => {
+    serve(view());
+    refuseStart();
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    fireEvent.pointerDown(await screen.findByRole('button', { name: HOLD }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('a trade is unfilled: deal-7');
+  });
+
+  it('drops a refused start error once the poll shows a halted job', async () => {
+    serve(view());
+    refuseStart();
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    fireEvent.pointerDown(await screen.findByRole('button', { name: HOLD }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('a trade is unfilled: deal-7');
+
+    serve(view({ job: job({ status: 'halted', haltReason: 'timeout', fundsAt: 'SPOT' }) }));
+
+    await screen.findByRole('button', { name: 'Resume' }, { timeout: 6_000 });
+    expect(screen.getByRole('button', { name: 'Abandon' })).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).toBeNull();
+  }, 10_000);
+
+  it('renders nothing with borrow 0, nothing to pull, and no job', async () => {
+    const urls = serve(view({ buckets: [usdc({ cash: 0, upnl: 0, equity: 0, borrow: 0 }), usdt], plan: noRoutePlan() }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await waitFor(() => expect(urls).toHaveLength(1));
+    expect(screen.queryByRole('region', { name: 'Rebalance' })).toBeNull();
+  });
+
+  it('renders with borrow 0 when USDC can be pulled, without the pill', async () => {
+    serve(pullAccount());
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    const rows = screen.getAllByRole('listitem');
-    expect(rows.map((r) => r.textContent)).toEqual([
-      expect.stringContaining('Buy USDC'),
-      expect.stringContaining('To spot'),
-      expect.stringContaining('To Hyperliquid'),
-    ]);
-    expect(rows[0].textContent).toContain('done');
-    expect(rows[0].textContent).toContain('2s');
-    expect(rows[1].textContent).toContain('running');
-    expect(rows[2].textContent).toContain('pending');
-    expect(rows[2].textContent).toContain('—');
-    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByText(/^Borrow \$/)).toBeNull();
+    expect(screen.getByRole('radiogroup', { name: 'Direction' })).toBeInTheDocument();
+    expect(screen.getByText('Interest / day')).toBeInTheDocument();
   });
 
-  it('shows the halt reason, the funds location, Resume and Abandon', async () => {
+  it('renders with borrow 0 and nothing to pull while a job runs', async () => {
+    serve(view({ buckets: [usdc({ cash: 0, upnl: 0, equity: 0, borrow: 0 }), usdt], plan: noRoutePlan(), job: job() }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getAllByRole('progressbar')).toHaveLength(3);
+  });
+
+  it('shows a progress bar with one segment per step for a running job that ticks every second', async () => {
+    const t0 = Date.now();
     serve(
       view({
         job: job({
-          status: 'halted',
-          haltReason: 'timeout',
-          fundsAt: 'SPOT',
           steps: [
-            step('Buy USDC', { status: 'done', startedAt: 1_000, doneAt: 3_000 }),
-            step('To spot', { status: 'done', startedAt: 3_000, doneAt: 8_000 }),
-            step('To Hyperliquid', { status: 'running', startedAt: 8_000 }),
+            step('Buy USDC', { status: 'done', startedAt: t0 - 10_000, doneAt: t0 - 8_000 }),
+            step('To spot', { status: 'running', startedAt: t0 - 2_000 }),
+            step('To Hyperliquid'),
           ],
         }),
       }),
@@ -228,10 +524,79 @@ describe('RebalanceSection', () => {
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
+    expect(screen.queryByRole('radiogroup')).toBeNull();
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
+
+    const rows = screen.getAllByRole('listitem');
+    expect(rows).toHaveLength(3);
+    expect(rows[0].textContent).toBe('Buy USDC2s');
+    expect(rows[1].textContent).toMatch(/^To spot[23]s \/ ~5s$/);
+    expect(rows[2].textContent).toBe('To Hyperliquid~2m 7s');
+
+    expect(screen.getByRole('progressbar', { name: 'Buy USDC' })).toHaveAttribute('aria-valuenow', '100');
+    const running = Number(screen.getByRole('progressbar', { name: 'To spot' }).getAttribute('aria-valuenow'));
+    expect(running).toBeGreaterThanOrEqual(40);
+    expect(running).toBeLessThanOrEqual(60);
+    expect(screen.getByRole('progressbar', { name: 'To Hyperliquid' })).toHaveAttribute('aria-valuenow', '0');
+
+    const before = rows[1].textContent;
+    await waitFor(() => expect(rows[1].textContent).not.toBe(before), { timeout: 3_000 });
+  });
+
+  it('caps the running segment of the progress bar at 95%', async () => {
+    const t0 = Date.now();
+    serve(
+      view({
+        job: job({
+          steps: [
+            step('Buy USDC', { status: 'done', startedAt: t0 - 70_000, doneAt: t0 - 68_000 }),
+            step('To spot', { status: 'running', startedAt: t0 - 60_500 }),
+            step('To Hyperliquid'),
+          ],
+        }),
+      }),
+    );
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getByRole('progressbar', { name: 'To spot' })).toHaveAttribute('aria-valuenow', '95');
+    expect(screen.getAllByRole('listitem')[1].textContent).toBe('To spot1m 0s / ~5s');
+  });
+
+  it('shows the halted segment in rose with the halt reason, the funds location, Resume and Abandon', async () => {
+    serve(view({ job: haltedJob() }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getByText('halted at 5s')).toHaveClass('text-rose-300');
+    expect(screen.getByRole('progressbar', { name: 'To Hyperliquid' })).toHaveAttribute('aria-valuenow', '4');
+    expect(screen.getByRole('progressbar', { name: 'To Hyperliquid' }).firstChild).toHaveClass('bg-rose-500');
     expect(screen.getByText('timeout')).toHaveClass('text-rose-300');
     expect(screen.getByText('Funds are in SPOT')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Resume' })).toBeEnabled();
     expect(screen.getByRole('button', { name: 'Abandon' })).toBeEnabled();
+  });
+
+  it('labels the step a halted job stopped on as halted, not running', async () => {
+    serve(view({ job: job({ status: 'halted', haltReason: 'timeout', fundsAt: 'GATE' }) }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    const rows = screen.getAllByRole('listitem');
+    expect(rows[1].textContent).toContain('To spot');
+    expect(rows[1].textContent).toContain('halted at');
+    expect(rows[1].textContent).not.toContain('/ ~');
+  });
+
+  it('stops a halted step counter at the halt time', async () => {
+    serve(view({ job: haltedJob() }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getAllByRole('listitem')[2].textContent).toBe('To Hyperliquidhalted at 5s');
+    await new Promise((r) => setTimeout(r, 1_100));
+    expect(screen.getAllByRole('listitem')[2].textContent).toBe('To Hyperliquidhalted at 5s');
   });
 
   it('posts resume for the halted job on Resume', async () => {
@@ -251,88 +616,18 @@ describe('RebalanceSection', () => {
     await waitFor(() => expect(posts).toEqual(['rb-1/resume']));
   });
 
-  it('stops a halted step counter at the halt time', async () => {
-    serve(
-      view({
-        job: job({
-          status: 'halted',
-          haltReason: 'timeout',
-          fundsAt: 'SPOT',
-          updatedAt: 13_000,
-          steps: [
-            step('Buy USDC', { status: 'done', startedAt: 1_000, doneAt: 3_000 }),
-            step('To spot', { status: 'done', startedAt: 3_000, doneAt: 8_000 }),
-            step('To Hyperliquid', { status: 'running', startedAt: 8_000 }),
-          ],
-        }),
-      }),
-    );
+  it('returns to the idle state and re-reads the tiles within 5 s after the job is done', async () => {
+    serve(view({ job: job() }));
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    const rows = screen.getAllByRole('listitem');
-    expect(within(rows[2]).getByText('5s')).toBeInTheDocument();
-  });
+    expect(screen.getAllByRole('progressbar')).toHaveLength(3);
 
-  it('sends one POST /api/rebalance with the plan amount and route after a full hold', async () => {
-    serve(view());
-    const posts: unknown[] = [];
-    server.use(
-      http.post('/api/rebalance', async ({ request }) => {
-        posts.push(await request.json());
-        return HttpResponse.json(env({ id: 'rb-2' }), { status: 202 });
-      }),
-    );
-    renderWithClient(<RebalanceSection holdMs={50} />);
+    serve(view({ buckets: [usdc({ borrow: 300, interestPerDayUsd: 0.08 }), usdt], job: job({ status: 'done' }) }));
 
-    const btn = await screen.findByRole('button', { name: 'Pay down 900.00 USDC' });
-    fireEvent.pointerDown(btn);
-
-    await waitFor(() => expect(posts).toEqual([{ amount: 900, route: 'loop' }]));
-    await new Promise((r) => setTimeout(r, 200));
-    expect(posts).toHaveLength(1);
-  });
-
-  it('shows the 409 message when the start is refused', async () => {
-    serve(view());
-    refuseStart();
-    renderWithClient(<RebalanceSection holdMs={50} />);
-
-    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Pay down 900.00 USDC' }));
-
-    expect(await screen.findByRole('alert')).toHaveTextContent('a trade is unfilled: deal-7');
-  });
-
-  it('drops a refused start error once the poll shows a halted job', async () => {
-    serve(view());
-    refuseStart();
-    renderWithClient(<RebalanceSection holdMs={50} />);
-
-    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Pay down 900.00 USDC' }));
-    expect(await screen.findByRole('alert')).toHaveTextContent('a trade is unfilled: deal-7');
-
-    serve(view({ job: job({ status: 'halted', haltReason: 'timeout', fundsAt: 'SPOT' }) }));
-
-    await screen.findByRole('button', { name: 'Resume' }, { timeout: 6_000 });
-    expect(screen.getByRole('button', { name: 'Abandon' })).toBeInTheDocument();
-    expect(screen.queryByRole('alert')).toBeNull();
+    expect(await screen.findByRole('button', { name: HOLD }, { timeout: 5_000 })).toBeEnabled();
+    expect(screen.queryByRole('progressbar')).toBeNull();
+    expect(screen.getByText('Borrow $300.00 · +$240.00 IM · +$120.00 MM')).toBeInTheDocument();
+    expect(screen.getByText('$0.08')).toBeInTheDocument();
   }, 10_000);
-  it('floors the borrow tile to cents so it never shows more than the button', async () => {
-    serve(view({ buckets: [usdc({ borrow: 1200.999 }), usdt] }));
-    renderWithClient(<RebalanceSection holdMs={50} />);
-
-    await section();
-    expect(screen.getByText('1,200.99')).toBeInTheDocument();
-  });
-
-  it('labels the step a halted job stopped on as halted, not running', async () => {
-    serve(view({ job: job({ status: 'halted', haltReason: 'timeout', fundsAt: 'GATE' }) }));
-    renderWithClient(<RebalanceSection holdMs={50} />);
-
-    await section();
-    const rows = screen.getAllByRole('listitem');
-    expect(rows[1].textContent).toContain('To spot');
-    expect(rows[1].textContent).toContain('halted');
-    expect(rows[1].textContent).not.toContain('running');
-  });
 });

--- a/web/src/panels/RebalanceSection.test.tsx
+++ b/web/src/panels/RebalanceSection.test.tsx
@@ -15,8 +15,9 @@ import { renderWithClient } from '../test/utils';
 import { RebalanceSection } from './RebalanceSection';
 
 const PAY_DOWN_TEXT =
-  "Only cash moves. Unrealised PnL stays where it is. Each USDC paid back lowers the Hyperliquid borrow by one USDC and frees 20% of it as initial margin and 10% as maintenance margin. Margin balance changes only by the route's cost.";
-const PULL_TEXT = "Only cash moves. The most you can pull is the bucket's equity, so a pull never opens a borrow.";
+  "Sends USDT to Hyperliquid as USDC and pays the borrow back. Each USDC paid back cuts the borrow by 1 USDC and frees 0.20 USDC of initial margin and 0.10 USDC of maintenance margin. Your account total changes only by the route's cost.";
+const PULL_TEXT =
+  'Brings USDC from Hyperliquid back to USDT. You can pull at most the USDC you own there, so a pull never starts a new borrow.';
 const LOOP_LINE =
   'via spot loop · 900.00 USDT → 899.55 USDC @ 1.0005 · costs $0.50 · saves $0.29/day · frees $450.00 margin · borrow after $300.45 · about 2.5 min';
 const PULL_LINE = 'via spot loop · 400.00 USDC → 399.52 USDT @ 0.9988 · costs $0.60 · about 6.7 min';
@@ -248,6 +249,25 @@ describe('RebalanceSection', () => {
 
     expect(await screen.findByText(PULL_TEXT)).toBeInTheDocument();
     expect(screen.queryByText(PAY_DOWN_TEXT)).toBeNull();
+  });
+
+  it('opens the what-and-why card from the info mark next to the title', async () => {
+    serve(borrowAccount());
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.queryByRole('tooltip')).toBeNull();
+
+    await userEvent.hover(screen.getByText('About rebalance').parentElement!);
+
+    const card = await screen.findByRole('tooltip');
+    expect(card).toHaveTextContent('Gate lends you the USDC to cover it');
+    expect(card).toHaveTextContent('20% as initial margin and 10% as maintenance margin');
+    expect(card).toHaveTextContent('USDT → Hyperliquid USDC pays the borrow back');
+
+    await userEvent.unhover(screen.getByText('About rebalance').parentElement!);
+
+    await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull());
   });
 
   it('defaults the direction to pull when there is no borrow and USDC can be pulled', async () => {

--- a/web/src/panels/RebalanceSection.test.tsx
+++ b/web/src/panels/RebalanceSection.test.tsx
@@ -419,6 +419,65 @@ describe('RebalanceSection', () => {
     expect(await screen.findByText(PULL_LINE)).toBeInTheDocument();
   });
 
+  it('shows the quote line for a pull by convert and posts route convert', async () => {
+    const convertPull = pullPlan({
+      route: 'convert',
+      price: 0.998,
+      receives: 399.2,
+      routes: { loop: route({ costUsd: 1.4, waitSeconds: 400 }), convert: route({ costUsd: 0.8, waitSeconds: 0 }) },
+    });
+    serve(byDirection(view({ buckets: pullBuckets, plan: noRoutePlan() }), view({ buckets: pullBuckets, plan: convertPull })));
+    const posts = recordStarts();
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(await screen.findByText('via convert · 400.00 USDC → 399.20 USDT @ 0.9980 · spread $0.80 · instant · sends on a fresh quote within 30 bps of this one')).toBeInTheDocument();
+    fireEvent.pointerDown(screen.getByRole('button', { name: PULL_HOLD }));
+
+    await waitFor(() => expect(posts).toEqual([{ direction: 'pull', amount: 400, route: 'convert' }]));
+  });
+
+  it('hides the hold and the quote line under 1 USDC and says why, for either direction', async () => {
+    const tiny = usdc({ cash: -0.37, upnl: 0, equity: -0.37, borrow: 0.37, imHeldUsd: 0.07, mmHeldUsd: 0.03 });
+    serve(view({ buckets: [tiny, usdt], plan: plan({ amount: 0.37, route: 'convert', receives: 0.36, price: 0.998 }) }));
+    const { unmount } = renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getByText('Borrow $0.37 · +$0.07 IM · +$0.03 MM')).toBeInTheDocument();
+    expect(screen.getByText('Nothing to pay back. The borrow is under 1 USDC.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
+    expect(screen.queryByText(/^via /)).toBeNull();
+    expect(screen.getByRole('radiogroup', { name: 'Direction' })).toBeInTheDocument();
+    unmount();
+
+    const spare = usdc({ cash: 0.5, upnl: 0, equity: 0.5, borrow: 0, imHeldUsd: 0, mmHeldUsd: 0 });
+    serve(view({ buckets: [spare, usdt], plan: pullPlan({ amount: 0.5, route: 'convert', receives: 0.49, price: 0.998 }) }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(await screen.findByText('Nothing to pull. Spare USDC is under 1 USDC.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
+    expect(screen.queryByText(/^via /)).toBeNull();
+  });
+
+  it('asks for at least 1 USDT when the typed amount is under the floor and hides the hold', async () => {
+    serve((url) => {
+      const typed = url.searchParams.get('amount');
+      return view({ plan: plan(typed ? { amount: Number(typed), route: 'convert', receives: Number(typed) * 0.998 } : {}) });
+    });
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await screen.findByRole('button', { name: HOLD });
+    const input = amountInput('Amount (USDT) · free 5,000.00');
+    await userEvent.clear(input);
+    await userEvent.type(input, '0.5');
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter at least 1 USDT');
+    expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
+    expect(screen.queryByText(/^via /)).toBeNull();
+    expect(screen.queryByText(/^Capped at/)).toBeNull();
+  });
+
   it('shows the shortfall line in amber under the quote line with the cash reason', async () => {
     serve(view({ plan: plan({ amount: 600, shortfall: { reason: 'cash', remaining: 300 } }) }));
     renderWithClient(<RebalanceSection holdMs={50} />);

--- a/web/src/panels/RebalanceSection.test.tsx
+++ b/web/src/panels/RebalanceSection.test.tsx
@@ -443,7 +443,7 @@ describe('RebalanceSection', () => {
     const { unmount } = renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    expect(screen.getByText('Borrow $0.37 · +$0.07 IM · +$0.03 MM')).toBeInTheDocument();
+    expect(screen.queryByText(/^Borrow \$/)).toBeNull();
     expect(screen.getByText('Nothing to pay back. The borrow is under 1 USDC.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
     expect(screen.queryByText(/^via /)).toBeNull();
@@ -594,6 +594,17 @@ describe('RebalanceSection', () => {
     expect(screen.queryByRole('region', { name: 'Rebalance' })).toBeNull();
   });
 
+  it('stays rendered when the borrow and the pullable amount both floor to 0 but the bucket is in use', async () => {
+    const onTheLine = usdc({ cash: 16.65, upnl: -16.646, equity: 0.004, borrow: 0, imHeldUsd: 0, mmHeldUsd: 0 });
+    serve(view({ buckets: [onTheLine, usdt], plan: noRoutePlan() }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.queryByText(/^Borrow \$/)).toBeNull();
+    expect(screen.getByRole('radiogroup', { name: 'Direction' })).toBeInTheDocument();
+    expect(screen.getByText('Nothing to pay back. There is no USDC borrow on Hyperliquid.')).toBeInTheDocument();
+  });
+
   it('renders with borrow 0 when USDC can be pulled, without the pill', async () => {
     serve(pullAccount());
     renderWithClient(<RebalanceSection holdMs={50} />);
@@ -733,5 +744,28 @@ describe('RebalanceSection', () => {
     expect(screen.queryByRole('progressbar')).toBeNull();
     expect(screen.getByText('Borrow $300.00 · +$240.00 IM · +$120.00 MM')).toBeInTheDocument();
     expect(screen.getByText('$0.08')).toBeInTheDocument();
+  }, 10_000);
+
+  it('goes back to the default direction with a fresh input once a job ends', async () => {
+    serve(view({ job: job() }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getAllByRole('progressbar')).toHaveLength(3);
+
+    const done = job({ status: 'done' });
+    serve(
+      byDirection(
+        view({ buckets: pullBuckets, plan: noRoutePlan(), job: done }),
+        view({ buckets: pullBuckets, plan: pullPlan(), job: done }),
+      ),
+    );
+
+    expect(
+      await screen.findByRole('radio', { name: 'Hyperliquid USDC → USDT', checked: true }, { timeout: 5_000 }),
+    ).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: PULL_HOLD })).toBeEnabled();
+    expect(amountInput('Amount (USDC) · free 400.00')).toHaveValue('400.00');
+    expect(screen.queryByText(/^Borrow \$/)).toBeNull();
   }, 10_000);
 });

--- a/web/src/panels/RebalanceSection.test.tsx
+++ b/web/src/panels/RebalanceSection.test.tsx
@@ -1,0 +1,278 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import type {
+  RebalanceBucket,
+  RebalanceJob,
+  RebalancePlan,
+  RebalanceRoute,
+  RebalanceStep,
+  RebalanceView,
+} from '../api/types';
+import { env, server } from '../test/server';
+import { renderWithClient } from '../test/utils';
+import { RebalanceSection } from './RebalanceSection';
+
+const usdc = (over: Partial<RebalanceBucket> = {}): RebalanceBucket => ({
+  coin: 'USDC',
+  venue: 'HYPERLIQUID',
+  cash: -1200,
+  upnl: 300,
+  equity: -900,
+  borrow: 1200,
+  interestPaid30dUsd: 4.2,
+  interestPerDayUsd: 0.31,
+  ...over,
+});
+
+const usdt: RebalanceBucket = {
+  coin: 'USDT',
+  venue: 'CROSSEX',
+  cash: 5000,
+  upnl: 0,
+  equity: 5000,
+  borrow: 0,
+  interestPaid30dUsd: 0,
+  interestPerDayUsd: 0,
+};
+
+const route = (over: Partial<RebalanceRoute> = {}): RebalanceRoute => ({
+  costUsd: 0.5,
+  waitSeconds: 150,
+  available: true,
+  reason: null,
+  ...over,
+});
+
+const plan = (over: Partial<RebalancePlan> = {}): RebalancePlan => ({
+  amount: 900,
+  deficit: 900,
+  shortfall: null,
+  routes: { loop: route(), convert: route({ costUsd: 1.8, waitSeconds: 0 }) },
+  route: 'loop',
+  savesPerDayUsd: 0.29,
+  marginFreedUsd: 450,
+  ...over,
+});
+
+const step = (name: string, over: Partial<RebalanceStep> = {}): RebalanceStep => ({
+  name,
+  text: null,
+  quoteId: null,
+  venueId: null,
+  qty: null,
+  balanceBefore: null,
+  status: 'pending',
+  startedAt: null,
+  doneAt: null,
+  ...over,
+});
+
+const job = (over: Partial<RebalanceJob> = {}): RebalanceJob => ({
+  id: 'rb-1',
+  route: 'loop',
+  amount: 900,
+  status: 'running',
+  stepIndex: 1,
+  steps: [
+    step('Buy USDC', { status: 'done', startedAt: 1_000, doneAt: 3_000, venueId: 'o-1' }),
+    step('To spot', { status: 'running', startedAt: 3_000 }),
+    step('To Hyperliquid'),
+  ],
+  fundsAt: 'GATE',
+  haltReason: null,
+  createdAt: 1_000,
+  updatedAt: 3_000,
+  ...over,
+});
+
+const view = (over: Partial<RebalanceView> = {}): RebalanceView => ({
+  buckets: [usdc(), usdt],
+  plan: plan(),
+  job: null,
+  ...over,
+});
+
+function serve(v: RebalanceView) {
+  let gets = 0;
+  server.use(
+    http.get('/api/rebalance', () => {
+      gets += 1;
+      return HttpResponse.json(env(v));
+    }),
+  );
+  return () => gets;
+}
+
+const section = () => screen.findByRole('region', { name: 'Pay down' });
+
+describe('RebalanceSection', () => {
+  it('shows the three tiles and the cost line with the loop wait', async () => {
+    serve(view());
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getByText('Borrow (USDC)')).toBeInTheDocument();
+    expect(screen.getByText('1,200.00')).toBeInTheDocument();
+    expect(screen.getByText('Interest / day')).toBeInTheDocument();
+    expect(screen.getByText('$0.31')).toBeInTheDocument();
+    expect(screen.getByText('Interest paid · 30 d')).toBeInTheDocument();
+    expect(screen.getByText('$4.20')).toBeInTheDocument();
+    expect(
+      screen.getByText('costs $0.50 · saves $0.29/day · frees $450.00 margin · about 2.5 min'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Pay down 900.00 USDC' })).toBeEnabled();
+  });
+
+  it('says instant for the convert route', async () => {
+    serve(view({ plan: plan({ route: 'convert' }) }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(
+      screen.getByText('costs $1.80 · saves $0.29/day · frees $450.00 margin · instant'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the shortfall line with the cash reason', async () => {
+    serve(view({ plan: plan({ amount: 600, shortfall: { reason: 'cash', remaining: 300 } }) }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(
+      screen.getByText(
+        'Only 600.00 USDC can move. 300.00 USDC stays borrowed: unrealised profit cannot move until the position closes',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Pay down 600.00 USDC' })).toBeInTheDocument();
+  });
+
+  it('shows both route reasons and no cost line when there is no route', async () => {
+    serve(
+      view({
+        plan: plan({
+          route: null,
+          routes: {
+            loop: route({ available: false, reason: 'USDC transfer is disabled' }),
+            convert: route({ available: false, reason: 'convert quote failed' }),
+          },
+        }),
+      }),
+    );
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getByText('Loop: USDC transfer is disabled')).toBeInTheDocument();
+    expect(screen.getByText('Convert: convert quote failed')).toBeInTheDocument();
+    expect(screen.queryByText(/costs \$/)).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('renders nothing with borrow 0 and no job', async () => {
+    const gets = serve(view({ buckets: [usdc({ cash: 0, equity: 0, borrow: 0 }), usdt], plan: plan({ amount: 0, route: null }) }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await waitFor(() => expect(gets()).toBe(1));
+    expect(screen.queryByRole('region', { name: 'Pay down' })).toBeNull();
+  });
+
+  it('shows one row per step for a running job', async () => {
+    serve(view({ job: job() }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    const rows = screen.getAllByRole('listitem');
+    expect(rows.map((r) => r.textContent)).toEqual([
+      expect.stringContaining('Buy USDC'),
+      expect.stringContaining('To spot'),
+      expect.stringContaining('To Hyperliquid'),
+    ]);
+    expect(rows[0].textContent).toContain('done');
+    expect(rows[0].textContent).toContain('2s');
+    expect(rows[1].textContent).toContain('running');
+    expect(rows[2].textContent).toContain('pending');
+    expect(rows[2].textContent).toContain('—');
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('shows the halt reason, the funds location, Resume and Abandon', async () => {
+    serve(
+      view({
+        job: job({
+          status: 'halted',
+          haltReason: 'timeout',
+          fundsAt: 'SPOT',
+          steps: [
+            step('Buy USDC', { status: 'done', startedAt: 1_000, doneAt: 3_000 }),
+            step('To spot', { status: 'done', startedAt: 3_000, doneAt: 8_000 }),
+            step('To Hyperliquid', { status: 'running', startedAt: 8_000 }),
+          ],
+        }),
+      }),
+    );
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getByText('timeout')).toHaveClass('text-rose-300');
+    expect(screen.getByText('Funds are in SPOT')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Resume' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Abandon' })).toBeEnabled();
+  });
+
+  it('posts resume for the halted job on Resume', async () => {
+    const halted = job({ status: 'halted', haltReason: 'server restarted', fundsAt: 'GATE' });
+    serve(view({ job: halted }));
+    const posts: string[] = [];
+    server.use(
+      http.post('/api/rebalance/:id/:cmd', ({ params }) => {
+        posts.push(`${params.id}/${params.cmd}`);
+        return HttpResponse.json(env({ ...halted, status: 'running' }));
+      }),
+    );
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Resume' }));
+
+    await waitFor(() => expect(posts).toEqual(['rb-1/resume']));
+  });
+
+  it('sends one POST /api/rebalance after a full hold', async () => {
+    serve(view());
+    let posts = 0;
+    server.use(
+      http.post('/api/rebalance', () => {
+        posts += 1;
+        return HttpResponse.json(env({ id: 'rb-2' }), { status: 202 });
+      }),
+    );
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    const btn = await screen.findByRole('button', { name: 'Pay down 900.00 USDC' });
+    fireEvent.pointerDown(btn);
+
+    await waitFor(() => expect(posts).toBe(1));
+    await new Promise((r) => setTimeout(r, 200));
+    expect(posts).toBe(1);
+  });
+
+  it('shows the 409 message when the start is refused', async () => {
+    serve(view());
+    server.use(
+      http.post('/api/rebalance', () =>
+        HttpResponse.json(
+          {
+            ok: false,
+            error: { category: 'validation', message: 'a trade is unfilled: deal-7', retryable: true },
+          },
+          { status: 409 },
+        ),
+      ),
+    );
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Pay down 900.00 USDC' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('a trade is unfilled: deal-7');
+  });
+});

--- a/web/src/panels/RebalanceSection.test.tsx
+++ b/web/src/panels/RebalanceSection.test.tsx
@@ -317,4 +317,22 @@ describe('RebalanceSection', () => {
     expect(screen.getByRole('button', { name: 'Abandon' })).toBeInTheDocument();
     expect(screen.queryByRole('alert')).toBeNull();
   }, 10_000);
+  it('floors the borrow tile to cents so it never shows more than the button', async () => {
+    serve(view({ buckets: [usdc({ borrow: 1200.999 }), usdt] }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getByText('1,200.99')).toBeInTheDocument();
+  });
+
+  it('labels the step a halted job stopped on as halted, not running', async () => {
+    serve(view({ job: job({ status: 'halted', haltReason: 'timeout', fundsAt: 'GATE' }) }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    const rows = screen.getAllByRole('listitem');
+    expect(rows[1].textContent).toContain('To spot');
+    expect(rows[1].textContent).toContain('halted');
+    expect(rows[1].textContent).not.toContain('running');
+  });
 });

--- a/web/src/panels/RebalanceSection.test.tsx
+++ b/web/src/panels/RebalanceSection.test.tsx
@@ -87,7 +87,7 @@ const pullPlan = (over: Partial<RebalancePlan> = {}): RebalancePlan =>
     borrowAfterUsd: 0,
     routes: {
       loop: route({ costUsd: 0.6, waitSeconds: 400 }),
-      convert: route({ costUsd: 0, waitSeconds: 0, available: false, reason: 'convert runs one way only' }),
+      convert: route({ costUsd: 0, waitSeconds: 0, available: false, reason: 'Convert runs only from USDT to USDC.' }),
     },
     savesPerDayUsd: 0,
     marginFreedUsd: 0,
@@ -304,7 +304,7 @@ describe('RebalanceSection', () => {
     await waitFor(() => expect(input).toHaveValue('0.00'));
     expect(screen.getByText(PAY_DOWN_TEXT)).toBeInTheDocument();
     expect(screen.queryByText(PULL_LINE)).toBeNull();
-    expect(screen.getByText('Loop: nothing to move')).toBeInTheDocument();
+    expect(screen.getByText('Nothing to pay back. There is no USDC borrow on Hyperliquid.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
 
     await toPull();
@@ -447,11 +447,36 @@ describe('RebalanceSection', () => {
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    expect(screen.getByText('Loop: USDC transfer is disabled')).toBeInTheDocument();
-    expect(screen.getByText('Convert: convert quote failed')).toBeInTheDocument();
+    expect(screen.getByText('USDC transfer is disabled')).toBeInTheDocument();
+    expect(screen.queryByText(/convert quote failed/)).toBeNull();
     expect(screen.queryByText(/^via /)).toBeNull();
     expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
     expect(amountInput('Amount (USDT) · free 5,000.00')).toHaveValue('900.00');
+  });
+
+  it('shows one plain line for a pull with no route and never the convert reason', async () => {
+    serve(
+      view({
+        buckets: [usdc({ cash: 1.29, upnl: 0, equity: 1.29, borrow: 0, imHeldUsd: 0, mmHeldUsd: 0 }), usdt],
+        plan: pullPlan({
+          amount: 1.29,
+          receives: 0,
+          price: null,
+          route: null,
+          routes: {
+            loop: route({ available: false, reason: 'Too small to pull. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Pull at least 12 USDC.' }),
+            convert: route({ costUsd: 0, waitSeconds: 0, available: false, reason: 'Convert runs only from USDT to USDC.' }),
+          },
+        }),
+      }),
+    );
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(await screen.findByText('Too small to pull. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Pull at least 12 USDC.')).toBeInTheDocument();
+    expect(screen.queryByText(/Convert runs only/)).toBeNull();
+    expect(screen.queryByText(/^Loop:/)).toBeNull();
+    expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
   });
 
   it('sends one POST /api/rebalance with the plan amount and route after a full hold', async () => {

--- a/web/src/panels/RebalanceSection.test.tsx
+++ b/web/src/panels/RebalanceSection.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { describe, expect, it } from 'vitest';
@@ -47,7 +47,6 @@ const route = (over: Partial<RebalanceRoute> = {}): RebalanceRoute => ({
 
 const plan = (over: Partial<RebalancePlan> = {}): RebalancePlan => ({
   amount: 900,
-  deficit: 900,
   shortfall: null,
   routes: { loop: route(), convert: route({ costUsd: 1.8, waitSeconds: 0 }) },
   route: 'loop',
@@ -63,6 +62,7 @@ const step = (name: string, over: Partial<RebalanceStep> = {}): RebalanceStep =>
   venueId: null,
   qty: null,
   balanceBefore: null,
+  attempt: 0,
   status: 'pending',
   startedAt: null,
   doneAt: null,
@@ -103,6 +103,20 @@ function serve(v: RebalanceView) {
     }),
   );
   return () => gets;
+}
+
+function refuseStart() {
+  server.use(
+    http.post('/api/rebalance', () =>
+      HttpResponse.json(
+        {
+          ok: false,
+          error: { category: 'validation', message: 'a trade is unfilled: deal-7', retryable: true },
+        },
+        { status: 409 },
+      ),
+    ),
+  );
 }
 
 const section = () => screen.findByRole('region', { name: 'Pay down' });
@@ -237,12 +251,35 @@ describe('RebalanceSection', () => {
     await waitFor(() => expect(posts).toEqual(['rb-1/resume']));
   });
 
-  it('sends one POST /api/rebalance after a full hold', async () => {
+  it('stops a halted step counter at the halt time', async () => {
+    serve(
+      view({
+        job: job({
+          status: 'halted',
+          haltReason: 'timeout',
+          fundsAt: 'SPOT',
+          updatedAt: 13_000,
+          steps: [
+            step('Buy USDC', { status: 'done', startedAt: 1_000, doneAt: 3_000 }),
+            step('To spot', { status: 'done', startedAt: 3_000, doneAt: 8_000 }),
+            step('To Hyperliquid', { status: 'running', startedAt: 8_000 }),
+          ],
+        }),
+      }),
+    );
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    const rows = screen.getAllByRole('listitem');
+    expect(within(rows[2]).getByText('5s')).toBeInTheDocument();
+  });
+
+  it('sends one POST /api/rebalance with the plan amount and route after a full hold', async () => {
     serve(view());
-    let posts = 0;
+    const posts: unknown[] = [];
     server.use(
-      http.post('/api/rebalance', () => {
-        posts += 1;
+      http.post('/api/rebalance', async ({ request }) => {
+        posts.push(await request.json());
         return HttpResponse.json(env({ id: 'rb-2' }), { status: 202 });
       }),
     );
@@ -251,28 +288,33 @@ describe('RebalanceSection', () => {
     const btn = await screen.findByRole('button', { name: 'Pay down 900.00 USDC' });
     fireEvent.pointerDown(btn);
 
-    await waitFor(() => expect(posts).toBe(1));
+    await waitFor(() => expect(posts).toEqual([{ amount: 900, route: 'loop' }]));
     await new Promise((r) => setTimeout(r, 200));
-    expect(posts).toBe(1);
+    expect(posts).toHaveLength(1);
   });
 
   it('shows the 409 message when the start is refused', async () => {
     serve(view());
-    server.use(
-      http.post('/api/rebalance', () =>
-        HttpResponse.json(
-          {
-            ok: false,
-            error: { category: 'validation', message: 'a trade is unfilled: deal-7', retryable: true },
-          },
-          { status: 409 },
-        ),
-      ),
-    );
+    refuseStart();
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     fireEvent.pointerDown(await screen.findByRole('button', { name: 'Pay down 900.00 USDC' }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent('a trade is unfilled: deal-7');
   });
+
+  it('drops a refused start error once the poll shows a halted job', async () => {
+    serve(view());
+    refuseStart();
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    fireEvent.pointerDown(await screen.findByRole('button', { name: 'Pay down 900.00 USDC' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('a trade is unfilled: deal-7');
+
+    serve(view({ job: job({ status: 'halted', haltReason: 'timeout', fundsAt: 'SPOT' }) }));
+
+    await screen.findByRole('button', { name: 'Resume' }, { timeout: 6_000 });
+    expect(screen.getByRole('button', { name: 'Abandon' })).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).toBeNull();
+  }, 10_000);
 });

--- a/web/src/panels/RebalanceSection.tsx
+++ b/web/src/panels/RebalanceSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ApiError } from '../api/client';
 import { useRebalance, useRebalanceCommand, useStartRebalance } from '../api/queries';
 import type { RebalanceDirection, RebalanceJob, RebalancePlan, RebalanceStep } from '../api/types';
@@ -199,16 +199,37 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
   const usdt = data?.buckets.find((b) => b.coin === 'USDT' && b.venue === 'CROSSEX');
   const borrow = floorCents(usdc?.borrow ?? 0);
   const pullable = floorCents(Math.min(usdc?.cash ?? 0, usdc?.equity ?? 0));
+  const job = data?.job && (data.job.status === 'running' || data.job.status === 'halted') ? data.job : null;
 
   useEffect(() => {
     if (chosen !== null || !data) return;
-    setChosen(borrow === 0 && pullable > 0 ? 'pull' : 'payDown');
+    setChosen(borrow < MIN_AMOUNT && pullable > 0 ? 'pull' : 'payDown');
   }, [chosen, data, borrow, pullable]);
+
+  /* A finished job leaves the bucket on the other side: a pay-down leaves
+     spare USDC, a pull leaves nothing. Go back to the default direction and
+     a fresh input, so the section reads for what is now possible. */
+  const activeJobId = job?.id ?? null;
+  const lastActive = useRef<string | null>(null);
+  useEffect(() => {
+    if (lastActive.current !== null && activeJobId === null) {
+      setChosen(null);
+      setTyped(null);
+      setAmountParam(null);
+      setBlurred(false);
+    }
+    lastActive.current = activeJobId;
+  }, [activeJobId]);
 
   if (!data) return null;
 
-  const job = data.job && (data.job.status === 'running' || data.job.status === 'halted') ? data.job : null;
-  if (borrow === 0 && pullable === 0 && !job) return null;
+  /* Presence must not depend on cents. Both directions end with the bucket's
+     equity near zero, where unrealised PnL flips the borrow and the pullable
+     amount between 0.00 and a few cents on every poll. Show the section for
+     any Hyperliquid USDC activity at all; the floor lines say what is
+     possible. */
+  const active = Boolean(usdc && (usdc.cash !== 0 || usdc.equity !== 0 || usdc.upnl !== 0)) || data.job !== null;
+  if (!active) return null;
 
   const plan = data.plan;
   const pull = direction === 'pull';
@@ -338,7 +359,7 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
           </div>
           <p className="text-[12px] text-ink-500">move cash between USDT and Hyperliquid USDC</p>
         </div>
-        {borrow > 0 && (
+        {borrow >= MIN_AMOUNT && (
           <span className="num rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-200">
             {`Borrow ${fmtUsd(borrow)} · +${fmtUsd(usdc?.imHeldUsd ?? 0)} IM · +${fmtUsd(usdc?.mmHeldUsd ?? 0)} MM`}
           </span>

--- a/web/src/panels/RebalanceSection.tsx
+++ b/web/src/panels/RebalanceSection.tsx
@@ -3,6 +3,7 @@ import { ApiError } from '../api/client';
 import { useRebalance, useRebalanceCommand, useStartRebalance } from '../api/queries';
 import type { RebalanceDirection, RebalanceJob, RebalancePlan, RebalanceStep } from '../api/types';
 import { HoldToConfirmButton } from '../components/HoldToConfirmButton';
+import { HoverCard } from '../components/HoverCard';
 import { SegmentedToggle } from '../components/SegmentedToggle';
 import { Stat } from '../components/Stat';
 import { fmtAge, fmtUsd, num } from '../lib/fmt';
@@ -23,9 +24,29 @@ const EXPECTED_SECONDS: Record<string, number> = {
 
 const EXPLANATION: Record<RebalanceDirection, string> = {
   payDown:
-    "Only cash moves. Unrealised PnL stays where it is. Each USDC paid back lowers the Hyperliquid borrow by one USDC and frees 20% of it as initial margin and 10% as maintenance margin. Margin balance changes only by the route's cost.",
-  pull: "Only cash moves. The most you can pull is the bucket's equity, so a pull never opens a borrow.",
+    "Sends USDT to Hyperliquid as USDC and pays the borrow back. Each USDC paid back cuts the borrow by 1 USDC and frees 0.20 USDC of initial margin and 0.10 USDC of maintenance margin. Your account total changes only by the route's cost.",
+  pull: 'Brings USDC from Hyperliquid back to USDT. You can pull at most the USDC you own there, so a pull never starts a new borrow.',
 };
+
+const ABOUT = (
+  <div className="flex flex-col gap-2 text-[12px] leading-snug">
+    <p>
+      <span className="font-semibold text-ink-100">What this is. </span>
+      Your CrossEx account holds USDT. The Hyperliquid legs of your pairs settle in USDC. When those legs lose money
+      or pay funding, Gate lends you the USDC to cover it. The amber pill shows that borrow.
+    </p>
+    <p>
+      <span className="font-semibold text-ink-100">Why it matters. </span>
+      Gate holds extra margin against the borrow: 20% as initial margin and 10% as maintenance margin. Once you are
+      more than 10,000 USDC short, Gate also charges interest every hour.
+    </p>
+    <p>
+      <span className="font-semibold text-ink-100">The two moves. </span>
+      USDT → Hyperliquid USDC pays the borrow back. That frees the margin and stops the interest. Hyperliquid USDC →
+      USDT brings spare USDC home when those legs made money.
+    </p>
+  </div>
+);
 
 const DIRECTION_OPTIONS: { value: RebalanceDirection; label: string }[] = [
   { value: 'payDown', label: 'USDT → Hyperliquid USDC' },
@@ -277,7 +298,12 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
     <section aria-label="Rebalance" className="flex flex-col gap-3">
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div>
-          <h2 className="text-xs font-semibold uppercase tracking-wider text-ink-400">Rebalance</h2>
+          <div className="flex items-center gap-1.5">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-ink-400">Rebalance</h2>
+            <HoverCard widthPx={420} label={<span className="sr-only">About rebalance</span>}>
+              {ABOUT}
+            </HoverCard>
+          </div>
           <p className="text-[12px] text-ink-500">move cash between USDT and Hyperliquid USDC</p>
         </div>
         {borrow > 0 && (

--- a/web/src/panels/RebalanceSection.tsx
+++ b/web/src/panels/RebalanceSection.tsx
@@ -1,0 +1,141 @@
+import { useRebalance, useRebalanceCommand, useStartRebalance } from '../api/queries';
+import type { RebalanceJob, RebalanceStep } from '../api/types';
+import { HoldToConfirmButton } from '../components/HoldToConfirmButton';
+import { Stat } from '../components/Stat';
+import { fmtUsd, num } from '../lib/fmt';
+import { useNow } from '../lib/useNow';
+
+const SHORTFALL_TEXT = {
+  cash: 'unrealised profit cannot move until the position closes',
+  margin: 'available margin is too low',
+} as const;
+
+const STEP_TONE: Record<RebalanceStep['status'], string> = {
+  pending: 'text-ink-500',
+  running: 'text-cyan-300',
+  done: 'text-emerald-300',
+};
+
+function waitText(waitSeconds: number): string {
+  if (waitSeconds === 0) return 'instant';
+  return `about ${Math.round(waitSeconds / 6) / 10} min`;
+}
+
+function elapsedText(step: RebalanceStep, now: number): string {
+  if (step.status === 'pending' || step.startedAt === null) return '—';
+  const end = step.status === 'done' && step.doneAt !== null ? step.doneAt : now;
+  return `${Math.max(0, Math.floor((end - step.startedAt) / 1000))}s`;
+}
+
+function stepRows(job: RebalanceJob, now: number) {
+  return (
+    <ul className="flex flex-col gap-1 text-sm">
+      {job.steps.map((s) => (
+        <li key={s.name} className="flex items-baseline gap-3">
+          <span className="text-ink-100">{s.name}</span>
+          <span className={`text-[11px] uppercase tracking-wider ${STEP_TONE[s.status]}`}>{s.status}</span>
+          <span className="num ml-auto text-ink-300">{elapsedText(s, now)}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function RebalanceSection({ holdMs }: { holdMs?: number }) {
+  const { data } = useRebalance();
+  const start = useStartRebalance();
+  const resume = useRebalanceCommand('resume');
+  const abandon = useRebalanceCommand('abandon');
+  const now = useNow(1_000);
+
+  if (!data) return null;
+
+  const bucket = data.buckets.find((b) => b.coin === 'USDC' && b.venue === 'HYPERLIQUID');
+  const borrow = bucket?.borrow ?? 0;
+  const job = data.job;
+  const jobActive = job !== null && (job.status === 'running' || job.status === 'halted');
+  if (borrow === 0 && !jobActive) return null;
+
+  const plan = data.plan;
+  const cmdError = (start.error ?? resume.error ?? abandon.error) as { message: string; hint?: string } | null;
+  const errorLine = cmdError && (
+    <p role="alert" className="text-[12px] text-rose-300">
+      {cmdError.message}
+      {cmdError.hint ? <span className="text-ink-400"> {cmdError.hint}</span> : null}
+    </p>
+  );
+
+  let body;
+  if (job && job.status === 'running') {
+    body = stepRows(job, now);
+  } else if (job && job.status === 'halted') {
+    const cmdPending = resume.isPending || abandon.isPending;
+    body = (
+      <>
+        {stepRows(job, now)}
+        <p className="text-[12px] text-rose-300">{job.haltReason}</p>
+        <p className="text-[12px] text-ink-300">Funds are in {job.fundsAt}</p>
+        <div className="flex gap-1.5">
+          <button type="button" className="btn-ghost-xs" disabled={cmdPending} onClick={() => resume.mutate(job.id)}>
+            Resume
+          </button>
+          <button type="button" className="btn-ghost-xs" disabled={cmdPending} onClick={() => abandon.mutate(job.id)}>
+            Abandon
+          </button>
+        </div>
+        {errorLine}
+      </>
+    );
+  } else if (plan.route) {
+    const route = plan.routes[plan.route];
+    body = (
+      <>
+        <p className="text-[12px] text-ink-300">
+          costs {fmtUsd(route.costUsd)} · saves {fmtUsd(plan.savesPerDayUsd)}/day · frees{' '}
+          {fmtUsd(plan.marginFreedUsd)} margin · {waitText(route.waitSeconds)}
+        </p>
+        {plan.shortfall && (
+          <p className="text-[12px] text-amber-300">
+            Only {num(plan.amount, 2)} USDC can move. {num(plan.shortfall.remaining, 2)} USDC stays borrowed:{' '}
+            {SHORTFALL_TEXT[plan.shortfall.reason]}
+          </p>
+        )}
+        <HoldToConfirmButton
+          tone="cyan"
+          holdMs={holdMs}
+          disabled={start.isPending}
+          onConfirm={() => start.mutate()}
+          className="self-start"
+        >
+          {`Pay down ${num(plan.amount, 2)} USDC`}
+        </HoldToConfirmButton>
+        {errorLine}
+      </>
+    );
+  } else {
+    body = (
+      <>
+        <p className="text-[12px] text-ink-300">Loop: {plan.routes.loop.reason ?? '—'}</p>
+        <p className="text-[12px] text-ink-300">Convert: {plan.routes.convert.reason ?? '—'}</p>
+      </>
+    );
+  }
+
+  return (
+    <section aria-label="Pay down" className="flex flex-col gap-3">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-ink-400">Pay down</h2>
+      <div className="flex flex-wrap gap-8">
+        <Stat label="Borrow (USDC)">
+          <span className="num">{num(borrow, 2)}</span>
+        </Stat>
+        <Stat label="Interest / day">
+          <span className="num">{fmtUsd(bucket?.interestPerDayUsd ?? 0)}</span>
+        </Stat>
+        <Stat label="Interest paid · 30 d">
+          <span className="num">{fmtUsd(bucket?.interestPaid30dUsd ?? 0)}</span>
+        </Stat>
+      </div>
+      {body}
+    </section>
+  );
+}

--- a/web/src/panels/RebalanceSection.tsx
+++ b/web/src/panels/RebalanceSection.tsx
@@ -1,8 +1,9 @@
+import { ApiError } from '../api/client';
 import { useRebalance, useRebalanceCommand, useStartRebalance } from '../api/queries';
 import type { RebalanceJob, RebalanceStep } from '../api/types';
 import { HoldToConfirmButton } from '../components/HoldToConfirmButton';
 import { Stat } from '../components/Stat';
-import { fmtUsd, num } from '../lib/fmt';
+import { fmtAge, fmtUsd, num } from '../lib/fmt';
 import { useNow } from '../lib/useNow';
 
 const SHORTFALL_TEXT = {
@@ -21,10 +22,22 @@ function waitText(waitSeconds: number): string {
   return `about ${Math.round(waitSeconds / 6) / 10} min`;
 }
 
-function elapsedText(step: RebalanceStep, now: number): string {
+function elapsedText(step: RebalanceStep, job: RebalanceJob, now: number): string {
   if (step.status === 'pending' || step.startedAt === null) return '—';
-  const end = step.status === 'done' && step.doneAt !== null ? step.doneAt : now;
-  return `${Math.max(0, Math.floor((end - step.startedAt) / 1000))}s`;
+  const end =
+    step.status === 'done' && step.doneAt !== null ? step.doneAt : job.status === 'halted' ? job.updatedAt : now;
+  return fmtAge(end - step.startedAt);
+}
+
+function errorLine(error: Error | null) {
+  if (!error) return null;
+  const hint = error instanceof ApiError ? error.hint : undefined;
+  return (
+    <p role="alert" className="text-[12px] text-rose-300">
+      {error.message}
+      {hint ? <span className="text-ink-400"> {hint}</span> : null}
+    </p>
+  );
 }
 
 function stepRows(job: RebalanceJob, now: number) {
@@ -34,7 +47,7 @@ function stepRows(job: RebalanceJob, now: number) {
         <li key={s.name} className="flex items-baseline gap-3">
           <span className="text-ink-100">{s.name}</span>
           <span className={`text-[11px] uppercase tracking-wider ${STEP_TONE[s.status]}`}>{s.status}</span>
-          <span className="num ml-auto text-ink-300">{elapsedText(s, now)}</span>
+          <span className="num ml-auto text-ink-300">{elapsedText(s, job, now)}</span>
         </li>
       ))}
     </ul>
@@ -57,13 +70,6 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
   if (borrow === 0 && !jobActive) return null;
 
   const plan = data.plan;
-  const cmdError = (start.error ?? resume.error ?? abandon.error) as { message: string; hint?: string } | null;
-  const errorLine = cmdError && (
-    <p role="alert" className="text-[12px] text-rose-300">
-      {cmdError.message}
-      {cmdError.hint ? <span className="text-ink-400"> {cmdError.hint}</span> : null}
-    </p>
-  );
 
   let body;
   if (job && job.status === 'running') {
@@ -83,11 +89,12 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
             Abandon
           </button>
         </div>
-        {errorLine}
+        {errorLine(resume.error ?? abandon.error)}
       </>
     );
   } else if (plan.route) {
-    const route = plan.routes[plan.route];
+    const routeName = plan.route;
+    const route = plan.routes[routeName];
     body = (
       <>
         <p className="text-[12px] text-ink-300">
@@ -104,12 +111,12 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
           tone="cyan"
           holdMs={holdMs}
           disabled={start.isPending}
-          onConfirm={() => start.mutate()}
+          onConfirm={() => start.mutate({ amount: plan.amount, route: routeName })}
           className="self-start"
         >
           {`Pay down ${num(plan.amount, 2)} USDC`}
         </HoldToConfirmButton>
-        {errorLine}
+        {errorLine(start.error)}
       </>
     );
   } else {

--- a/web/src/panels/RebalanceSection.tsx
+++ b/web/src/panels/RebalanceSection.tsx
@@ -1,33 +1,124 @@
+import { useEffect, useState } from 'react';
 import { ApiError } from '../api/client';
 import { useRebalance, useRebalanceCommand, useStartRebalance } from '../api/queries';
-import type { RebalanceJob, RebalanceStep } from '../api/types';
+import type { RebalanceDirection, RebalanceJob, RebalancePlan, RebalanceStep } from '../api/types';
 import { HoldToConfirmButton } from '../components/HoldToConfirmButton';
+import { SegmentedToggle } from '../components/SegmentedToggle';
 import { Stat } from '../components/Stat';
 import { fmtAge, fmtUsd, num } from '../lib/fmt';
 import { roundToStep } from '../lib/ticks';
 import { useNow } from '../lib/useNow';
+
+const PULL_STEP_SECONDS = 390;
+
+const EXPECTED_SECONDS: Record<string, number> = {
+  'Buy USDC': 2,
+  'To spot': 5,
+  'To Hyperliquid': 127,
+  Convert: 2,
+  'Pull from Hyperliquid': PULL_STEP_SECONDS,
+  'To Gate': 6,
+  'Sell USDC': 2,
+};
+
+const EXPLANATION: Record<RebalanceDirection, string> = {
+  payDown:
+    "Only cash moves. Unrealised PnL stays where it is. Each USDC paid back lowers the Hyperliquid borrow by one USDC and frees 20% of it as initial margin and 10% as maintenance margin. Margin balance changes only by the route's cost.",
+  pull: "Only cash moves. The most you can pull is the bucket's equity, so a pull never opens a borrow.",
+};
+
+const DIRECTION_OPTIONS: { value: RebalanceDirection; label: string }[] = [
+  { value: 'payDown', label: 'USDT → Hyperliquid USDC' },
+  { value: 'pull', label: 'Hyperliquid USDC → USDT' },
+];
 
 const SHORTFALL_TEXT = {
   cash: 'unrealised profit cannot move until the position closes',
   margin: 'available margin is too low',
 } as const;
 
-const STEP_TONE: Record<RebalanceStep['status'], string> = {
-  pending: 'text-ink-500',
-  running: 'text-cyan-300',
-  done: 'text-emerald-300',
+type SegmentKind = 'done' | 'running' | 'pending' | 'halted';
+
+const SEGMENT_FILL: Record<SegmentKind, string> = {
+  done: 'bg-emerald-500',
+  running: 'bg-cyan-500',
+  pending: 'bg-transparent',
+  halted: 'bg-rose-500',
 };
 
-function waitText(waitSeconds: number): string {
-  if (waitSeconds === 0) return 'instant';
-  return `about ${Math.round(waitSeconds / 6) / 10} min`;
+const SEGMENT_TEXT: Record<SegmentKind, string> = {
+  done: 'text-emerald-300',
+  running: 'text-cyan-300',
+  pending: 'text-ink-500',
+  halted: 'text-rose-300',
+};
+
+function floorCents(value: number): number {
+  return Number(roundToStep(Math.max(0, value), '0.01', 'down'));
 }
 
-function elapsedText(step: RebalanceStep, job: RebalanceJob, now: number): string {
-  if (step.status === 'pending' || step.startedAt === null) return '—';
-  const end =
-    step.status === 'done' && step.doneAt !== null ? step.doneAt : job.status === 'halted' ? job.updatedAt : now;
-  return fmtAge(end - step.startedAt);
+function parseAmount(text: string): number | null {
+  const n = Number(text);
+  return text.trim() !== '' && Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function quoteLine(plan: RebalancePlan, routeName: 'loop' | 'convert', pull: boolean): string {
+  const route = plan.routes[routeName];
+  const price = plan.price === null ? '—' : num(plan.price, 4);
+  const wait = `about ${num(route.waitSeconds / 60, 1)} min`;
+  if (pull) {
+    return `via spot loop · ${num(plan.amount, 2)} USDC → ${num(plan.receives, 2)} USDT @ ${price} · costs ${fmtUsd(route.costUsd)} · ${wait}`;
+  }
+  const move = `${num(plan.amount, 2)} USDT → ${num(plan.receives, 2)} USDC @ ${price}`;
+  const effect = `saves ${fmtUsd(plan.savesPerDayUsd)}/day · frees ${fmtUsd(plan.marginFreedUsd)} margin · borrow after ${fmtUsd(plan.borrowAfterUsd)}`;
+  if (routeName === 'convert') {
+    return `via convert · ${move} · spread ${fmtUsd(route.costUsd)} · ${effect} · instant · sends on a fresh quote within 30 bps of this one`;
+  }
+  return `via spot loop · ${move} · costs ${fmtUsd(route.costUsd)} · ${effect} · ${wait}`;
+}
+
+function segment(step: RebalanceStep, job: RebalanceJob, now: number): { kind: SegmentKind; pct: number; text: string } {
+  const expected = EXPECTED_SECONDS[step.name] ?? 0;
+  if (step.status === 'done' && step.startedAt !== null && step.doneAt !== null) {
+    return { kind: 'done', pct: 100, text: fmtAge(step.doneAt - step.startedAt) };
+  }
+  if (step.status === 'running' && step.startedAt !== null) {
+    const halted = job.status === 'halted';
+    const elapsed = Math.max(0, (halted ? job.updatedAt : now) - step.startedAt);
+    const ratio = expected > 0 ? elapsed / 1000 / expected : 1;
+    const pct = Math.min(95, ratio * 100);
+    if (halted) return { kind: 'halted', pct, text: `halted at ${fmtAge(elapsed)}` };
+    return { kind: 'running', pct, text: `${fmtAge(elapsed)} / ~${fmtAge(expected * 1000)}` };
+  }
+  return { kind: 'pending', pct: 0, text: `~${fmtAge(expected * 1000)}` };
+}
+
+function progressBar(job: RebalanceJob, now: number) {
+  return (
+    <ol className="flex gap-2">
+      {job.steps.map((s) => {
+        const seg = segment(s, job, now);
+        return (
+          <li key={s.name} className="flex flex-1 flex-col gap-1">
+            <div className="flex items-baseline justify-between gap-2 text-[11px]">
+              <span className="text-ink-100">{s.name}</span>
+              <span className={`num ${SEGMENT_TEXT[seg.kind]}`}>{seg.text}</span>
+            </div>
+            <div
+              role="progressbar"
+              aria-label={s.name}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={Math.round(seg.pct)}
+              className="h-1.5 overflow-hidden rounded-full bg-ink-800"
+            >
+              <div className={`h-full ${SEGMENT_FILL[seg.kind]}`} style={{ width: `${seg.pct}%` }} />
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
 }
 
 function errorLine(error: Error | null) {
@@ -41,54 +132,59 @@ function errorLine(error: Error | null) {
   );
 }
 
-/** The step the job stopped on keeps status running in the file; on screen it is halted. */
-function stepLabel(step: RebalanceStep, job: RebalanceJob): { text: string; tone: string } {
-  if (job.status === 'halted' && step.status === 'running') return { text: 'halted', tone: 'text-rose-300' };
-  return { text: step.status, tone: STEP_TONE[step.status] };
-}
-
-function stepRows(job: RebalanceJob, now: number) {
-  return (
-    <ul className="flex flex-col gap-1 text-sm">
-      {job.steps.map((s) => {
-        const label = stepLabel(s, job);
-        return (
-          <li key={s.name} className="flex items-baseline gap-3">
-            <span className="text-ink-100">{s.name}</span>
-            <span className={`text-[11px] uppercase tracking-wider ${label.tone}`}>{label.text}</span>
-            <span className="num ml-auto text-ink-300">{elapsedText(s, job, now)}</span>
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
-
 export function RebalanceSection({ holdMs }: { holdMs?: number }) {
-  const { data } = useRebalance();
+  const [chosen, setChosen] = useState<RebalanceDirection | null>(null);
+  const direction = chosen ?? 'payDown';
+  const [typed, setTyped] = useState<string | null>(null);
+  const [blurred, setBlurred] = useState(false);
+  const [amountParam, setAmountParam] = useState<number | null>(null);
+  const query = useRebalance({ direction, amount: amountParam });
   const start = useStartRebalance();
   const resume = useRebalanceCommand('resume');
   const abandon = useRebalanceCommand('abandon');
   const now = useNow(1_000);
 
+  useEffect(() => {
+    if (typed === null) return;
+    const t = setTimeout(() => setAmountParam(parseAmount(typed)), 300);
+    return () => clearTimeout(t);
+  }, [typed]);
+
+  const data = query.data;
+  const usdc = data?.buckets.find((b) => b.coin === 'USDC' && b.venue === 'HYPERLIQUID');
+  const usdt = data?.buckets.find((b) => b.coin === 'USDT' && b.venue === 'CROSSEX');
+  const borrow = floorCents(usdc?.borrow ?? 0);
+  const pullable = floorCents(Math.min(usdc?.cash ?? 0, usdc?.equity ?? 0));
+
+  useEffect(() => {
+    if (chosen !== null || !data) return;
+    setChosen(borrow === 0 && pullable > 0 ? 'pull' : 'payDown');
+  }, [chosen, data, borrow, pullable]);
+
   if (!data) return null;
 
-  const bucket = data.buckets.find((b) => b.coin === 'USDC' && b.venue === 'HYPERLIQUID');
-  const borrow = bucket?.borrow ?? 0;
-  const job = data.job;
-  const jobActive = job !== null && (job.status === 'running' || job.status === 'halted');
-  if (borrow === 0 && !jobActive) return null;
+  const job = data.job && (data.job.status === 'running' || data.job.status === 'halted') ? data.job : null;
+  if (borrow === 0 && pullable === 0 && !job) return null;
 
   const plan = data.plan;
+  const pull = direction === 'pull';
+
+  const pickDirection = (next: RebalanceDirection) => {
+    setChosen(next);
+    setTyped(null);
+    setAmountParam(null);
+    setBlurred(false);
+    start.reset();
+  };
 
   let body;
-  if (job && job.status === 'running') {
-    body = stepRows(job, now);
-  } else if (job && job.status === 'halted') {
+  if (job?.status === 'running') {
+    body = progressBar(job, now);
+  } else if (job) {
     const cmdPending = resume.isPending || abandon.isPending;
     body = (
       <>
-        {stepRows(job, now)}
+        {progressBar(job, now)}
         <p className="text-[12px] text-rose-300">{job.haltReason}</p>
         <p className="text-[12px] text-ink-300">Funds are in {job.fundsAt}</p>
         <div className="flex gap-1.5">
@@ -102,56 +198,103 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
         {errorLine(resume.error ?? abandon.error)}
       </>
     );
-  } else if (plan.route) {
+  } else {
+    const inputValue = typed ?? roundToStep(plan.amount, '0.01', 'down');
+    const typedAmount = typed === null ? null : parseAmount(typed);
+    const invalid = parseAmount(inputValue) === null;
+    const showEnter = blurred && invalid;
+    const settled = !query.isPlaceholderData && amountParam === typedAmount;
+    const capped = settled && typedAmount !== null && floorCents(typedAmount) > plan.amount;
+    const free = pull ? pullable : floorCents(usdt?.cash ?? 0);
     const routeName = plan.route;
-    const route = plan.routes[routeName];
     body = (
       <>
-        <p className="text-[12px] text-ink-300">
-          costs {fmtUsd(route.costUsd)} · saves {fmtUsd(plan.savesPerDayUsd)}/day · frees{' '}
-          {fmtUsd(plan.marginFreedUsd)} margin · {waitText(route.waitSeconds)}
-        </p>
-        {plan.shortfall && (
-          <p className="text-[12px] text-amber-300">
-            Only {num(plan.amount, 2)} USDC can move. {num(plan.shortfall.remaining, 2)} USDC stays borrowed:{' '}
-            {SHORTFALL_TEXT[plan.shortfall.reason]}
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex flex-col gap-1">
+            <span className="text-[11px] text-ink-400">Direction</span>
+            <SegmentedToggle<RebalanceDirection>
+              ariaLabel="Direction"
+              value={direction}
+              onChange={pickDirection}
+              options={DIRECTION_OPTIONS}
+            />
+          </div>
+          <div className="flex min-w-[16rem] flex-1 flex-col gap-1">
+            <label htmlFor="rebalance-amount" className="text-[11px] text-ink-400">
+              {`Amount (${pull ? 'USDC' : 'USDT'}) · free ${num(free, 2)}`}
+            </label>
+            <input
+              id="rebalance-amount"
+              className={`input num ${showEnter ? '!border-rose-500/60' : ''}`}
+              inputMode="decimal"
+              aria-invalid={showEnter ? true : undefined}
+              aria-describedby={showEnter ? 'rebalance-amount-error' : undefined}
+              value={inputValue}
+              onChange={(e) => setTyped(e.target.value)}
+              onBlur={() => setBlurred(true)}
+            />
+          </div>
+          {routeName && (
+            <HoldToConfirmButton
+              tone="cyan"
+              holdMs={holdMs}
+              disabled={start.isPending || invalid || !settled}
+              onConfirm={() => start.mutate({ direction, amount: plan.amount, route: routeName })}
+            >
+              {pull
+                ? `Hold to pull ${num(plan.amount, 2)} USDC → USDT`
+                : `Hold to move ${num(plan.amount, 2)} USDT → USDC`}
+            </HoldToConfirmButton>
+          )}
+        </div>
+        {showEnter && (
+          <p id="rebalance-amount-error" role="alert" className="text-[11px] text-rose-300">
+            Enter an amount
           </p>
         )}
-        <HoldToConfirmButton
-          tone="cyan"
-          holdMs={holdMs}
-          disabled={start.isPending}
-          onConfirm={() => start.mutate({ amount: plan.amount, route: routeName })}
-          className="self-start"
-        >
-          {`Pay down ${num(plan.amount, 2)} USDC`}
-        </HoldToConfirmButton>
-        {errorLine(start.error)}
-      </>
-    );
-  } else {
-    body = (
-      <>
-        <p className="text-[12px] text-ink-300">Loop: {plan.routes.loop.reason ?? '—'}</p>
-        <p className="text-[12px] text-ink-300">Convert: {plan.routes.convert.reason ?? '—'}</p>
+        {capped && <p className="text-[11px] text-amber-300">Capped at {num(plan.amount, 2)}</p>}
+        {routeName ? (
+          <>
+            <p className="text-[12px] text-ink-300">{quoteLine(plan, routeName, pull)}</p>
+            {!pull && plan.shortfall && (
+              <p className="text-[12px] text-amber-300">
+                {`Only ${num(plan.amount, 2)} USDC can move. ${num(plan.shortfall.remaining, 2)} USDC stays borrowed: ${SHORTFALL_TEXT[plan.shortfall.reason]}`}
+              </p>
+            )}
+            {errorLine(start.error)}
+          </>
+        ) : (
+          <>
+            <p className="text-[12px] text-ink-300">Loop: {plan.routes.loop.reason ?? '—'}</p>
+            <p className="text-[12px] text-ink-300">Convert: {plan.routes.convert.reason ?? '—'}</p>
+          </>
+        )}
       </>
     );
   }
 
   return (
-    <section aria-label="Pay down" className="flex flex-col gap-3">
-      <h2 className="text-xs font-semibold uppercase tracking-wider text-ink-400">Pay down</h2>
+    <section aria-label="Rebalance" className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-ink-400">Rebalance</h2>
+          <p className="text-[12px] text-ink-500">move cash between USDT and Hyperliquid USDC</p>
+        </div>
+        {borrow > 0 && (
+          <span className="num rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-200">
+            {`Borrow ${fmtUsd(borrow)} · +${fmtUsd(usdc?.imHeldUsd ?? 0)} IM · +${fmtUsd(usdc?.mmHeldUsd ?? 0)} MM`}
+          </span>
+        )}
+      </div>
       <div className="flex flex-wrap gap-8">
-        <Stat label="Borrow (USDC)">
-          <span className="num">{num(roundToStep(borrow, '0.01', 'down'), 2)}</span>
-        </Stat>
         <Stat label="Interest / day">
-          <span className="num">{fmtUsd(bucket?.interestPerDayUsd ?? 0)}</span>
+          <span className="num">{fmtUsd(usdc?.interestPerDayUsd ?? 0)}</span>
         </Stat>
         <Stat label="Interest paid · 30 d">
-          <span className="num">{fmtUsd(bucket?.interestPaid30dUsd ?? 0)}</span>
+          <span className="num">{fmtUsd(usdc?.interestPaid30dUsd ?? 0)}</span>
         </Stat>
       </div>
+      <p className="text-[12px] text-ink-400">{EXPLANATION[job ? job.direction : direction]}</p>
       {body}
     </section>
   );

--- a/web/src/panels/RebalanceSection.tsx
+++ b/web/src/panels/RebalanceSection.tsx
@@ -98,6 +98,17 @@ function quoteLine(plan: RebalancePlan, routeName: 'loop' | 'convert', pull: boo
   return `via spot loop · ${move} · costs ${fmtUsd(route.costUsd)} · ${effect} · ${wait}`;
 }
 
+function noRouteLine(plan: RebalancePlan, pull: boolean, borrow: number, free: number): { text: string; warn: boolean } {
+  const reason = plan.routes.loop.reason;
+  if (reason && reason !== 'nothing to move') return { text: reason, warn: true };
+  if (pull) {
+    return { text: free > 0 ? 'Nothing to pull.' : 'Nothing to pull. There is no spare USDC on Hyperliquid.', warn: false };
+  }
+  if (borrow === 0) return { text: 'Nothing to pay back. There is no USDC borrow on Hyperliquid.', warn: false };
+  if (free === 0) return { text: 'Nothing to move. There is no free USDT.', warn: false };
+  return { text: 'Nothing to move.', warn: false };
+}
+
 function segment(step: RebalanceStep, job: RebalanceJob, now: number): { kind: SegmentKind; pct: number; text: string } {
   const expected = EXPECTED_SECONDS[step.name] ?? 0;
   if (step.status === 'done' && step.startedAt !== null && step.doneAt !== null) {
@@ -285,10 +296,10 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
             {errorLine(start.error)}
           </>
         ) : (
-          <>
-            <p className="text-[12px] text-ink-300">Loop: {plan.routes.loop.reason ?? '—'}</p>
-            <p className="text-[12px] text-ink-300">Convert: {plan.routes.convert.reason ?? '—'}</p>
-          </>
+          (() => {
+            const line = noRouteLine(plan, pull, borrow, free);
+            return <p className={`text-[12px] ${line.warn ? 'text-amber-300' : 'text-ink-300'}`}>{line.text}</p>;
+          })()
         )}
       </>
     );

--- a/web/src/panels/RebalanceSection.tsx
+++ b/web/src/panels/RebalanceSection.tsx
@@ -4,6 +4,7 @@ import type { RebalanceJob, RebalanceStep } from '../api/types';
 import { HoldToConfirmButton } from '../components/HoldToConfirmButton';
 import { Stat } from '../components/Stat';
 import { fmtAge, fmtUsd, num } from '../lib/fmt';
+import { roundToStep } from '../lib/ticks';
 import { useNow } from '../lib/useNow';
 
 const SHORTFALL_TEXT = {
@@ -40,16 +41,25 @@ function errorLine(error: Error | null) {
   );
 }
 
+/** The step the job stopped on keeps status running in the file; on screen it is halted. */
+function stepLabel(step: RebalanceStep, job: RebalanceJob): { text: string; tone: string } {
+  if (job.status === 'halted' && step.status === 'running') return { text: 'halted', tone: 'text-rose-300' };
+  return { text: step.status, tone: STEP_TONE[step.status] };
+}
+
 function stepRows(job: RebalanceJob, now: number) {
   return (
     <ul className="flex flex-col gap-1 text-sm">
-      {job.steps.map((s) => (
-        <li key={s.name} className="flex items-baseline gap-3">
-          <span className="text-ink-100">{s.name}</span>
-          <span className={`text-[11px] uppercase tracking-wider ${STEP_TONE[s.status]}`}>{s.status}</span>
-          <span className="num ml-auto text-ink-300">{elapsedText(s, job, now)}</span>
-        </li>
-      ))}
+      {job.steps.map((s) => {
+        const label = stepLabel(s, job);
+        return (
+          <li key={s.name} className="flex items-baseline gap-3">
+            <span className="text-ink-100">{s.name}</span>
+            <span className={`text-[11px] uppercase tracking-wider ${label.tone}`}>{label.text}</span>
+            <span className="num ml-auto text-ink-300">{elapsedText(s, job, now)}</span>
+          </li>
+        );
+      })}
     </ul>
   );
 }
@@ -133,7 +143,7 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
       <h2 className="text-xs font-semibold uppercase tracking-wider text-ink-400">Pay down</h2>
       <div className="flex flex-wrap gap-8">
         <Stat label="Borrow (USDC)">
-          <span className="num">{num(borrow, 2)}</span>
+          <span className="num">{num(roundToStep(borrow, '0.01', 'down'), 2)}</span>
         </Stat>
         <Stat label="Interest / day">
           <span className="num">{fmtUsd(bucket?.interestPerDayUsd ?? 0)}</span>

--- a/web/src/panels/RebalanceSection.tsx
+++ b/web/src/panels/RebalanceSection.tsx
@@ -11,6 +11,8 @@ import { roundToStep } from '../lib/ticks';
 import { useNow } from '../lib/useNow';
 
 const PULL_STEP_SECONDS = 390;
+/** Under this the hold is hidden: a few-cent convert or a pull that the $1 fee eats is never worth a hold. */
+const MIN_AMOUNT = 1;
 
 const EXPECTED_SECONDS: Record<string, number> = {
   'Buy USDC': 2,
@@ -88,7 +90,11 @@ function quoteLine(plan: RebalancePlan, routeName: 'loop' | 'convert', pull: boo
   const price = plan.price === null ? '—' : num(plan.price, 4);
   const wait = `about ${num(route.waitSeconds / 60, 1)} min`;
   if (pull) {
-    return `via spot loop · ${num(plan.amount, 2)} USDC → ${num(plan.receives, 2)} USDT @ ${price} · costs ${fmtUsd(route.costUsd)} · ${wait}`;
+    const move = `${num(plan.amount, 2)} USDC → ${num(plan.receives, 2)} USDT @ ${price}`;
+    if (routeName === 'convert') {
+      return `via convert · ${move} · spread ${fmtUsd(route.costUsd)} · instant · sends on a fresh quote within 30 bps of this one`;
+    }
+    return `via spot loop · ${move} · costs ${fmtUsd(route.costUsd)} · ${wait}`;
   }
   const move = `${num(plan.amount, 2)} USDT → ${num(plan.receives, 2)} USDC @ ${price}`;
   const effect = `saves ${fmtUsd(plan.savesPerDayUsd)}/day · frees ${fmtUsd(plan.marginFreedUsd)} margin · borrow after ${fmtUsd(plan.borrowAfterUsd)}`;
@@ -107,6 +113,12 @@ function noRouteLine(plan: RebalancePlan, pull: boolean, borrow: number, free: n
   if (borrow === 0) return { text: 'Nothing to pay back. There is no USDC borrow on Hyperliquid.', warn: false };
   if (free === 0) return { text: 'Nothing to move. There is no free USDT.', warn: false };
   return { text: 'Nothing to move.', warn: false };
+}
+
+function tooSmallLine(pull: boolean, borrow: number): string {
+  if (pull) return `Nothing to pull. Spare USDC is under ${MIN_AMOUNT} USDC.`;
+  if (borrow < MIN_AMOUNT) return `Nothing to pay back. The borrow is under ${MIN_AMOUNT} USDC.`;
+  return `Under ${MIN_AMOUNT} USDT can move. Free USDT or margin is too low.`;
 }
 
 function segment(step: RebalanceStep, job: RebalanceJob, now: number): { kind: SegmentKind; pct: number; text: string } {
@@ -239,6 +251,9 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
     const capped = settled && typedAmount !== null && floorCents(typedAmount) > plan.amount;
     const free = pull ? pullable : floorCents(usdt?.cash ?? 0);
     const routeName = plan.route;
+    const floorHit = settled && routeName !== null && plan.amount < MIN_AMOUNT;
+    const capTooSmall = floorHit && (typedAmount === null || floorCents(typedAmount) > plan.amount);
+    const typedTooSmall = floorHit && !capTooSmall;
     body = (
       <>
         <div className="flex flex-wrap items-end gap-3">
@@ -266,7 +281,7 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
               onBlur={() => setBlurred(true)}
             />
           </div>
-          {routeName && (
+          {routeName && !floorHit && (
             <HoldToConfirmButton
               tone="cyan"
               holdMs={holdMs}
@@ -284,8 +299,14 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
             Enter an amount
           </p>
         )}
-        {capped && <p className="text-[11px] text-amber-300">Capped at {num(plan.amount, 2)}</p>}
-        {routeName ? (
+        {typedTooSmall && (
+          <p role="alert" className="text-[11px] text-rose-300">
+            {`Enter at least ${MIN_AMOUNT} ${pull ? 'USDC' : 'USDT'}`}
+          </p>
+        )}
+        {capped && !floorHit && <p className="text-[11px] text-amber-300">Capped at {num(plan.amount, 2)}</p>}
+        {capTooSmall && <p className="text-[12px] text-ink-300">{tooSmallLine(pull, borrow)}</p>}
+        {floorHit ? null : routeName ? (
           <>
             <p className="text-[12px] text-ink-300">{quoteLine(plan, routeName, pull)}</p>
             {!pull && plan.shortfall && (

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -238,7 +238,11 @@ export function baseHandlers() {
         env<RebalanceView>({
           buckets: [],
           plan: {
+            direction: 'payDown',
             amount: 0,
+            receives: 0,
+            price: null,
+            borrowAfterUsd: 0,
             shortfall: null,
             routes: {
               loop: { costUsd: 0.05, waitSeconds: 150, available: false, reason: 'nothing to move' },

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -17,6 +17,7 @@ import type {
   PositionsResponse,
   PreviewResponse,
   PreviewResult,
+  RebalanceView,
   StrategyLeg,
   StrategyReturns,
   StrategyRollup,
@@ -232,6 +233,26 @@ export function baseHandlers() {
       HttpResponse.json(env(makeDealView({ pair: { id: String(params.id) } }))),
     ),
     http.get('/api/deals', () => HttpResponse.json(env([]))),
+    http.get('/api/rebalance', () =>
+      HttpResponse.json(
+        env<RebalanceView>({
+          buckets: [],
+          plan: {
+            amount: 0,
+            deficit: 0,
+            shortfall: null,
+            routes: {
+              loop: { costUsd: 0.05, waitSeconds: 150, available: false, reason: 'nothing to move' },
+              convert: { costUsd: 0, waitSeconds: 0, available: false, reason: 'nothing to move' },
+            },
+            route: null,
+            savesPerDayUsd: 0,
+            marginFreedUsd: 0,
+          },
+          job: null,
+        }),
+      ),
+    ),
     http.get('/api/alerts', () => HttpResponse.json(env([]))),
     // Default: disclaimer already accepted, so the gate stays out of the way.
     // Tests that exercise the gate override this with accepted:false.

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -239,7 +239,6 @@ export function baseHandlers() {
           buckets: [],
           plan: {
             amount: 0,
-            deficit: 0,
             shortfall: null,
             routes: {
               loop: { costUsd: 0.05, waitSeconds: 150, available: false, reason: 'nothing to move' },


### PR DESCRIPTION
## TLDR

On CrossEx, a hedged pair with a Hyperliquid leg borrows USDC when that leg loses. Gate holds 20% margin against the borrow and charges interest once the shortfall passes 10,000 USDC. Nothing in the app showed this.

This PR adds a Rebalance section to the Balances tab. It shows the borrow, the margin it holds, and the interest. One hold moves cash either way: USDT to Hyperliquid USDC to pay the borrow back, or spare USDC back to USDT. The server picks the cheaper of two routes, an instant convert at 20 bps or a spot loop, and runs it as a resumable job with a live progress bar. Both directions and both routes ran on the real account. Ticket ED-6434.

## By commit

1. The feature: `GET` and `POST /api/rebalance`, the plan maths, the job runner, the section.
2. Fixes from a ten-agent review and an audit: convert double-send, resume after a venue rejection, halt logging and alerts, disclaimer gate, amount and route bound to the hold, a cache bust race.
3. Two display fixes from a browser check: the borrow floors to cents, a halted step reads HALTED.
4. The agreed mockup layout, plus the pull direction (Hyperliquid USDC to USDT). `direction` and `amount` on both endpoints. An old job file reads as pay-down.
5. Plain-words explanation lines and an info card on the title.
6. One plain sentence when nothing can move, with the numbers a trader needs.
7. Convert as a pull route, auto-picked when cheaper, and no hold under 1 USDC.
8. User guide: when the USDC borrow appears (opening a leg does not borrow; funding, fees, and losses do), and the section as built.
9. Gate sends the USDC transfer minimum as a string; the route now coerces it, so the pull reason says `Pull at least 12 USDC`, not `111`. Found in the live pull-by-convert run below. The server mocks now mirror the real wire.
10. Version 1.5.1: `version.json` highlights for the update pop-up and the `CHANGELOG.md` entry.
11. The section no longer vanishes after a job. Both directions end with the bucket's equity near zero, where the borrow and the pullable amount flip between 0.00 and a few cents on every poll; the render rule hid the section when both floored to zero. It now stays for any Hyperliquid USDC activity, the pill shows from 1 USDC, and the direction re-defaults when a job ends.

## MUST DO BEFORE DEPLOY

Nothing.

## Review focus

- `src/server/rebalanceRunner.ts:179` — the convert step reads the receiving bucket's balance once, before the quote, and never overwrites it. The landed check at :111 compares against that stored value. Since the seventh commit the bucket depends on the direction (`convertSpec`, :96). With the two-look rule this is what stops a lost order response from converting twice.
- `src/server/rebalanceRunner.ts:148` — the tag lookup. A resumed step with a tag and no venue id looks the tag up on Gate before any re-send.
- `src/server/rebalanceRunner.ts:67` — a rejected order or a dead transfer clears its venue id and tag and bumps the attempt, so Resume sends a fresh one with a new tag.
- `src/server/rebalanceRunner.ts:278` — the send phase and its error split. A Gate 4xx with a label halts. Any other send error leaves the tag in place for the lookup.
- `src/server/rebalanceRunner.ts:190` — the convert floor. A fresh quote below amount × 0.997 halts before any order is sent.
- `src/server/routes/rebalance.ts:127` — the start route: disclaimer, job, and deal checks run before any Gate read; then the body's amount and route are checked against the fresh plan (`plan changed` at :149).
- `src/server/routes/rebalance.ts:37` — a running job is halted at plugin start, logged, and raised as an engine alert.
- `src/server/cache.ts:137` — an entry busted while its fetch is in flight is no longer re-inserted. This is a change to the shared cache; every route uses it.
- `src/engine/loop.ts` — one word: `decodeStatus` is now exported. No behaviour change in the engine.

## Test evidence

```
yarn typecheck && yarn test && yarn --cwd web typecheck && yarn --cwd web test
```

| Step | Result |
|---|---|
| `yarn typecheck` | pass |
| `yarn test` (unit + server) | 61 files, 1018 tests passed, exit 0 |
| `yarn --cwd web typecheck` | pass |
| `yarn --cwd web test` | 49 files, 722 tests passed, exit 0 |

New tests: plan maths, the runner state machine with a fake clock and fake clients (convert double-send, fee in USDC, dead-transfer resume with a new tag, unknown step, 404 on first poll), the routes over nock (order of the 409 checks, body binding, disclaimer 403, interest paging window), the cache bust race, the update and credential 409s, and the section in jsdom. Every `-t` filter the specs name selects at least one test.

### Live run, 2026-09-07

`tests/live/rebalance.test.ts` ran against the real account with `REBALANCE=1 LIVE_TRADE_TESTS=1 LIVE_TRADE_ACK=…`. It passed in 83 s.

| Step | Venue id | Quantity |
|---|---|---|
| Buy USDC | 2208119383918080 | 11.99 USDC for 12 USDT |
| To spot | 38236916403045888 | 11.99 |
| To Hyperliquid | 38236916432282624 | 11.94 (fee 0.05) |

USDC/HYPERLIQUID balance went from -262.34 to -250.40, a rise of 11.94, so the landed check holds. DoD line P2-D4 is now MET.

### Browser check, 2026-09-07

The branch ran on a spare port against the real account, and the Balances tab was driven in Chrome:

- The Pay down section shows the three tiles, the cost line, and the hold button for the account's 272 USDC borrow.
- A job file staged mid-flight halted at boot with `server restarted`, raised the alert banner on the tab, and rendered the step rows, the reason, the funds location, and the Resume and Abandon buttons.
- Abandon returned the section to the plan view.

### Real hold, 2026-09-07

With the user's yes, the button was held for real in Chrome on the branch server. The job took 93 s.

| Step | Venue id | Quantity |
|---|---|---|
| Buy USDC | 2208121615301120 | 273.27 USDC for 273.31 USDT |
| To spot | 38236918634413312 | 273.27 |
| To Hyperliquid | 38236918655385856 | 273.22 (fee 0.05) |

Gate then reported USDC/HYPERLIQUID liability 0 and balance +22.84. Initial margin used fell from 21% to 16%, and available rose by about $55, which is what the plan's "frees" figure said.

### Pull direction, live probe, 2026-09-07

The three pull legs ran on the real account with 12 USDC through the SDK (`docs/test/probe/`, local only).

| Leg | Time | Fee | Result |
|---|---|---|---|
| `CROSSEX_HYPERLIQUID` → `SPOT` | 387 s | $1 flat | 12 sent, 11 received |
| `SPOT` → `CROSSEX_GATE` | 6 s | none | 11 |
| MARKET SELL 11 USDC | 0.2 s | none | 11 USDT into the pooled bucket |

So the pull route costs $1 plus the spread and takes about 6.6 minutes. Transfers that touch Hyperliquid time out after 30 minutes instead of 10.

### Browser check of the new layout, 2026-09-07

- Idle pay-down state with a 9.5 USDC borrow: pill, tiles, explanation, toggle, input prefilled, convert quote line, hold.
- Pull direction on this account: `free 0.00`, both route reasons, no hold.
- Typing 50 into the input showed `Capped at 9.96`.
- A real hold on the convert route: the bar showed `Convert 0s / ~2s`, the job finished in 0.25 s, and the idle state returned.
- A staged pull job halted at boot: three-segment bar with the pull segment full at 6m 27s, the Gate segment rose at `halted at 41s`, the sell segment empty at `~2s`; reason, funds location, Resume, Abandon.
- With the bucket's equity just above zero, the toggle defaulted to pull and explained that 0.3 USDC lands as 0 after the $1 fee.

A rough edge seen here, the section offering a few-cent pay-down when the bucket's equity sat at -0.055 USDC, is closed by the 1 USDC floor in the seventh commit.

### Pull by convert, live, 2026-09-07

After the user's own pay-down retest (15.32 USDT by convert, done in the UI), the bucket held 5.38 USDC of spare equity. `POST /api/rebalance` with `direction: pull, route: convert` ran through the real job runner.

| Field | Value |
|---|---|
| Amount | 4.29 USDC (the plan's cap; unrealised PnL had moved) |
| Quote | 2208141399825920, order 2208141404013824 |
| Received | 4.28 USDT into the pooled bucket |
| `balanceBefore` | 977.19, read from USDT/CROSSEX as the direction requires |
| Time | 228 ms, `fundsAt` CROSSEX, status done |

The same view showed the loop's reason as `Pull at least 111 USDC`: Gate's `min_trans_amount` is the string `"11"`. Fixed in the ninth commit.

### The vanishing section, reproduced, 2026-09-07

The user reported the section disappearing after a pay-down or a pull until a reload. A 6.83 USDT pay-down by convert was held in Chrome while a script sampled the section every second. The pill read `Borrow $6.88`, then was gone at 5 s, back at 13 s as `$0.06`, `$0.18` at 17 s, gone again at 25 s. Unrealised PnL was moving the borrow across zero every few polls; whenever the pullable amount floored to zero in the same poll, the old render rule hid the whole section. Fixed in the eleventh commit.

Test spec: `docs/test/2026-09-07-rebalance-borrow.md`, local only, excluded from git by repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkyjuJDutqYm5BdM9h9gEj
