### PR TITLE
Show the USDC borrow on every tab, and say its cost in words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ Pay back borrowed USDC from the Balances tab, or bring spare USDC home, with one
 
 - **A new Rebalance section on the Balances tab.** When a Hyperliquid leg loses money or pays
   funding, Gate lends the USDC and holds 20% of it as initial margin and 10% as maintenance
-  margin. Past 10,000 USDC short it also charges interest every hour. The section shows the
-  borrow with the margin it holds, the interest per day, and the interest paid in the last 30
-  days. An info mark next to the title explains all of it.
+  margin. Past 10,000 USDC short it also charges interest every hour. The section says in
+  words what Gate lent you, the margin it holds, and whether interest runs. The borrow also
+  shows as an amber pill in the header on every tab; click it to open the section. An info
+  mark next to the title explains all of it.
 - **One hold moves cash either way.** USDT to Hyperliquid USDC pays the borrow back and frees
   the margin. Hyperliquid USDC to USDT brings spare USDC home, capped so it never opens a
   borrow. The amount is prefilled with the most that can move, and you can type less.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -117,7 +117,7 @@ Opening a Hyperliquid leg does not borrow USDC. Its margin comes from your whole
 
 The borrow costs two things. Gate holds 20% of it as initial margin and 10% as maintenance margin. Once the bucket is more than 10,000 USDC short, Gate also charges interest every hour.
 
