### PR TITLE
Open the update dialog by itself on every app open while an update waits

### DIFF
--- a/web/src/components/UpdateIndicator.test.tsx
+++ b/web/src/components/UpdateIndicator.test.tsx
@@ -81,6 +81,22 @@ describe('UpdateIndicator', () => {
     expect(screen.queryByRole('button', { name: /Update v/ })).toBeNull();
   });
 
+  it('opens the dialog by itself when an update is waiting; close puts it away for this page load', async () => {
+    server.use(versionHandler({ latest: '1.2.0', updateAvailable: true, highlights: ['A brand new thing'] }));
+    renderWithClient(<UpdateIndicator />);
+
+    // No click: the dialog is up as soon as the version answer lands.
+    expect(await screen.findByText('Update available — v1.2.0')).toBeInTheDocument();
+    expect(screen.getByText('A brand new thing')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'close' }));
+    expect(screen.queryByText('Update available — v1.2.0')).toBeNull();
+    // The button stays, and the dialog does not come back on its own.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(screen.queryByText('Update available — v1.2.0')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Update v1.2.0' })).toBeInTheDocument();
+  });
+
   it('shows the pill for a newer version; the modal carries highlights and ONE button', async () => {
     await openModal({ current: '1.0.0', highlights: ['A brand new thing', 'Another improvement'] });
 

--- a/web/src/components/UpdateIndicator.tsx
+++ b/web/src/components/UpdateIndicator.tsx
@@ -169,6 +169,22 @@ export function UpdateIndicator() {
   const log = useUpdateLog(running);
 
   /**
+   * OPEN BY ITSELF, once per page load, while an update waits.
+   *
+   * The amber button alone was missed: a trader who never reads the header
+   * runs an old version for weeks. So the dialog opens on every open of the
+   * app until the update is installed. Close puts it away for this page load,
+   * and the button stays for when they are ready.
+   */
+  const [offered, setOffered] = useState(false);
+  const waiting = Boolean(data?.updateAvailable && data.latest);
+  useEffect(() => {
+    if (offered || running || !waiting) return;
+    setOffered(true);
+    setOpen(true);
+  }, [offered, running, waiting]);
+
+  /**
    * RELOAD ONTO THE NEW BUNDLE, once the swap has actually happened.
    *
    * After a successful update this page reconnects to the new server still


### PR DESCRIPTION
## TLDR

A tester said people will miss updates: the only sign of one is an amber `Update v1.5.1` button in the header, and the dialog opens on a click. The dialog now opens by itself on every open of the app while an update waits. Close puts it away for that page load. The button stays.

This ships in the next release and works from the one after it, because the copy that opens the dialog is the copy being replaced.

## What changed

- `UpdateIndicator` opens its dialog once per page load when the version answer says an update is available. It does not open while an update is already installing.
- Nothing else moves: the dialog, the two routes, the progress panel, and the reload on the new commit are as before.

## MUST DO BEFORE DEPLOY

Nothing.

## Review focus

- `web/src/components/UpdateIndicator.tsx:171` — the one effect, and the comment that says why once per page load and not once per version.

## Test evidence

```
yarn verify
```

| Step | Result |
|---|---|
| `yarn typecheck` | pass |
| `yarn test` (unit + server) | 61 files, 1028 tests passed, exit 0 |
| `yarn --cwd web typecheck` | pass |
| `yarn --cwd web test` | 50 files, 742 tests passed, exit 0 |

New test: the dialog is up with no click as soon as the version answer lands; close puts it away and the header button stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkyjuJDutqYm5BdM9h9gEj
