### PR TITLE
Refuse a deal start or resume while a rebalance runs, and a rebalance resume while a deal works

### DIFF
--- a/src/server/routes/deals.ts
+++ b/src/server/routes/deals.ts
@@ -5,7 +5,7 @@
  * the reconcile loop picks up on its next tick; commands are one-row intent
  * edits (levels, not events).
  */
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyReply } from 'fastify';
 import { CoreError } from '../../core/errors';
 import { formatRestPrice } from '../../core/numbers';
 import { setLeverage } from '../../core/orders';
@@ -27,6 +27,23 @@ function dealView(deps: AppDeps, pair: PairRow) {
 
 export function dealsRoutes(deps: AppDeps) {
   return async function routes(app: FastifyInstance): Promise<void> {
+    /* A rebalance moves cash out of CrossEx for minutes, and its amount was
+       sized on the margin that was free when it started. A deal that opens
+       meanwhile takes that margin. The rebalance start refuses while a deal
+       works; this is the same rule the other way. Only a running job blocks:
+       a halted one moves nothing until it is resumed, and resume has the
+       same check. */
+    const rebalanceRunning = (): boolean => deps.rebalance?.jobs.read()?.status === 'running';
+    const refuseForRebalance = (reply: FastifyReply, what: string): FastifyReply =>
+      reply.code(409).send({
+        ok: false,
+        error: {
+          category: 'validation',
+          message: `a rebalance is still running — wait for it to finish before ${what}`,
+          retryable: true,
+        },
+      });
+
     app.post('/deals', async (req, reply) => {
       // First-run gate: no real order until the disclaimer is accepted. Tied to
       // the config-backed credentials service (always present in a real install;
@@ -51,6 +68,7 @@ export function dealsRoutes(deps: AppDeps) {
       if (deps.engine!.store.getPair(body.id)) {
         return reply.code(202).ok({ id: body.id, duplicate: true });
       }
+      if (rebalanceRunning()) return refuseForRebalance(reply, 'starting a deal');
       const clients = deps.getClients();
       const getAccount = async () =>
         (await deps.cache.get('account', TTL.live, async () => (await clients.crossEx.getCrossexAccount()).body)).value;
@@ -205,6 +223,7 @@ export function dealsRoutes(deps: AppDeps) {
     app.post('/deals/:id/resume', async (req, reply) => {
       const pair = requireDeal((req.params as { id: string }).id);
       if (pair.mode !== 'HALTED') throw new CoreError(`deal ${pair.id} is not halted (mode: ${pair.mode})`);
+      if (rebalanceRunning()) return refuseForRebalance(reply, 'resuming a deal');
       commands.resumeAfterHalt(deps.engine!.store, pair.id);
       deps.engine!.wake?.();
       return reply.ok({ id: pair.id, mode: 'STOPPING' });

--- a/src/server/routes/rebalance.ts
+++ b/src/server/routes/rebalance.ts
@@ -187,6 +187,10 @@ export function rebalanceRoutes(deps: AppDeps) {
       const store = requireJobs();
       const job = haltedOr409(store, (req.params as { id: string }).id, reply);
       if (!job) return reply;
+      // The same rule as the start: the remaining steps move cash a working
+      // deal may be counting on.
+      const working = workingDeal();
+      if (working) return conflict(reply, `deal ${working} is still working`);
       // The steps hold venue ids and amounts of the account they ran on. On
       // another account they would poll ids it does not know, or send from it.
       if (job.userId !== null && (await currentUserId()) !== job.userId) {

--- a/tests/server/deals.test.ts
+++ b/tests/server/deals.test.ts
@@ -5,11 +5,15 @@
  * MANUALLY (tickPair) against the same FakeVenue the unit sim uses, proving the
  * route → store → loop wiring end to end without timers.
  */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import type { FastifyInstance } from 'fastify';
 import nock from 'nock';
 import { afterEach, describe, expect, it } from 'vitest';
 import { tickPair, type LoopDeps } from '../../src/engine/loop';
 import { Store } from '../../src/engine/db';
+import { JobFile, newJob } from '../../src/server/rebalanceJob';
 import { A_CONTRACT, B_CONTRACT, FakeVenue, VirtualClock } from '../unit/engine-sim';
 import { gate, HOST, makeTestApp, mockGateGet } from './helpers/gate-nock';
 
@@ -85,6 +89,62 @@ describe('POST /api/deals', () => {
     expect(view.pair.mode).toBe('DONE');
     expect(view.projection.aFilled).toBe('0.152');
     expect(view.projection.bFilled).toBe('0.152');
+  });
+
+  it('refuses to start or resume a deal while a rebalance is running, and not while one is halted', async () => {
+    const jobs = new JobFile(mkdtempSync(path.join(tmpdir(), 'rebalance-')));
+    const store = new Store(':memory:');
+    app = makeTestApp({ engine: { store, venue: new FakeVenue(), clock: new VirtualClock() }, rebalance: { jobs } });
+    // The rebalance plugin halts a running job at boot, so boot first.
+    await app.ready();
+    const running = newJob('payDown', 'loop', 300, Date.now());
+    jobs.write(running);
+
+    let res = await app.inject({ method: 'POST', url: '/api/deals', headers: HOST, payload: makerPayload() });
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toEqual({
+      ok: false,
+      error: {
+        category: 'validation',
+        message: 'a rebalance is still running — wait for it to finish before starting a deal',
+        retryable: true,
+      },
+    });
+    expect(store.getPair('deal-000001')).toBeNull();
+
+    store.createPair({
+      id: 'deal-halted',
+      mode: 'HALTED',
+      a: { contract: A_CONTRACT, side: 'BUY', lot: '0.001', minSize: '0', minNotional: '0', tick: '0.01' },
+      b: null,
+      targetQty: '0.05',
+      limitPrice: '2500',
+      pricePolicy: 'fixed',
+      deadlineAt: null,
+      makerNotBefore: 0,
+      hedgeNotBefore: 0,
+      pocRejects: 0,
+      hedgeRejectStreak: 0,
+      maxClip: null,
+      clipBandBp: null,
+      haltReason: 'test',
+      reportJson: null,
+      createdAt: Date.now(),
+    });
+    res = await app.inject({ method: 'POST', url: '/api/deals/deal-halted/resume', headers: HOST });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toBe('a rebalance is still running — wait for it to finish before resuming a deal');
+    expect(store.getPair('deal-halted')!.mode).toBe('HALTED');
+
+    running.status = 'halted';
+    jobs.write(running);
+    res = await app.inject({ method: 'POST', url: '/api/deals/deal-halted/resume', headers: HOST });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().data).toEqual({ id: 'deal-halted', mode: 'STOPPING' });
+    // The create guard is past too: the empty body fails on validation, not on the rebalance.
+    res = await app.inject({ method: 'POST', url: '/api/deals', headers: HOST, payload: {} });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error.message).toBe('deal id is required');
   });
 
   it('is idempotent on the deal id (duplicate → 202, nothing new created)', async () => {

--- a/tests/server/rebalance-job.test.ts
+++ b/tests/server/rebalance-job.test.ts
@@ -792,6 +792,18 @@ describe('POST /api/rebalance/:id/resume and /abandon', () => {
     expect(res.json().error.message).toBe(`rebalance ${halted.id} is abandoned`);
   });
 
+  it('resume refuses while a deal is working', async () => {
+    mockView();
+    const job = haltedLoopJob(1, { venueId: 'x1' });
+    const h = boot({ job, store: busyDeal() });
+
+    const res = await h.post(`/api/rebalance/${job.id}/resume`);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error.message).toBe('deal deal-409 is still working');
+    expect(h.file().status).toBe('halted');
+  });
+
   it('resume refuses a job started on another Gate account and runs one started on this account', async () => {
     mockView();
     const foreign = haltedLoopJob(1, { venueId: 'x1' });


### PR DESCRIPTION
## TLDR

The last open finding from the pre-release review of 1.5.1. The rebalance start refused while a deal worked, but nothing refused the other way: a deal could start or resume while a rebalance was moving cash out of CrossEx, and a halted rebalance could resume while a deal worked. The user chose to block both ways. This PR adds the three refusals, each a 409 with a plain message.

## What changed

- `POST /deals` returns 409 `a rebalance is still running — wait for it to finish before starting a deal` while the job file says running. The check sits after the idempotency check, so a lost-response retry of a deal that was created still gets its 202.
- `POST /deals/:id/resume` returns 409 with the same message, ending in `resuming a deal`, under the same condition.
- `POST /rebalance/:id/resume` returns 409 `deal <id> is still working` while a deal is active, the same message the start uses.

Only a running rebalance blocks. A halted one moves nothing until it is resumed, and resume has its own check. Engine-driven maker hedges are not blocked; a route check cannot reach them.

## MUST DO BEFORE DEPLOY

Nothing.

## Review focus

- `src/server/routes/deals.ts:36` — the two helpers and the comment that states the rule.
- `src/server/routes/deals.ts:71` — the create guard, after the duplicate check and before the first Gate read.
- `src/server/routes/rebalance.ts:192` — the resume guard, before the account-id check.

## Test evidence

```
yarn verify
```

| Step | Result |
|---|---|
| `yarn typecheck` | pass |
| `yarn test` (unit + server) | 61 files, 1028 tests passed, exit 0 |
| `yarn --cwd web typecheck` | pass |
| `yarn --cwd web test` | 50 files, 741 tests passed, exit 0 |

New tests: a running job refuses a deal create with nothing created and refuses a deal resume with the pair still halted; a halted job refuses neither; a working deal refuses a rebalance resume with the job still halted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkyjuJDutqYm5BdM9h9gEj