-The Balances tab shows a **Rebalance** section whenever Hyperliquid has a USDC borrow or spare USDC, or a job runs or is halted. The pill shows the borrow and the margin it holds. The two tiles show the interest per day and the interest paid in the last 30 days. The info mark next to the title opens a short card that says all this.
+The Balances tab shows a **Rebalance** section whenever Hyperliquid has a USDC borrow or spare USDC, or a job runs or is halted. An amber pill shows the borrow. The line under it says what Gate lent you, the margin it holds, and whether interest runs. Two tiles with the interest per day and the interest paid in the last 30 days appear once interest is charged. The info mark next to the title opens a short card that says all this. The same amber pill sits in the header on every tab. Click it to open this section.
 
 Pick a direction, keep the prefilled amount or type one, and hold the button:
 

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "version": "1.5.1",
   "highlights": [
-    "The Balances tab now shows when Hyperliquid has borrowed USDC, and what it costs you in held margin and interest",
+    "An amber pill in the header shows when Gate has lent you USDC for Hyperliquid. The Balances tab says what it costs you in held margin and interest",
     "One hold pays the borrow back by the cheapest route, or brings spare USDC home as USDT",
     "A progress bar shows each step and how long it should take. A refresh keeps a running move; a restart halts it safely with Resume and Abandon"
   ]

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
-import type { OpenOrder, PositionsResponse, TradesResponse, VenueFees } from './api/types';
+import type { OpenOrder, PositionsResponse, RebalanceBucket, TradesResponse, VenueFees } from './api/types';
 import { ACTIVE_TAB_KEY } from './components/TabBar';
 import { USER_GUIDE_RAW_URL } from './components/UserGuideModal';
 import {
@@ -16,7 +16,9 @@ import {
   makeOpportunityGroup,
   makeOpportunityLeg,
   makeOpportunityPair,
+  makeRebalanceView,
   opportunitiesHandler,
+  rebalanceHandler,
   versionHandler,
 } from './test/fixtures';
 import { env, server } from './test/server';
@@ -279,6 +281,54 @@ describe('App tab shell', () => {
     expect(document.querySelector('.flash-ring')).not.toBeNull();
     // And the execution wizard stays shut — it could not trade without keys.
     expect(screen.queryByRole('heading', { name: /Open this strategy/ })).not.toBeInTheDocument();
+  });
+});
+
+/** The Hyperliquid USDC bucket with `borrow` USDC lent by Gate. */
+function borrowed(borrow: number): RebalanceBucket {
+  return {
+    coin: 'USDC',
+    venue: 'HYPERLIQUID',
+    cash: -borrow,
+    upnl: 0,
+    equity: -borrow,
+    borrow,
+    imHeldUsd: borrow * 0.2,
+    mmHeldUsd: borrow * 0.1,
+    interestPaid30dUsd: 0,
+    interestPerDayUsd: 0,
+  };
+}
+
+describe('borrow pill', () => {
+  it('shows the USDC borrow in the header on every tab, and opens Balances on click', async () => {
+    mockApp();
+    server.use(rebalanceHandler(makeRebalanceView({ buckets: [borrowed(8.5)] })));
+    await renderApp();
+
+    const pill = await screen.findByRole('button', { name: 'Borrowing 8.50 USDC' });
+    expect(tab(/^Opportunities/)).toHaveAttribute('aria-selected', 'true');
+    expect(pill).toHaveAttribute(
+      'title',
+      'Gate lent you 8.50 USDC for the Hyperliquid legs. It holds $1.70 of initial margin against it. Open Balances to pay it back.',
+    );
+
+    await userEvent.click(pill);
+
+    expect(tab(/^Balances/)).toHaveAttribute('aria-selected', 'true');
+    expect(panel('balances')).toBeVisible();
+    expect(within(panel('balances')).getByRole('region', { name: 'Rebalance' })).toBeVisible();
+  });
+
+  it('shows no pill under 1 USDC of borrow', async () => {
+    mockApp();
+    server.use(rebalanceHandler(makeRebalanceView({ buckets: [borrowed(0.4)] })));
+    await renderApp();
+
+    // The hidden Balances panel renders its section from the same response,
+    // so once it exists the pill has had its answer.
+    await screen.findByRole('region', { name: 'Rebalance', hidden: true });
+    expect(screen.queryByRole('button', { name: /^Borrowing / })).toBeNull();
   });
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 import { useCredentials, useDisclaimer, useOpenOrders, usePositions } from './api/queries';
 import { AccountHealthStrip } from './components/AccountHealthStrip';
+import { BorrowChip } from './components/BorrowChip';
 import { BrandMark } from './components/BrandMark';
 import { Chip } from './components/Chip';
 import { DisclaimerGate } from './components/DisclaimerGate';
@@ -136,7 +137,14 @@ export default function App() {
               <BrandMark />
               {/* Unconfigured, /api/account 503s forever and the strip would
                   sit on its loading skeleton — hide it until keys exist. */}
-              {!setupNeeded && <AccountHealthStrip />}
+              {!setupNeeded && (
+                <AccountHealthStrip>
+                  {/* The USDC borrow, on every tab: the Rebalance section
+                      lives on Balances, and a trader on Positions would
+                      never learn about it otherwise. */}
+                  {configured && <BorrowChip onOpen={() => selectTab('balances')} />}
+                </AccountHealthStrip>
+              )}
               {!configured && <div className="ml-auto flex items-center gap-2">{headerControls}</div>}
             </div>
             {configured && (

--- a/web/src/components/AccountHealthStrip.tsx
+++ b/web/src/components/AccountHealthStrip.tsx
@@ -1,11 +1,13 @@
+import type { ReactNode } from 'react';
 import { useAccount } from '../api/queries';
 import { fmtUsd } from '../lib/fmt';
 import { MarginBreakdown } from './MarginDonut';
 import { SignedNumber } from './SignedNumber';
 import { Skeleton } from './Skeleton';
 
-/** Header strip: available/balance, signed uPnL (sum of asset uPnLs), margin pies. */
-export function AccountHealthStrip() {
+/** Header strip: available/balance, signed uPnL (sum of asset uPnLs), margin
+ * pies, then `children` (the borrow pill) once the account has loaded. */
+export function AccountHealthStrip({ children }: { children?: ReactNode }) {
   const { data: acc } = useAccount();
   if (!acc) {
     return (
@@ -30,6 +32,7 @@ export function AccountHealthStrip() {
         <SignedNumber value={upnl} format={(n) => fmtUsd(n)} className="font-medium" />
       </div>
       <MarginBreakdown acc={acc} variant="compact" />
+      {children}
       <span className="hidden text-[10px] uppercase tracking-wider text-ink-500 xl:inline">
         {acc.accountMode} · {acc.positionMode}
       </span>

--- a/web/src/components/BorrowChip.tsx
+++ b/web/src/components/BorrowChip.tsx
@@ -1,0 +1,27 @@
+import { useRebalance } from '../api/queries';
+import { fmtUsd, num } from '../lib/fmt';
+import { floorCents } from '../lib/ticks';
+
+/** Under this the borrow is noise: unrealised PnL flips it across zero by a
+ * few cents on every poll. Same floor as the Rebalance section's pill. */
+const MIN_BORROW = 1;
+
+/** Header pill: the USDC that Gate lent for the Hyperliquid legs, on every
+ * tab. A trader who never opens Balances still learns about the borrow.
+ * Click opens Balances, where the Rebalance section pays it back. */
+export function BorrowChip({ onOpen }: { onOpen: () => void }) {
+  const { data } = useRebalance({ direction: 'payDown', amount: null });
+  const usdc = data?.buckets.find((b) => b.coin === 'USDC' && b.venue === 'HYPERLIQUID');
+  const borrow = floorCents(usdc?.borrow ?? 0);
+  if (!usdc || borrow < MIN_BORROW) return null;
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      title={`Gate lent you ${num(borrow, 2)} USDC for the Hyperliquid legs. It holds ${fmtUsd(usdc.imHeldUsd)} of initial margin against it. Open Balances to pay it back.`}
+      className="num rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-200 transition-colors hover:border-amber-400/60 hover:bg-amber-500/20"
+    >
+      {`Borrowing ${num(borrow, 2)} USDC`}
+    </button>
+  );
+}

--- a/web/src/lib/ticks.ts
+++ b/web/src/lib/ticks.ts
@@ -103,3 +103,9 @@ export function formatRestPrice(price: number, side: 'BUY' | 'SELL', symbol: str
   }
   return stripZeros(snapped);
 }
+
+/** Floor to cents, never negative. A figure a button acts on must not show
+ * more than the button can move. */
+export function floorCents(value: number): number {
+  return Number(roundToStep(Math.max(0, value), '0.01', 'down'));
+}

--- a/web/src/panels/RebalanceSection.test.tsx
+++ b/web/src/panels/RebalanceSection.test.tsx
@@ -215,14 +215,19 @@ const amountInput = (label: string) => screen.getByRole('textbox', { name: label
 const toPull = () => userEvent.click(screen.getByRole('radio', { name: 'Hyperliquid USDC → USDT' }));
 
 describe('RebalanceSection', () => {
-  it('shows the Rebalance header, the borrow pill, and the two tiles', async () => {
+  it('shows the Rebalance header, the borrow pill, the cost line, and the two tiles', async () => {
     serve(view());
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
     expect(screen.getByRole('heading', { name: 'Rebalance' })).toBeInTheDocument();
     expect(screen.getByText('move cash between USDT and Hyperliquid USDC')).toBeInTheDocument();
-    expect(screen.getByText('Borrow $1,200.00 · +$240.00 IM · +$120.00 MM')).toHaveClass('border-amber-500/30');
+    expect(screen.getByText('Borrowing 1,200.00 USDC')).toHaveClass('border-amber-500/30');
+    expect(
+      screen.getByText(
+        'Gate lent you 1,200.00 USDC. It holds $240.00 of initial margin and $120.00 of maintenance margin against it. It charges $0.31 a day in interest.',
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText('Interest / day')).toBeInTheDocument();
     expect(screen.getByText('$0.31')).toBeInTheDocument();
     expect(screen.getByText('Interest paid · 30 d')).toBeInTheDocument();
@@ -235,7 +240,38 @@ describe('RebalanceSection', () => {
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    expect(screen.getByText('Borrow $1,200.99 · +$240.00 IM · +$120.00 MM')).toBeInTheDocument();
+    expect(screen.getByText('Borrowing 1,200.99 USDC')).toBeInTheDocument();
+  });
+
+  it('says in words that margin is held and no interest runs yet, and drops the $0.00 tiles', async () => {
+    serve(view({ buckets: [usdc({ borrow: 8.5, imHeldUsd: 1.7, mmHeldUsd: 0.85, interestPaid30dUsd: 0, interestPerDayUsd: 0 }), usdt] }));
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.getByText('Borrowing 8.50 USDC')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Gate lent you 8.50 USDC. It holds $1.70 of initial margin and $0.85 of maintenance margin against it. No interest until the borrow passes 10,000 USDC.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Interest / day')).toBeNull();
+    expect(screen.queryByText('Interest paid · 30 d')).toBeNull();
+  });
+
+  it('keeps the interest tiles for interest already paid once the borrow is gone', async () => {
+    serve(
+      view({
+        buckets: [usdc({ cash: 5, upnl: 0, equity: 5, borrow: 0, imHeldUsd: 0, mmHeldUsd: 0, interestPaid30dUsd: 2.5, interestPerDayUsd: 0 }), usdt],
+        plan: noRoutePlan(),
+      }),
+    );
+    renderWithClient(<RebalanceSection holdMs={50} />);
+
+    await section();
+    expect(screen.queryByText(/^Borrowing /)).toBeNull();
+    expect(screen.queryByText(/^Gate lent you/)).toBeNull();
+    expect(screen.getByText('Interest paid · 30 d')).toBeInTheDocument();
+    expect(screen.getByText('$2.50')).toBeInTheDocument();
   });
 
   it('shows the explanation line for each direction', async () => {
@@ -443,7 +479,7 @@ describe('RebalanceSection', () => {
     const { unmount } = renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    expect(screen.queryByText(/^Borrow \$/)).toBeNull();
+    expect(screen.queryByText(/^Borrowing /)).toBeNull();
     expect(screen.getByText('Nothing to pay back. The borrow is under 1 USDC.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
     expect(screen.queryByText(/^via /)).toBeNull();
@@ -600,7 +636,7 @@ describe('RebalanceSection', () => {
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    expect(screen.queryByText(/^Borrow \$/)).toBeNull();
+    expect(screen.queryByText(/^Borrowing /)).toBeNull();
     expect(screen.getByRole('radiogroup', { name: 'Direction' })).toBeInTheDocument();
     expect(screen.getByText('Nothing to pay back. There is no USDC borrow on Hyperliquid.')).toBeInTheDocument();
   });
@@ -610,9 +646,10 @@ describe('RebalanceSection', () => {
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    expect(screen.queryByText(/^Borrow \$/)).toBeNull();
+    expect(screen.queryByText(/^Borrowing /)).toBeNull();
     expect(screen.getByRole('radiogroup', { name: 'Direction' })).toBeInTheDocument();
-    expect(screen.getByText('Interest / day')).toBeInTheDocument();
+    expect(screen.queryByText(/^Gate lent you/)).toBeNull();
+    expect(screen.queryByText('Interest / day')).toBeNull();
   });
 
   it('renders with borrow 0 and nothing to pull while a job runs', async () => {
@@ -742,7 +779,7 @@ describe('RebalanceSection', () => {
 
     expect(await screen.findByRole('button', { name: HOLD }, { timeout: 5_000 })).toBeEnabled();
     expect(screen.queryByRole('progressbar')).toBeNull();
-    expect(screen.getByText('Borrow $300.00 · +$240.00 IM · +$120.00 MM')).toBeInTheDocument();
+    expect(screen.getByText('Borrowing 300.00 USDC')).toBeInTheDocument();
     expect(screen.getByText('$0.08')).toBeInTheDocument();
   }, 10_000);
 
@@ -766,6 +803,6 @@ describe('RebalanceSection', () => {
     ).toBeInTheDocument();
     expect(await screen.findByRole('button', { name: PULL_HOLD })).toBeEnabled();
     expect(amountInput('Amount (USDC) · free 400.00')).toHaveValue('400.00');
-    expect(screen.queryByText(/^Borrow \$/)).toBeNull();
+    expect(screen.queryByText(/^Borrowing /)).toBeNull();
   }, 10_000);
 });

--- a/web/src/panels/RebalanceSection.tsx
+++ b/web/src/panels/RebalanceSection.tsx
@@ -1,18 +1,20 @@
 import { useEffect, useRef, useState } from 'react';
 import { ApiError } from '../api/client';
 import { useRebalance, useRebalanceCommand, useStartRebalance } from '../api/queries';
-import type { RebalanceDirection, RebalanceJob, RebalancePlan, RebalanceStep } from '../api/types';
+import type { RebalanceBucket, RebalanceDirection, RebalanceJob, RebalancePlan, RebalanceStep } from '../api/types';
 import { HoldToConfirmButton } from '../components/HoldToConfirmButton';
 import { HoverCard } from '../components/HoverCard';
 import { SegmentedToggle } from '../components/SegmentedToggle';
 import { Stat } from '../components/Stat';
 import { fmtAge, fmtUsd, num } from '../lib/fmt';
-import { roundToStep } from '../lib/ticks';
+import { floorCents, roundToStep } from '../lib/ticks';
 import { useNow } from '../lib/useNow';
 
 const PULL_STEP_SECONDS = 390;
 /** Under this the hold is hidden: a few-cent convert or a pull that the $1 fee eats is never worth a hold. */
 const MIN_AMOUNT = 1;
+/** Gate charges interest on the borrow only past this. Server: INTEREST_THRESHOLD in core/rebalance/plan.ts. */
+const INTEREST_FREE_UNTIL = 10_000;
 
 const EXPECTED_SECONDS: Record<string, number> = {
   'Buy USDC': 2,
@@ -40,7 +42,7 @@ const ABOUT = (
     <p>
       <span className="font-semibold text-ink-100">Why it matters. </span>
       Gate holds extra margin against the borrow: 20% as initial margin and 10% as maintenance margin. Once you are
-      more than 10,000 USDC short, Gate also charges interest every hour.
+      more than {num(INTEREST_FREE_UNTIL, 0)} USDC short, Gate also charges interest every hour.
     </p>
     <p>
       <span className="font-semibold text-ink-100">The two moves. </span>
@@ -76,10 +78,6 @@ const SEGMENT_TEXT: Record<SegmentKind, string> = {
   halted: 'text-rose-300',
 };
 
-function floorCents(value: number): number {
-  return Number(roundToStep(Math.max(0, value), '0.01', 'down'));
-}
-
 function parseAmount(text: string): number | null {
   const n = Number(text);
   return text.trim() !== '' && Number.isFinite(n) && n > 0 ? n : null;
@@ -113,6 +111,16 @@ function noRouteLine(plan: RebalancePlan, pull: boolean, borrow: number, free: n
   if (borrow === 0) return { text: 'Nothing to pay back. There is no USDC borrow on Hyperliquid.', warn: false };
   if (free === 0) return { text: 'Nothing to move. There is no free USDT.', warn: false };
   return { text: 'Nothing to move.', warn: false };
+}
+
+/** The situation in words, so a skimmer does not have to decode IM, MM, or a $0.00 tile. */
+function costLine(usdc: RebalanceBucket, borrow: number): string {
+  const held = `It holds ${fmtUsd(usdc.imHeldUsd)} of initial margin and ${fmtUsd(usdc.mmHeldUsd)} of maintenance margin against it.`;
+  const interest =
+    usdc.interestPerDayUsd > 0
+      ? `It charges ${fmtUsd(usdc.interestPerDayUsd)} a day in interest.`
+      : `No interest until the borrow passes ${num(INTEREST_FREE_UNTIL, 0)} USDC.`;
+  return `Gate lent you ${num(borrow, 2)} USDC. ${held} ${interest}`;
 }
 
 function tooSmallLine(pull: boolean, borrow: number): string {
@@ -233,6 +241,10 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
 
   const plan = data.plan;
   const pull = direction === 'pull';
+  /* The tiles earn their place only once interest is real. Under the
+     threshold they read $0.00, which says "no cost" to a skimmer; the cost
+     line above them says what the borrow holds instead. */
+  const charged = (usdc?.interestPerDayUsd ?? 0) > 0 || (usdc?.interestPaid30dUsd ?? 0) > 0;
 
   const pickDirection = (next: RebalanceDirection) => {
     setChosen(next);
@@ -361,18 +373,21 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
         </div>
         {borrow >= MIN_AMOUNT && (
           <span className="num rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-200">
-            {`Borrow ${fmtUsd(borrow)} · +${fmtUsd(usdc?.imHeldUsd ?? 0)} IM · +${fmtUsd(usdc?.mmHeldUsd ?? 0)} MM`}
+            {`Borrowing ${num(borrow, 2)} USDC`}
           </span>
         )}
       </div>
-      <div className="flex flex-wrap gap-8">
-        <Stat label="Interest / day">
-          <span className="num">{fmtUsd(usdc?.interestPerDayUsd ?? 0)}</span>
-        </Stat>
-        <Stat label="Interest paid · 30 d">
-          <span className="num">{fmtUsd(usdc?.interestPaid30dUsd ?? 0)}</span>
-        </Stat>
-      </div>
+      {usdc && borrow >= MIN_AMOUNT && <p className="text-[12px] text-ink-200">{costLine(usdc, borrow)}</p>}
+      {charged && (
+        <div className="flex flex-wrap gap-8">
+          <Stat label="Interest / day">
+            <span className="num">{fmtUsd(usdc?.interestPerDayUsd ?? 0)}</span>
+          </Stat>
+          <Stat label="Interest paid · 30 d">
+            <span className="num">{fmtUsd(usdc?.interestPaid30dUsd ?? 0)}</span>
+          </Stat>
+        </div>
+      )}
       <p className="text-[12px] text-ink-400">{EXPLANATION[job ? job.direction : direction]}</p>
       {body}
     </section>

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -233,29 +233,7 @@ export function baseHandlers() {
       HttpResponse.json(env(makeDealView({ pair: { id: String(params.id) } }))),
     ),
     http.get('/api/deals', () => HttpResponse.json(env([]))),
-    http.get('/api/rebalance', () =>
-      HttpResponse.json(
-        env<RebalanceView>({
-          buckets: [],
-          plan: {
-            direction: 'payDown',
-            amount: 0,
-            receives: 0,
-            price: null,
-            borrowAfterUsd: 0,
-            shortfall: null,
-            routes: {
-              loop: { costUsd: 0.05, waitSeconds: 150, available: false, reason: 'nothing to move' },
-              convert: { costUsd: 0, waitSeconds: 0, available: false, reason: 'nothing to move' },
-            },
-            route: null,
-            savesPerDayUsd: 0,
-            marginFreedUsd: 0,
-          },
-          job: null,
-        }),
-      ),
-    ),
+    rebalanceHandler(),
     http.get('/api/alerts', () => HttpResponse.json(env([]))),
     // Default: disclaimer already accepted, so the gate stays out of the way.
     // Tests that exercise the gate override this with accepted:false.
@@ -734,4 +712,32 @@ export function opportunitiesHandler(
         )
       : HttpResponse.json(env(data));
   });
+}
+
+/** GET /api/rebalance with nothing to move; pass `buckets` for a borrow. */
+export function makeRebalanceView(over: Partial<RebalanceView> = {}): RebalanceView {
+  return {
+    buckets: [],
+    plan: {
+      direction: 'payDown',
+      amount: 0,
+      receives: 0,
+      price: null,
+      borrowAfterUsd: 0,
+      shortfall: null,
+      routes: {
+        loop: { costUsd: 0.05, waitSeconds: 150, available: false, reason: 'nothing to move' },
+        convert: { costUsd: 0, waitSeconds: 0, available: false, reason: 'nothing to move' },
+      },
+      route: null,
+      savesPerDayUsd: 0,
+      marginFreedUsd: 0,
+    },
+    job: null,
+    ...over,
+  };
+}
+
+export function rebalanceHandler(view: RebalanceView = makeRebalanceView()) {
+  return http.get('/api/rebalance', () => HttpResponse.json(env<RebalanceView>(view)));
 }


### PR DESCRIPTION
## TLDR

The borrow was visible only on the Balances tab, as `Borrow $5.51 · +$1.10 IM · +$0.55 MM` over two tiles that read `$0.00` for every account under 10,000 USDC short. A trader on Positions never saw it. A trader who did read "no cost".

Now an amber `Borrowing 5.51 USDC` pill sits in the header on every tab and opens Balances on click. The section's pill is the same one number, and a line under it says what Gate lent, the margin it holds, and whether interest runs. The interest tiles show only once interest is charged. Follow-up to #37, ticket ED-6434.

## What changed

- `web/src/components/BorrowChip.tsx` (new): reads the same `GET /api/rebalance` view the section uses, so the query is shared. Hidden under 1 USDC, floored to cents, hover title in one sentence.
- `web/src/components/AccountHealthStrip.tsx`: takes `children`, rendered after the margin gauges once the account has loaded.
- `web/src/App.tsx`: mounts the chip when configured; click calls the existing `selectTab('balances')`.
- `web/src/panels/RebalanceSection.tsx`: pill text, the cost line (`costLine`), tiles behind `charged`. `floorCents` moved to `web/src/lib/ticks.ts`.
- `web/src/test/fixtures.ts`: `makeRebalanceView` and `rebalanceHandler` exported for the App tests.
- User guide, CHANGELOG 1.5.1 entry, and the first `version.json` highlight updated. No version bump: 1.5.1 is still unreleased on dev.

No server change.

## MUST DO BEFORE DEPLOY

Nothing.

## Review focus

- `web/src/components/BorrowChip.tsx:14` — the 1 USDC floor. Same reason as the section: near zero, unrealised PnL flips the borrow by cents on every poll.
- `web/src/panels/RebalanceSection.tsx` `costLine` — the wording. Initial and maintenance margin are named apart, not summed; they are not additive in the account.
- `web/src/App.tsx` — the chip is inside `AccountHealthStrip`, so it never renders on the first-run view where `/api/rebalance` would fail.

## Test evidence

```
yarn verify
```

| Step | Result |
|---|---|
| `tsc --noEmit` | pass |
| `yarn test` (unit + server) | 61 files, 1018 tests passed |
| `yarn --cwd web typecheck` | pass |
| `yarn --cwd web test` | 49 files, 726 tests passed |

New tests: the header pill on every tab with its click into Balances, no pill under 1 USDC, the cost line with and without interest, tiles hidden at $0.00, tiles kept for interest already paid once the borrow is gone. Existing pill assertions updated.

### Browser check, 2026-09-07

The branch ran on the spare port against the real account with a 5.5 USDC borrow. Screenshots, one per change, are in the test brief: https://claude.ai/code/artifact/ec98b40a-9f6e-4778-a943-e2981621d996#screens

- Opportunities tab: `Borrowing 5.51 USDC` in the header next to the IM and MM gauges.
- Click on the pill: the Balances tab opened with the section under the margin card.
- The section: pill `Borrowing 5.52 USDC`, the cost line `Gate lent you 5.52 USDC. It holds $1.11 of initial margin and $0.55 of maintenance margin against it. No interest until the borrow passes 10,000 USDC.`, no tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkyjuJDutqYm5BdM9h9gEj
