### PR TITLE
Name the two rebalance directions for where the cash lands, and say move, not pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Pay back what Gate lent you, USDC or USDT, from the Balances tab with one hold.
   or brings spare USDC home when there is none, capped so it never opens a borrow. The amount is
   prefilled with the borrow, and you can type another.
 - **The cheaper route is picked for you and shown.** An instant convert at 20 bps, or a spot
-  loop through Gate that costs $0.05 for a pay-down and a flat $1 for a pull. The quote is a
+  loop through Gate that costs $0.05 toward USDC and a flat $1 toward USDT. The quote is a
   row of facts: the route, the price, what lands, the cost, and the borrow after the move. Under
   1 USDC there is nothing to hold.
 - **You can watch it run.** A progress bar shows each step with its seconds. A job survives a

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -124,9 +124,9 @@ The Balances tab shows a **Rebalance** section whenever either wallet has a borr
 The section opens on the direction that repays the borrow. Keep the prefilled amount or type one, and hold the button:
 
 - **USDT → Hyperliquid USDC** pays a USDC borrow back. The amount is capped at the borrow, at your free USDT, and at your available margin. When less than the borrow can move, an amber line says how much stays borrowed and why.
-- **Hyperliquid USDC → USDT** pays a USDT borrow back, or brings spare USDC home when there is none. The amount is capped at the USDC you own there after open losses, so a pull never starts a new borrow. With a USDT borrow the prefilled amount is the borrow, and you can type more, up to the spare.
+- **Hyperliquid USDC → USDT** pays a USDT borrow back, or brings spare USDC home when there is none. The amount is capped at the USDC you own there after open losses, so this move never starts a new borrow. With a USDT borrow the prefilled amount is the borrow, and you can type more, up to the spare.
 
-Two routes exist and the terminal takes the cheaper one: a direct convert on Hyperliquid (instant, about 20 bps), or a spot loop through Gate (a spot trade plus two transfers; about 2.5 minutes for a pay-down, about 6.5 minutes plus a flat $1 fee for a pull). Under 1 USDC the hold is hidden.
+Two routes exist and the terminal takes the cheaper one: a direct convert on Hyperliquid (instant, about 20 bps), or a spot loop through Gate (a spot trade plus two transfers; about 2.5 minutes toward USDC, about 6.5 minutes plus a flat $1 fee toward USDT). Under 1 USDC the hold is hidden.
 
 A running job shows a progress bar, one segment per step with its seconds. A halted job shows the reason, the line `Funds are in <place>`, and a **Resume** and an **Abandon** button. After **Abandon**, move any USDC left in the Gate spot wallet by hand in Gate.
 

--- a/src/core/rebalance/plan.ts
+++ b/src/core/rebalance/plan.ts
@@ -11,16 +11,16 @@ export const SPOT_SYMBOL = 'GATE_SPOT_USDC_USDT';
 /** Gate charges interest on a borrow only once the wallet's equity is below
  * this. Checked live for USDC on Hyperliquid; assumed the same for USDT. */
 const INTEREST_THRESHOLD = -10000;
-export const LOOP_WAIT_SECONDS = 150;
-export const PULL_WAIT_SECONDS = 400;
+export const TO_USDC_WAIT_SECONDS = 150;
+export const TO_USDT_WAIT_SECONDS = 400;
 const CONVERT_RATE = 0.002;
 const DEPOSIT_FEE_USD = 0.05;
-export const PULL_FEE_USD = 1;
+export const HYPERLIQUID_WITHDRAW_FEE_USD = 1;
 
-export type Direction = 'payDown' | 'pull';
+export type Direction = 'toUsdc' | 'toUsdt';
 
 /** Where the cash lands. A move repays that wallet's borrow first. */
-export const TARGET: Record<Direction, Wallet> = { payDown: USDC_WALLET, pull: USDT_WALLET };
+export const TARGET: Record<Direction, Wallet> = { toUsdc: USDC_WALLET, toUsdt: USDT_WALLET };
 
 /** `USDC/HYPERLIQUID`: the key the interest ledger and the buckets share. */
 export const walletKey = (coin: string, venue: string): string => `${coin}/${venue}`;
@@ -212,14 +212,14 @@ export function planFor(
   buckets: Bucket[],
   account: AccountLike,
   inputs: PlanInputs,
-  { direction = 'payDown', requested = Infinity }: PlanRequest = {},
+  { direction = 'toUsdc', requested = Infinity }: PlanRequest = {},
 ): Plan {
   const usdcBucket = buckets.find(isWallet(USDC_WALLET));
   const usdtBucket = buckets.find(isWallet(USDT_WALLET));
 
-  if (direction === 'pull') {
+  if (direction === 'toUsdt') {
     // USDC → USDT. The USDC that can leave is what the wallet owns after open
-    // losses, so a pull never opens a USDC borrow. With a USDT borrow the
+    // losses, so the move never opens a USDC borrow. With a USDT borrow the
     // prefilled amount repays it and no more; a typed amount may bring any
     // of the spare home, borrow or not.
     const usdcAsset = (account.assets ?? []).find(isWallet(USDC_WALLET));
@@ -234,17 +234,17 @@ export function planFor(
         ? null
         : { reason: available < equity ? 'cash' : 'spare', remaining: floorCents(deficit - amount) };
     const bid = positive(inputs.bid);
-    const lands = Math.max(0, floorCents(amount - PULL_FEE_USD));
+    const lands = Math.max(0, floorCents(amount - HYPERLIQUID_WITHDRAW_FEE_USD));
     const loop = loopQuote(
       amount,
       inputs,
       bid,
       bid === null ? 0 : Math.max(1 - bid, 0),
-      PULL_FEE_USD,
-      PULL_WAIT_SECONDS,
+      HYPERLIQUID_WITHDRAW_FEE_USD,
+      TO_USDT_WAIT_SECONDS,
       (min) =>
         lands < min
-          ? `Too small to pull. Gate takes a flat $${PULL_FEE_USD} fee on the way out and needs at least ${min} USDC to arrive. Pull at least ${min + PULL_FEE_USD} USDC.`
+          ? `Too small to move. Gate takes a flat $${HYPERLIQUID_WITHDRAW_FEE_USD} fee on the way out and needs at least ${min} USDC to arrive. Move at least ${min + HYPERLIQUID_WITHDRAW_FEE_USD} USDC.`
           : null,
     );
     const convert = convertQuote(amount);
@@ -289,7 +289,7 @@ export function planFor(
     ask,
     ask === null ? 0 : Math.max(ask - 1, 0),
     DEPOSIT_FEE_USD,
-    LOOP_WAIT_SECONDS,
+    TO_USDC_WAIT_SECONDS,
     (min) => (bought < min ? `Too small for the spot loop. Gate needs at least ${min} USDC per transfer.` : null),
   );
 

--- a/src/server/rebalanceJob.ts
+++ b/src/server/rebalanceJob.ts
@@ -38,11 +38,15 @@ export interface Job {
   updatedAt: number;
 }
 
-export const LOOP_STEPS = ['Buy USDC', 'To spot', 'To Hyperliquid'] as const;
+export const TO_USDC_STEPS = ['Buy USDC', 'To spot', 'To Hyperliquid'] as const;
 export const CONVERT_STEPS = ['Convert'] as const;
-export const PULL_STEPS = ['Pull from Hyperliquid', 'To Gate', 'Sell USDC'] as const;
-export type StepName = (typeof LOOP_STEPS)[number] | (typeof CONVERT_STEPS)[number] | (typeof PULL_STEPS)[number];
-export const STEP_NAMES: readonly string[] = [...LOOP_STEPS, ...CONVERT_STEPS, ...PULL_STEPS];
+export const TO_USDT_STEPS = ['From Hyperliquid', 'To Gate', 'Sell USDC'] as const;
+export type StepName = (typeof TO_USDC_STEPS)[number] | (typeof CONVERT_STEPS)[number] | (typeof TO_USDT_STEPS)[number];
+export const STEP_NAMES: readonly string[] = [...TO_USDC_STEPS, ...CONVERT_STEPS, ...TO_USDT_STEPS];
+
+/** Names before 1.5.1. A job file written by that build must still resume. */
+const LEGACY_DIRECTION: Record<string, Direction> = { payDown: 'toUsdc', pull: 'toUsdt' };
+const LEGACY_STEP: Record<string, StepName> = { 'Pull from Hyperliquid': 'From Hyperliquid' };
 
 const JOB_STATUSES: readonly string[] = ['running', 'halted', 'done', 'abandoned'];
 const FUNDS_AT: readonly string[] = ['CROSSEX', 'GATE', 'SPOT', 'HYPERLIQUID'];
@@ -54,7 +58,7 @@ export function newJob(
   now: number,
   userId: string | null = null,
 ): Job {
-  const names: readonly string[] = route === 'convert' ? CONVERT_STEPS : direction === 'pull' ? PULL_STEPS : LOOP_STEPS;
+  const names: readonly string[] = route === 'convert' ? CONVERT_STEPS : direction === 'toUsdt' ? TO_USDT_STEPS : TO_USDC_STEPS;
   return {
     id: now.toString(36),
     userId,
@@ -74,7 +78,7 @@ export function newJob(
       startedAt: null,
       doneAt: null,
     })),
-    fundsAt: direction === 'pull' ? 'HYPERLIQUID' : 'CROSSEX',
+    fundsAt: direction === 'toUsdt' ? 'HYPERLIQUID' : 'CROSSEX',
     haltReason: null,
     createdAt: now,
     updatedAt: now,
@@ -89,11 +93,15 @@ export function haltMessage(job: Job): string {
 function parseJob(value: unknown): Job | null {
   const job = value as Partial<Job> | null;
   if (typeof job !== 'object' || job === null) return null;
-  if (job.direction === undefined) job.direction = 'payDown';
+  if (job.direction === undefined) job.direction = 'toUsdc';
+  if (typeof job.direction === 'string' && job.direction in LEGACY_DIRECTION) job.direction = LEGACY_DIRECTION[job.direction];
   if (job.userId === undefined) job.userId = null;
-  if (job.direction !== 'payDown' && job.direction !== 'pull') return null;
+  if (job.direction !== 'toUsdc' && job.direction !== 'toUsdt') return null;
   if (!JOB_STATUSES.includes(String(job.status))) return null;
   if (!Array.isArray(job.steps) || job.steps.length === 0) return null;
+  for (const step of job.steps as Partial<Step>[]) {
+    if (typeof step?.name === 'string' && step.name in LEGACY_STEP) step.name = LEGACY_STEP[step.name];
+  }
   const index = job.stepIndex;
   if (!Number.isInteger(index) || (index as number) < 0 || (index as number) >= job.steps.length) return null;
   if (!job.steps.every((step) => STEP_NAMES.includes(String((step as Partial<Step> | null)?.name)))) return null;

--- a/src/server/rebalanceRunner.ts
+++ b/src/server/rebalanceRunner.ts
@@ -38,7 +38,7 @@ const STEPS: Record<StepName, StepSpec> = {
   'To spot': { kind: 'transfer', from: 'CROSSEX_GATE', to: 'SPOT', dest: 'SPOT' },
   'To Hyperliquid': { kind: 'transfer', from: 'SPOT', to: HYPERLIQUID_ACCOUNT, dest: 'HYPERLIQUID' },
   Convert: { kind: 'convert', dest: 'HYPERLIQUID' },
-  'Pull from Hyperliquid': { kind: 'transfer', from: HYPERLIQUID_ACCOUNT, to: 'SPOT', dest: 'SPOT' },
+  'From Hyperliquid': { kind: 'transfer', from: HYPERLIQUID_ACCOUNT, to: 'SPOT', dest: 'SPOT' },
   'To Gate': { kind: 'transfer', from: 'SPOT', to: 'CROSSEX_GATE', dest: 'GATE' },
   'Sell USDC': { kind: 'order', side: CrossexOrderRequest.Side.SELL, dest: 'CROSSEX' },
 };
@@ -85,11 +85,11 @@ export async function runJob(deps: RunnerDeps): Promise<void> {
 
   const previousQty = (): number => (job.stepIndex === 0 ? job.amount : (job.steps[job.stepIndex - 1].qty ?? 0));
 
-  /** Convert runs on Hyperliquid in both directions. Pay-down turns USDT into
-   * USDC there; pull turns USDC into USDT, which lands in the pooled CROSSEX
-   * bucket. */
+  /** Convert runs on Hyperliquid in both directions. Toward USDC it turns USDT
+   * into USDC there; toward USDT it turns USDC into USDT, which lands in the
+   * pooled CROSSEX bucket. */
   const convertSpec = () =>
-    job.direction === 'pull'
+    job.direction === 'toUsdt'
       ? { fromCoin: 'USDC', toCoin: 'USDT', dest: 'CROSSEX' as FundsAt }
       : { fromCoin: 'USDT', toCoin: 'USDC', dest: 'HYPERLIQUID' as FundsAt };
 

--- a/src/server/routes/rebalance.ts
+++ b/src/server/routes/rebalance.ts
@@ -16,7 +16,9 @@ const conflict = (reply: FastifyReply, message: string): FastifyReply =>
 const orEmpty = <T>(read: Promise<{ value: T[]; stale: boolean }>): Promise<{ value: T[]; stale: boolean }> =>
   read.catch(() => ({ value: [], stale: true }));
 
-const directionOf = (value: unknown): Direction => (value === 'pull' ? 'pull' : 'payDown');
+/** `pull` and `payDown` are the names before 1.5.1; a tab still running that
+ * bundle for a moment after an update must not have its move flipped. */
+const directionOf = (value: unknown): Direction => (value === 'toUsdt' || value === 'pull' ? 'toUsdt' : 'toUsdc');
 
 const requestedOf = (value: unknown): number => {
   const n = typeof value === 'number' || typeof value === 'string' ? Number(value) : NaN;
@@ -168,7 +170,7 @@ export function rebalanceRoutes(deps: AppDeps) {
       const { plan, accountStale, userId } = await loadView(true, direction, requestedOf(body.amount));
       // The amount is sized from this read. A read served from the cache
       // because Gate rate-limited the fresh one may be seconds old, and a
-      // pull sized on old equity can open the borrow it promises not to.
+      // move to USDT sized on old equity can open the borrow it promises not to.
       if (accountStale) return conflict(reply, 'Gate is rate-limiting the account read. Try again in a few seconds.');
       if (typeof body.route === 'string' && body.route !== plan.route) {
         return conflict(reply, `plan changed: now ${plan.route ?? 'no route'}`);

--- a/tests/live/rebalance.test.ts
+++ b/tests/live/rebalance.test.ts
@@ -28,7 +28,7 @@ describe.skipIf(process.env.REBALANCE !== '1')('live rebalance — 12 USDT down 
     const liability = Number(row(before, 'USDC', 'HYPERLIQUID')?.liability ?? 0);
     const cash = Number(row(before, 'USDT', 'CROSSEX')?.balance ?? 0);
     if (!(liability > AMOUNT)) {
-      throw new Error(`USDC/HYPERLIQUID liability ${liability} is not above ${AMOUNT}. Nothing to pay down.`);
+      throw new Error(`USDC/HYPERLIQUID liability ${liability} is not above ${AMOUNT}. Nothing to move toward USDC.`);
     }
     if (!(cash > AMOUNT)) {
       throw new Error(`USDT/CROSSEX balance ${cash} is not above ${AMOUNT}. Not enough cash to buy USDC.`);
@@ -39,7 +39,7 @@ describe.skipIf(process.env.REBALANCE !== '1')('live rebalance — 12 USDT down 
 
     const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rebalance-live-'));
     const jobs = new JobFile(dataDir);
-    const job = newJob('payDown', 'loop', AMOUNT, Date.now());
+    const job = newJob('toUsdc', 'loop', AMOUNT, Date.now());
     jobs.write(job);
     console.log(`  ▸ job ${job.id} written to ${dataDir}`);
 
@@ -63,7 +63,7 @@ describe.skipIf(process.env.REBALANCE !== '1')('live rebalance — 12 USDT down 
     expect(Math.abs(balanceAfter - balanceBefore - landed)).toBeLessThanOrEqual(0.01);
   }, 400_000);
 
-  it('pull: moves USDC from Hyperliquid to spot, then to Gate, then sells it for USDT', async (ctx) => {
+  it('toUsdt: moves USDC from Hyperliquid to spot, then to Gate, then sells it for USDT', async (ctx) => {
     assertLiveTestsEnabled();
     assertAck();
     const clients = assertCredentials();
@@ -75,15 +75,15 @@ describe.skipIf(process.env.REBALANCE !== '1')('live rebalance — 12 USDT down 
     const usdc = row(before, 'USDC', 'HYPERLIQUID');
     const cap = Math.min(Number(usdc?.availableBalance ?? 0), Number(usdc?.equity ?? 0));
     if (!(cap >= AMOUNT)) {
-      ctx.skip(`USDC/HYPERLIQUID pull cap ${cap} is below ${AMOUNT} USDC. Nothing to pull.`);
+      ctx.skip(`USDC/HYPERLIQUID spare cap ${cap} is below ${AMOUNT} USDC. Nothing to move.`);
     }
     const cashBefore = Number(row(before, 'USDT', 'CROSSEX')?.balance ?? 0);
 
-    budget.beforeOrder(AMOUNT, 'rebalance pull');
+    budget.beforeOrder(AMOUNT, 'rebalance toUsdt');
 
     const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rebalance-live-'));
     const jobs = new JobFile(dataDir);
-    const job = newJob('pull', 'loop', AMOUNT, Date.now());
+    const job = newJob('toUsdt', 'loop', AMOUNT, Date.now());
     jobs.write(job);
     console.log(`  ▸ job ${job.id} written to ${dataDir}`);
 

--- a/tests/server/credentials-put.test.ts
+++ b/tests/server/credentials-put.test.ts
@@ -142,7 +142,7 @@ describe('PUT /api/credentials', () => {
       rebalance: { jobs },
     });
     await app.ready();
-    jobs.write(newJob('payDown', 'loop', 12, Date.now()));
+    jobs.write(newJob('toUsdc', 'loop', 12, Date.now()));
 
     const res = await put({ key: NEW_KEY, secret: NEW_SECRET });
 
@@ -161,7 +161,7 @@ describe('PUT /api/credentials', () => {
     });
     await app.ready();
     const halted = (userId: string | null) => {
-      const job = newJob('payDown', 'loop', 12, Date.now(), userId);
+      const job = newJob('toUsdc', 'loop', 12, Date.now(), userId);
       job.status = 'halted';
       jobs.write(job);
     };

--- a/tests/server/deals.test.ts
+++ b/tests/server/deals.test.ts
@@ -97,7 +97,7 @@ describe('POST /api/deals', () => {
     app = makeTestApp({ engine: { store, venue: new FakeVenue(), clock: new VirtualClock() }, rebalance: { jobs } });
     // The rebalance plugin halts a running job at boot, so boot first.
     await app.ready();
-    const running = newJob('payDown', 'loop', 300, Date.now());
+    const running = newJob('toUsdc', 'loop', 300, Date.now());
     jobs.write(running);
 
     let res = await app.inject({ method: 'POST', url: '/api/deals', headers: HOST, payload: makerPayload() });

--- a/tests/server/rebalance-job.test.ts
+++ b/tests/server/rebalance-job.test.ts
@@ -5,7 +5,7 @@ import type { FastifyInstance } from 'fastify';
 import nock from 'nock';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { makeClients } from '../../src/core/clients';
-import { PULL_FEE_USD, PULL_WAIT_SECONDS } from '../../src/core/rebalance/plan';
+import { HYPERLIQUID_WITHDRAW_FEE_USD, TO_USDT_WAIT_SECONDS } from '../../src/core/rebalance/plan';
 import { Store } from '../../src/engine/db';
 import { gateVenue } from '../../src/engine/venueGate';
 import { TtlCache } from '../../src/server/cache';
@@ -179,7 +179,7 @@ function mockLoopAfterBuy(): nock.Scope {
 }
 
 function haltedLoopJob(stepIndex: number, patch: Partial<Step> = {}): Job {
-  const job = newJob('payDown', 'loop', AMOUNT, t);
+  const job = newJob('toUsdc', 'loop', AMOUNT, t);
   job.status = 'halted';
   job.haltReason = 'server restarted';
   job.stepIndex = stepIndex;
@@ -199,9 +199,9 @@ function haltedLoopJob(stepIndex: number, patch: Partial<Step> = {}): Job {
   return job;
 }
 
-const PULL_AMOUNT = 1200;
+const TO_USDT_AMOUNT = 1200;
 
-const pullAccount = () => account({ balance: '5000', available_balance: '5000', equity: '5000', liability: '0' });
+const toUsdtAccount = () => account({ balance: '5000', available_balance: '5000', equity: '5000', liability: '0' });
 
 const isTransfer = (b: Record<string, unknown>, from: string, to: string, amount: string): boolean =>
   b.coin === 'USDC' && b.from === from && b.to === to && b.amount === amount && typeof b.text === 'string';
@@ -288,7 +288,7 @@ describe('POST /api/rebalance', () => {
   });
 
   it('refuses: 409 for a running job, a working deal, no route, a changed plan, and one of two concurrent POSTs; 403 before the disclaimer', async () => {
-    const stored = newJob('payDown', 'loop', AMOUNT, t);
+    const stored = newJob('toUsdc', 'loop', AMOUNT, t);
     let h = boot({ job: stored });
     let res = await h.post();
     expect(res.statusCode).toBe(409);
@@ -390,7 +390,7 @@ describe('POST /api/rebalance', () => {
 
     const { job } = (await h.view()).data;
     expect(job).toMatchObject({
-      direction: 'payDown',
+      direction: 'toUsdc',
       status: 'done',
       route: 'loop',
       amount: AMOUNT,
@@ -504,7 +504,7 @@ describe('POST /api/rebalance', () => {
 
   it('halts on boot: a running job in rebalance.json is halted with server restarted before the first GET', async () => {
     mockView();
-    const job = newJob('payDown', 'loop', AMOUNT, t);
+    const job = newJob('toUsdc', 'loop', AMOUNT, t);
     Object.assign(job.steps[0], { text: tagFor(job.id, 0), venueId: 'o1', status: 'running', startedAt: t });
     const h = boot({ job });
 
@@ -515,10 +515,10 @@ describe('POST /api/rebalance', () => {
     expect(h.file()).toMatchObject({ status: 'halted', haltReason: 'server restarted' });
   });
 
-  it('pull: 202 with direction pull, two transfers then a market sell sized by what landed, qty from executedAmount, funds at CROSSEX', async () => {
+  it('toUsdt: 202 with direction toUsdt, two transfers then a market sell sized by what landed, qty from executedAmount, funds at CROSSEX', async () => {
     const cache = new TtlCache();
-    mockView({ account: pullAccount() });
-    const pulls = gate()
+    mockView({ account: toUsdtAccount() });
+    const transfers = gate()
       .post(`${API}/crossex/transfers`, (b) => isTransfer(b, 'CROSSEX_HYPERLIQUID', 'SPOT', '1200.00000'))
       .query(true)
       .reply(200, { tx_id: 'p1', text: 't' });
@@ -542,10 +542,10 @@ describe('POST /api/rebalance', () => {
     mockGateGet('/orders/s1', { body: { ...orderBody('FILLED', '1199', 's1'), executed_amount: '1197.8011' } });
     let h = boot({ cache });
 
-    const before = (await h.view(`?direction=pull&amount=${PULL_AMOUNT}`)).data;
+    const before = (await h.view(`?direction=toUsdt&amount=${TO_USDT_AMOUNT}`)).data;
     expect(before.plan).toMatchObject({
-      direction: 'pull',
-      amount: PULL_AMOUNT,
+      direction: 'toUsdt',
+      amount: TO_USDT_AMOUNT,
       route: 'loop',
       price: 1,
       receives: 1197.8,
@@ -554,33 +554,33 @@ describe('POST /api/rebalance', () => {
       savesPerDayUsd: 0,
       marginFreedUsd: 0,
     });
-    expect(before.plan.routes.loop).toMatchObject({ waitSeconds: PULL_WAIT_SECONDS, available: true, reason: null });
-    expect(before.plan.routes.loop.costUsd).toBeCloseTo(PULL_AMOUNT * 0.001 + PULL_FEE_USD, 9);
+    expect(before.plan.routes.loop).toMatchObject({ waitSeconds: TO_USDT_WAIT_SECONDS, available: true, reason: null });
+    expect(before.plan.routes.loop.costUsd).toBeCloseTo(TO_USDT_AMOUNT * 0.001 + HYPERLIQUID_WITHDRAW_FEE_USD, 9);
     expect(before.plan.routes.convert).toMatchObject({ available: true, reason: null, waitSeconds: 0 });
-    expect(before.plan.routes.convert.costUsd).toBeCloseTo(PULL_AMOUNT * 0.002, 9);
+    expect(before.plan.routes.convert.costUsd).toBeCloseTo(TO_USDT_AMOUNT * 0.002, 9);
     expect(before.job).toBeNull();
 
-    const res = await h.post('/api/rebalance', { direction: 'pull', amount: PULL_AMOUNT, route: 'loop' });
+    const res = await h.post('/api/rebalance', { direction: 'toUsdt', amount: TO_USDT_AMOUNT, route: 'loop' });
     expect(res.statusCode).toBe(202);
     expect(h.file()).toMatchObject({
       id: res.json().data.id,
-      direction: 'pull',
+      direction: 'toUsdt',
       route: 'loop',
-      amount: PULL_AMOUNT,
+      amount: TO_USDT_AMOUNT,
       status: 'running',
       fundsAt: 'HYPERLIQUID',
     });
-    expect(h.file().steps.map((s) => s.name)).toEqual(['Pull from Hyperliquid', 'To Gate', 'Sell USDC']);
+    expect(h.file().steps.map((s) => s.name)).toEqual(['From Hyperliquid', 'To Gate', 'Sell USDC']);
     await waitFor(() => h.file().status === 'done', 'done');
 
-    expect(pulls.isDone()).toBe(true);
+    expect(transfers.isDone()).toBe(true);
     expect(toGate.isDone()).toBe(true);
     expect(sells.isDone()).toBe(true);
     const { value } = await cache.get('account', 60_000, async () => 'fresh');
     expect(value).toBe('fresh');
 
     const { job } = (await h.view()).data;
-    expect(job).toMatchObject({ direction: 'pull', status: 'done', stepIndex: 2, fundsAt: 'CROSSEX', haltReason: null });
+    expect(job).toMatchObject({ direction: 'toUsdt', status: 'done', stepIndex: 2, fundsAt: 'CROSSEX', haltReason: null });
     expect(job.steps.map((s: Step) => s.status)).toEqual(['done', 'done', 'done']);
     expect(job.steps.map((s: Step) => s.venueId)).toEqual(['p1', 'p2', 's1']);
     expect(job.steps.map((s: Step) => s.qty)).toEqual([1199, 1199, 1197.8011]);
@@ -593,48 +593,48 @@ describe('POST /api/rebalance', () => {
     await reset();
     mockView();
     h = boot();
-    const empty = (await h.view('?direction=pull')).data.plan;
-    expect(empty).toMatchObject({ direction: 'pull', amount: 0, route: null, receives: 0, price: null });
+    const empty = (await h.view('?direction=toUsdt')).data.plan;
+    expect(empty).toMatchObject({ direction: 'toUsdt', amount: 0, route: null, receives: 0, price: null });
     expect(empty.routes.loop).toMatchObject({ available: false, reason: 'nothing to move' });
     expect(empty.routes.convert).toMatchObject({ available: false, reason: 'nothing to move' });
-    const refused = await h.post('/api/rebalance', { direction: 'pull' });
+    const refused = await h.post('/api/rebalance', { direction: 'toUsdt' });
     expect(refused.statusCode).toBe(409);
     expect(refused.json().error.message).toBe('no route');
   });
 
-  it('pull convert: a small pull picks convert, quotes USDC to USDT, sends, funds at CROSSEX; a resumed quote is found on Gate by its id', async () => {
-    mockView({ account: pullAccount() });
-    const isPullQuote = (b: Record<string, unknown>): boolean =>
+  it('toUsdt convert: a small move picks convert, quotes USDC to USDT, sends, funds at CROSSEX; a resumed quote is found on Gate by its id', async () => {
+    mockView({ account: toUsdtAccount() });
+    const isToUsdtQuote = (b: Record<string, unknown>): boolean =>
       b.exchange_type === 'HYPERLIQUID' && b.from_coin === 'USDC' && b.to_coin === 'USDT' && b.from_amount === '12';
     const quotes = gate()
-      .post(`${API}/crossex/convert/quote`, isPullQuote)
+      .post(`${API}/crossex/convert/quote`, isToUsdtQuote)
       .query(true)
       .reply(200, { ...quoteBody('q3', '11.98'), from_coin: 'USDC', to_coin: 'USDT', from_amount: '12', price: '0.9981' });
     const orders = mockGatePost('/convert/orders', { body: { order_id: 'c3', text: 'q3' } });
     let h = boot();
 
-    const before = (await h.view('?direction=pull&amount=12')).data;
-    expect(before.plan).toMatchObject({ direction: 'pull', amount: 12, route: 'convert', price: 0.998, receives: 11.97 });
+    const before = (await h.view('?direction=toUsdt&amount=12')).data;
+    expect(before.plan).toMatchObject({ direction: 'toUsdt', amount: 12, route: 'convert', price: 0.998, receives: 11.97 });
     expect(before.plan.routes.loop).toMatchObject({ available: true, reason: null });
-    expect(before.plan.routes.loop.costUsd).toBeCloseTo(12 * 0.001 + PULL_FEE_USD, 9);
+    expect(before.plan.routes.loop.costUsd).toBeCloseTo(12 * 0.001 + HYPERLIQUID_WITHDRAW_FEE_USD, 9);
     expect(before.plan.routes.convert.costUsd).toBeCloseTo(0.024, 9);
     // Gate sends min_trans_amount as the string "11"; the reason must add, not concatenate.
-    const small = (await h.view('?direction=pull&amount=11.5')).data.plan;
+    const small = (await h.view('?direction=toUsdt&amount=11.5')).data.plan;
     expect(small.routes.loop.reason).toBe(
-      'Too small to pull. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Pull at least 12 USDC.',
+      'Too small to move. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Move at least 12 USDC.',
     );
     expect(small.route).toBe('convert');
 
-    const res = await h.post('/api/rebalance', { direction: 'pull', amount: 12, route: 'convert' });
+    const res = await h.post('/api/rebalance', { direction: 'toUsdt', amount: 12, route: 'convert' });
     expect(res.statusCode).toBe(202);
-    expect(h.file()).toMatchObject({ direction: 'pull', route: 'convert', amount: 12, fundsAt: 'HYPERLIQUID' });
+    expect(h.file()).toMatchObject({ direction: 'toUsdt', route: 'convert', amount: 12, fundsAt: 'HYPERLIQUID' });
     expect(h.file().steps.map((s) => s.name)).toEqual(['Convert']);
     await waitFor(() => h.file().status === 'done', 'done');
 
     expect(quotes.isDone()).toBe(true);
     expect(orders.isDone()).toBe(true);
     const { job } = (await h.view()).data;
-    expect(job).toMatchObject({ direction: 'pull', route: 'convert', status: 'done', fundsAt: 'CROSSEX', haltReason: null });
+    expect(job).toMatchObject({ direction: 'toUsdt', route: 'convert', status: 'done', fundsAt: 'CROSSEX', haltReason: null });
     expect(job.steps[0]).toMatchObject({
       name: 'Convert',
       text: tagFor(job.id, 0),
@@ -645,11 +645,11 @@ describe('POST /api/rebalance', () => {
     });
 
     await reset();
-    mockView({ account: pullAccount() });
+    mockView({ account: toUsdtAccount() });
     const byQuote = mockGateGet('/orders/q4', { body: convertOrderBody('c4', 'q4', '11.98') });
     mockGateGet('/orders/c4', { body: convertOrderBody('c4', 'q4', '11.98') });
     const unsent = mockGatePost('/convert/orders', { body: { order_id: 'c5', text: 'q5' } });
-    const resumed = newJob('pull', 'convert', 12, t);
+    const resumed = newJob('toUsdt', 'convert', 12, t);
     resumed.status = 'halted';
     resumed.haltReason = 'server restarted';
     Object.assign(resumed.steps[0], { text: tagFor(resumed.id, 0), quoteId: 'q4', qty: 11.98, status: 'running', startedAt: t });
@@ -664,24 +664,24 @@ describe('POST /api/rebalance', () => {
     expect(h.file().steps[0]).toMatchObject({ quoteId: 'q4', venueId: 'c4', qty: 11.98, status: 'done' });
   });
 
-  it('pull halts and resumes like pay-down: a FAILED pull halts with funds at HYPERLIQUID, abandon ends it, and a resumed Sell USDC with a tag only adopts the order and sends nothing', async () => {
-    mockView({ account: pullAccount() });
+  it('toUsdt halts and resumes like toUsdc: a FAILED transfer halts with funds at HYPERLIQUID, abandon ends it, and a resumed Sell USDC with a tag only adopts the order and sends nothing', async () => {
+    mockView({ account: toUsdtAccount() });
     mockGatePost('/transfers', { body: { tx_id: 'p1', text: 't' } });
     mockGateGet('/transfers', { body: [transferRow('p1', 'FAILED', { amount: '1200.00000', fail_reason: 'withdraw paused' })] });
     let h = boot();
-    let res = await h.post('/api/rebalance', { direction: 'pull', amount: PULL_AMOUNT });
+    let res = await h.post('/api/rebalance', { direction: 'toUsdt', amount: TO_USDT_AMOUNT });
     expect(res.statusCode).toBe(202);
     await waitFor(() => h.file().status === 'halted', 'the halt');
-    expect(h.file()).toMatchObject({ direction: 'pull', haltReason: 'withdraw paused', fundsAt: 'HYPERLIQUID', stepIndex: 0 });
-    expect(h.file().steps[0]).toMatchObject({ name: 'Pull from Hyperliquid', venueId: null, text: null, status: 'running' });
+    expect(h.file()).toMatchObject({ direction: 'toUsdt', haltReason: 'withdraw paused', fundsAt: 'HYPERLIQUID', stepIndex: 0 });
+    expect(h.file().steps[0]).toMatchObject({ name: 'From Hyperliquid', venueId: null, text: null, status: 'running' });
     const { id } = h.file();
     res = await h.post(`/api/rebalance/${id}/abandon`);
     expect(res.statusCode).toBe(200);
-    expect(res.json().data).toMatchObject({ id, direction: 'pull', status: 'abandoned' });
+    expect(res.json().data).toMatchObject({ id, direction: 'toUsdt', status: 'abandoned' });
 
     await reset();
-    mockView({ account: pullAccount() });
-    const job = newJob('pull', 'loop', PULL_AMOUNT, t);
+    mockView({ account: toUsdtAccount() });
+    const job = newJob('toUsdt', 'loop', TO_USDT_AMOUNT, t);
     job.status = 'halted';
     job.haltReason = 'server restarted';
     job.stepIndex = 2;
@@ -706,7 +706,7 @@ describe('POST /api/rebalance', () => {
 
     res = await h.post(`/api/rebalance/${job.id}/resume`);
     expect(res.statusCode).toBe(200);
-    expect(res.json().data).toMatchObject({ id: job.id, direction: 'pull', status: 'running', stepIndex: 2 });
+    expect(res.json().data).toMatchObject({ id: job.id, direction: 'toUsdt', status: 'running', stepIndex: 2 });
     await waitFor(() => h.file().status === 'done', 'done');
     expect(lookup.isDone()).toBe(true);
     expect(poll.isDone()).toBe(true);
@@ -723,29 +723,37 @@ describe('GET /api/rebalance', () => {
     const planAt = async (query: string) => (await h.view(query)).data.plan;
 
     const full = await planAt('');
-    expect(full).toMatchObject({ direction: 'payDown', amount: AMOUNT, route: 'loop', price: 1.0001, receives: 299.62 });
+    expect(full).toMatchObject({ direction: 'toUsdc', amount: AMOUNT, route: 'loop', price: 1.0001, receives: 299.62 });
     expect(full.borrowAfterUsd).toBeCloseTo(0.38, 9);
 
     const capped = await planAt('?amount=100.005');
-    expect(capped).toMatchObject({ direction: 'payDown', amount: 100, route: 'loop', price: 1.0001, receives: 99.84 });
+    expect(capped).toMatchObject({ direction: 'toUsdc', amount: 100, route: 'loop', price: 1.0001, receives: 99.84 });
     expect(capped.borrowAfterUsd).toBeCloseTo(200.16, 9);
 
     expect((await planAt('?amount=5000')).amount).toBe(AMOUNT);
     expect((await planAt('?amount=abc')).amount).toBe(AMOUNT);
     expect((await planAt('?amount=0')).amount).toBe(AMOUNT);
-    expect((await planAt('?direction=payDown&amount=50')).amount).toBe(50);
+    expect((await planAt('?direction=toUsdc&amount=50')).amount).toBe(50);
   });
 
-  it('old job file: a rebalance.json without direction reads as payDown and is written back with it', async () => {
+  it('old job file: a rebalance.json without direction reads as toUsdc and is written back with it', async () => {
     mockView();
-    const { direction: _direction, ...legacy } = newJob('payDown', 'loop', AMOUNT, t);
+    const { direction: _direction, ...legacy } = newJob('toUsdc', 'loop', AMOUNT, t);
     const h = boot({ job: legacy as Job });
 
     const { data } = await h.view();
 
-    expect(data.job).toMatchObject({ id: legacy.id, userId: null, direction: 'payDown', status: 'halted', haltReason: 'server restarted' });
+    expect(data.job).toMatchObject({ id: legacy.id, userId: null, direction: 'toUsdc', status: 'halted', haltReason: 'server restarted' });
     expect(data.job.steps.map((s: Step) => s.name)).toEqual(['Buy USDC', 'To spot', 'To Hyperliquid']);
-    expect(h.file().direction).toBe('payDown');
+    expect(h.file().direction).toBe('toUsdc');
+  });
+
+  it('accepts the direction names from before 1.5.1 on the API: pull reads as toUsdt, payDown as toUsdc', async () => {
+    mockView();
+    const h = boot();
+
+    expect((await h.view('?direction=pull')).data.plan.direction).toBe('toUsdt');
+    expect((await h.view('?direction=payDown')).data.plan.direction).toBe('toUsdc');
   });
 });
 
@@ -890,7 +898,7 @@ describe('POST /api/rebalance/:id/resume and /abandon', () => {
     const convertOrders = mockGatePost('/convert/orders', { body: { order_id: 'c9', text: 'q9' } });
     const known = mockGateGet('/orders/q1', { body: convertOrderBody('c1', 'q1', '299.4') });
     mockGateGet('/orders/c1', { body: convertOrderBody('c1', 'q1', '299.4') });
-    job = newJob('payDown', 'convert', AMOUNT, t);
+    job = newJob('toUsdc', 'convert', AMOUNT, t);
     job.status = 'halted';
     job.haltReason = 'server restarted';
     Object.assign(job.steps[0], { text: tagFor(job.id, 0), quoteId: 'q1', qty: 299.4, status: 'running', startedAt: t });

--- a/tests/server/version.test.ts
+++ b/tests/server/version.test.ts
@@ -332,7 +332,7 @@ describe('POST /api/version/update', () => {
     const jobs = new JobFile(mkdtempSync(path.join(tmpdir(), 'rebalance-')));
     app = makeTestApp({ install: INSTALLED, rebalance: { jobs } });
     await app.ready();
-    jobs.write(newJob('payDown', 'loop', 12, Date.now()));
+    jobs.write(newJob('toUsdc', 'loop', 12, Date.now()));
 
     const res = await post();
 

--- a/tests/unit/rebalance-plan.test.ts
+++ b/tests/unit/rebalance-plan.test.ts
@@ -5,9 +5,9 @@ import {
   USDC_WALLET,
   USDT_WALLET,
   SPOT_SYMBOL,
-  LOOP_WAIT_SECONDS,
-  PULL_FEE_USD,
-  PULL_WAIT_SECONDS,
+  TO_USDC_WAIT_SECONDS,
+  HYPERLIQUID_WITHDRAW_FEE_USD,
+  TO_USDT_WAIT_SECONDS,
   type AccountLike,
   type AssetLike,
   type PlanInputs,
@@ -56,7 +56,7 @@ const OPEN: PlanInputs = {
   bid: 0.9999,
 };
 
-const PULL: PlanRequest = { direction: 'pull' };
+const TO_USDT: PlanRequest = { direction: 'toUsdt' };
 
 interface Scenario {
   usdcEquity: number;
@@ -250,9 +250,9 @@ describe('planFor amount', () => {
 describe('planFor requested amount', () => {
   const s: Scenario = { usdcEquity: -500, usdtCash: 1000, margin: 2000 };
 
-  it('reads as payDown for the full deficit when no request is given', () => {
+  it('reads as toUsdc for the full deficit when no request is given', () => {
     const p = plan(s);
-    expect(p.direction).toBe('payDown');
+    expect(p.direction).toBe('toUsdc');
     expect(p.amount).toBe(500);
   });
 
@@ -342,7 +342,7 @@ describe('planFor shortfall', () => {
 describe('planFor route', () => {
   it('quotes loop at 150 s and convert at 0 s with the formula costs', () => {
     const p = plan({ usdcEquity: -500, usdtCash: 1000, margin: 2000 });
-    expect(p.routes.loop.waitSeconds).toBe(LOOP_WAIT_SECONDS);
+    expect(p.routes.loop.waitSeconds).toBe(TO_USDC_WAIT_SECONDS);
     expect(p.routes.loop.waitSeconds).toBe(150);
     expect(p.routes.convert.waitSeconds).toBe(0);
     expect(p.routes.loop.costUsd).toBeCloseTo(500 * 0.0001 + 0.05, 9);
@@ -463,34 +463,34 @@ describe('planFor loop unavailable', () => {
   });
 });
 
-describe('planFor pull', () => {
+describe('planFor toUsdt', () => {
   const s: Scenario = { usdcEquity: 50, usdcCash: 50, usdtCash: 1000, margin: 2000 };
 
-  it('reads as pull with the bucket equity as the amount', () => {
-    const p = plan(s, OPEN, PULL);
-    expect(p.direction).toBe('pull');
+  it('reads as toUsdt with the bucket equity as the amount', () => {
+    const p = plan(s, OPEN, TO_USDT);
+    expect(p.direction).toBe('toUsdt');
     expect(p.amount).toBe(50);
   });
 
   it('equals the requested amount when it is the smallest', () => {
-    expect(plan(s, OPEN, { ...PULL, requested: 20 }).amount).toBe(20);
+    expect(plan(s, OPEN, { ...TO_USDT, requested: 20 }).amount).toBe(20);
   });
 
   it('equals the available balance when it is the smallest', () => {
-    expect(plan({ ...s, usdcAvailable: 30 }, OPEN, PULL).amount).toBe(30);
+    expect(plan({ ...s, usdcAvailable: 30 }, OPEN, TO_USDT).amount).toBe(30);
   });
 
   it('equals the equity when it is the smallest', () => {
-    expect(plan({ ...s, usdcAvailable: 80 }, OPEN, PULL).amount).toBe(50);
+    expect(plan({ ...s, usdcAvailable: 80 }, OPEN, TO_USDT).amount).toBe(50);
   });
 
   it('floors the amount to 0.01', () => {
-    expect(plan({ ...s, usdcEquity: 50.129, usdcAvailable: 100 }, OPEN, PULL).amount).toBe(50.12);
+    expect(plan({ ...s, usdcEquity: 50.129, usdcAvailable: 100 }, OPEN, TO_USDT).amount).toBe(50.12);
   });
 
   it('is 0 when the equity is 0 or below, with both routes unavailable', () => {
     for (const usdcEquity of [0, -300]) {
-      const p = plan({ ...s, usdcEquity, usdcAvailable: 100 }, OPEN, PULL);
+      const p = plan({ ...s, usdcEquity, usdcAvailable: 100 }, OPEN, TO_USDT);
       expect(p.amount).toBe(0);
       expect(p.route).toBeNull();
       expect(p.routes.loop).toMatchObject({ available: false, reason: 'nothing to move' });
@@ -498,22 +498,22 @@ describe('planFor pull', () => {
     }
   });
 
-  it('quotes the loop as amount x (1 - bid) + amount x taker + the pull fee, with the pull wait', () => {
-    const p = plan(s, OPEN, PULL);
-    expect(p.routes.loop.costUsd).toBeCloseTo(50 * 0.0001 + PULL_FEE_USD, 9);
-    expect(p.routes.loop.waitSeconds).toBe(PULL_WAIT_SECONDS);
+  it('quotes the loop as amount x (1 - bid) + amount x taker + the Hyperliquid withdraw fee, with the toUsdt wait', () => {
+    const p = plan(s, OPEN, TO_USDT);
+    expect(p.routes.loop.costUsd).toBeCloseTo(50 * 0.0001 + HYPERLIQUID_WITHDRAW_FEE_USD, 9);
+    expect(p.routes.loop.waitSeconds).toBe(TO_USDT_WAIT_SECONDS);
     expect(p.routes.loop.waitSeconds).toBe(400);
-    const withFee = plan(s, { ...OPEN, spotTakerRate: 0.001 }, PULL);
-    expect(withFee.routes.loop.costUsd).toBeCloseTo(50 * 0.0001 + 50 * 0.001 + PULL_FEE_USD, 9);
+    const withFee = plan(s, { ...OPEN, spotTakerRate: 0.001 }, TO_USDT);
+    expect(withFee.routes.loop.costUsd).toBeCloseTo(50 * 0.0001 + 50 * 0.001 + HYPERLIQUID_WITHDRAW_FEE_USD, 9);
   });
 
   it('charges no spread when the bid is above 1', () => {
-    const p = plan(s, { ...OPEN, bid: 1.0002 }, PULL);
-    expect(p.routes.loop.costUsd).toBeCloseTo(PULL_FEE_USD, 9);
+    const p = plan(s, { ...OPEN, bid: 1.0002 }, TO_USDT);
+    expect(p.routes.loop.costUsd).toBeCloseTo(HYPERLIQUID_WITHDRAW_FEE_USD, 9);
   });
 
-  it('quotes convert as amount x 0.002, instant, and picks it for a small pull', () => {
-    const p = plan(s, OPEN, PULL);
+  it('quotes convert as amount x 0.002, instant, and picks it for a small move', () => {
+    const p = plan(s, OPEN, TO_USDT);
     expect(p.routes.convert).toMatchObject({ waitSeconds: 0, available: true, reason: null });
     expect(p.routes.convert.costUsd).toBeCloseTo(0.1, 9);
     expect(p.routes.loop.costUsd).toBeCloseTo(1.005, 9);
@@ -524,8 +524,8 @@ describe('planFor pull', () => {
     expect(p.borrowAfterUsd).toBe(0);
   });
 
-  it('picks the loop for a big pull, where the $1 fee beats 20 bps, with the bid as the price and the sold USDT as receives', () => {
-    const p = plan({ ...s, usdcEquity: 5000, usdcCash: 5000 }, OPEN, PULL);
+  it('picks the loop for a big move, where the $1 fee beats 20 bps, with the bid as the price and the sold USDT as receives', () => {
+    const p = plan({ ...s, usdcEquity: 5000, usdcCash: 5000 }, OPEN, TO_USDT);
     expect(p.routes.loop.costUsd).toBeCloseTo(1.5, 9);
     expect(p.routes.convert.costUsd).toBeCloseTo(10, 9);
     expect(p.route).toBe('loop');
@@ -538,7 +538,7 @@ describe('planFor pull', () => {
   });
 
   it('matches the live runs: the loop for 12 USDC at bid 1 costs the $1 fee, and convert at 2 cents wins', () => {
-    const p = plan({ ...s, usdcEquity: 12, usdcCash: 12 }, { ...OPEN, bid: 1 }, PULL);
+    const p = plan({ ...s, usdcEquity: 12, usdcCash: 12 }, { ...OPEN, bid: 1 }, TO_USDT);
     expect(p.amount).toBe(12);
     expect(p.routes.loop).toMatchObject({ available: true, reason: null });
     expect(p.routes.loop.costUsd).toBeCloseTo(1, 9);
@@ -548,29 +548,29 @@ describe('planFor pull', () => {
   });
 
   it('takes the spot taker fee out of the loop receives', () => {
-    const p = plan({ ...s, usdcEquity: 5000, usdcCash: 5000 }, { ...OPEN, bid: 1, spotTakerRate: 0.001 }, PULL);
+    const p = plan({ ...s, usdcEquity: 5000, usdcCash: 5000 }, { ...OPEN, bid: 1, spotTakerRate: 0.001 }, TO_USDT);
     expect(p.route).toBe('loop');
     expect(p.receives).toBe(4994);
   });
 
   it('is unavailable when the USDC transfer is disabled or missing', () => {
-    const disabled = plan(s, { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 } }, PULL);
+    const disabled = plan(s, { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 } }, TO_USDT);
     expect(disabled.routes.loop).toMatchObject({ available: false, reason: 'Gate has paused USDC transfers on CrossEx. Try again later.' });
-    const missing = plan(s, { ...OPEN, usdcTransfer: null }, PULL);
+    const missing = plan(s, { ...OPEN, usdcTransfer: null }, TO_USDT);
     expect(missing.routes.loop).toMatchObject({ available: false, reason: 'Gate has paused USDC transfers on CrossEx. Try again later.' });
     expect(missing.route).toBe('convert');
   });
 
   it('is unavailable when the spot rule is not live or missing', () => {
-    expect(plan(s, { ...OPEN, spotRule: { state: 'suspended' } }, PULL).routes.loop.reason).toBe(
+    expect(plan(s, { ...OPEN, spotRule: { state: 'suspended' } }, TO_USDT).routes.loop.reason).toBe(
       'The USDC/USDT spot market on Gate is not trading right now.',
     );
-    expect(plan(s, { ...OPEN, spotRule: null }, PULL).routes.loop.reason).toBe('The USDC/USDT spot market on Gate is not trading right now.');
+    expect(plan(s, { ...OPEN, spotRule: null }, TO_USDT).routes.loop.reason).toBe('The USDC/USDT spot market on Gate is not trading right now.');
   });
 
   it('is unavailable when there is no spot bid, even with an ask', () => {
     for (const bid of [null, 0]) {
-      const p = plan(s, { ...OPEN, bid }, PULL);
+      const p = plan(s, { ...OPEN, bid }, TO_USDT);
       expect(p.routes.loop).toMatchObject({ available: false, reason: 'No price for USDC/USDT on Gate spot right now.' });
       expect(p.route).toBe('convert');
       expect(p.price).toBe(0.998);
@@ -578,32 +578,32 @@ describe('planFor pull', () => {
     }
   });
 
-  it('is unavailable when the pull lands below the transfer minimum after the fee', () => {
-    const p = plan({ ...s, usdcEquity: 11.5, usdcCash: 11.5 }, OPEN, PULL);
+  it('is unavailable when the move lands below the transfer minimum after the fee', () => {
+    const p = plan({ ...s, usdcEquity: 11.5, usdcCash: 11.5 }, OPEN, TO_USDT);
     expect(p.amount).toBe(11.5);
     expect(p.routes.loop.available).toBe(false);
-    expect(p.routes.loop.reason).toBe('Too small to pull. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Pull at least 12 USDC.');
+    expect(p.routes.loop.reason).toBe('Too small to move. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Move at least 12 USDC.');
     expect(p.route).toBe('convert');
-    const enough = plan({ ...s, usdcEquity: 12, usdcCash: 12 }, OPEN, PULL);
+    const enough = plan({ ...s, usdcEquity: 12, usdcCash: 12 }, OPEN, TO_USDT);
     expect(enough.routes.loop.available).toBe(true);
   });
 
   it('reports the first cause only', () => {
-    const nothing = plan({ ...s, usdcEquity: 0 }, { ...OPEN, usdcTransfer: null, bid: null }, PULL);
+    const nothing = plan({ ...s, usdcEquity: 0 }, { ...OPEN, usdcTransfer: null, bid: null }, TO_USDT);
     expect(nothing.routes.loop.reason).toBe('nothing to move');
-    const disabled = plan(s, { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 }, spotRule: null, bid: null }, PULL);
+    const disabled = plan(s, { ...OPEN, usdcTransfer: { isDisabled: 1, minTransAmount: 11 }, spotRule: null, bid: null }, TO_USDT);
     expect(disabled.routes.loop.reason).toBe('Gate has paused USDC transfers on CrossEx. Try again later.');
-    const notLive = plan(s, { ...OPEN, spotRule: { state: 'paused' }, bid: null }, PULL);
+    const notLive = plan(s, { ...OPEN, spotRule: { state: 'paused' }, bid: null }, TO_USDT);
     expect(notLive.routes.loop.reason).toBe('The USDC/USDT spot market on Gate is not trading right now.');
   });
 });
 
-describe('planFor pull with a USDT borrow', () => {
+describe('planFor toUsdt with a USDT borrow', () => {
   // USDC on Hyperliquid holds 500 of spare; the USDT wallet is 300 short.
   const s: Scenario = { usdcEquity: 500, usdcCash: 500, usdtCash: 100, usdtEquity: -300, usdtIm: 60, margin: 2000 };
 
   it('prefills the USDT deficit, not the whole spare, and the borrow after is what does not land', () => {
-    const p = plan(s, OPEN, PULL, BOTH_RATES);
+    const p = plan(s, OPEN, TO_USDT, BOTH_RATES);
     expect(p.amount).toBe(300);
     expect(p.shortfall).toBeNull();
     expect(p.receives).toBeGreaterThan(0);
@@ -611,25 +611,25 @@ describe('planFor pull with a USDT borrow', () => {
   });
 
   it('lets a typed amount bring more than the deficit home, up to the spare', () => {
-    expect(plan(s, OPEN, { ...PULL, requested: 450 }, BOTH_RATES).amount).toBe(450);
-    expect(plan(s, OPEN, { ...PULL, requested: 600 }, BOTH_RATES).amount).toBe(500);
+    expect(plan(s, OPEN, { ...TO_USDT, requested: 450 }, BOTH_RATES).amount).toBe(450);
+    expect(plan(s, OPEN, { ...TO_USDT, requested: 600 }, BOTH_RATES).amount).toBe(500);
   });
 
   it('caps the prefilled amount at the spare and names spare as the shortfall', () => {
-    const p = plan({ ...s, usdcEquity: 100, usdcCash: 100 }, OPEN, PULL, BOTH_RATES);
+    const p = plan({ ...s, usdcEquity: 100, usdcCash: 100 }, OPEN, TO_USDT, BOTH_RATES);
     expect(p.amount).toBe(100);
     expect(p.shortfall).toEqual({ reason: 'spare', remaining: 200 });
   });
 
   it('names cash when the USDC profit is not yet cash', () => {
-    const p = plan({ ...s, usdcCash: 100 }, OPEN, PULL, BOTH_RATES);
+    const p = plan({ ...s, usdcCash: 100 }, OPEN, TO_USDT, BOTH_RATES);
     expect(p.amount).toBe(100);
     expect(p.shortfall).toEqual({ reason: 'cash', remaining: 200 });
   });
 
   it('frees initial margin and saves interest on the USDT borrow for what lands', () => {
     const big: Scenario = { usdcEquity: 5000, usdcCash: 5000, usdtCash: 0, usdtEquity: -20000, usdtIm: 4000, margin: 0 };
-    const p = plan(big, OPEN, PULL, BOTH_RATES);
+    const p = plan(big, OPEN, TO_USDT, BOTH_RATES);
     expect(p.amount).toBe(5000);
     expect(p.shortfall).toEqual({ reason: 'spare', remaining: 15000 });
     const perDay = 20000 * 0.00002 * 24;
@@ -638,14 +638,14 @@ describe('planFor pull with a USDT borrow', () => {
     expect(p.borrowAfterUsd).toBeCloseTo(20000 - p.receives, 9);
   });
 
-  it('saves the whole charge when the pull brings the USDT borrow back under 10,000', () => {
+  it('saves the whole charge when the move brings the USDT borrow back under 10,000', () => {
     const near: Scenario = { usdcEquity: 5000, usdcCash: 5000, usdtCash: 0, usdtEquity: -10500, usdtIm: 2100, margin: 0 };
-    const p = plan(near, OPEN, PULL, BOTH_RATES);
+    const p = plan(near, OPEN, TO_USDT, BOTH_RATES);
     expect(p.savesPerDayUsd).toBeCloseTo(10500 * 0.00002 * 24, 9);
   });
 
   it('saves and frees nothing without a USDT borrow', () => {
-    const p = plan({ ...s, usdtCash: 1000, usdtEquity: 1000, usdtIm: 0 }, OPEN, PULL, BOTH_RATES);
+    const p = plan({ ...s, usdtCash: 1000, usdtEquity: 1000, usdtIm: 0 }, OPEN, TO_USDT, BOTH_RATES);
     expect(p.amount).toBe(500);
     expect(p).toMatchObject({ borrowAfterUsd: 0, savesPerDayUsd: 0, marginFreedUsd: 0, shortfall: null });
   });

--- a/tests/unit/rebalance-runner.test.ts
+++ b/tests/unit/rebalance-runner.test.ts
@@ -98,7 +98,7 @@ function harness(
   }
   const dir = fs.mkdtempSync(path.join(tmpdir(), 'rebalance-'));
   const jobs = new JobFile(dir, clock.now);
-  const job = newJob('payDown', route, 12, clock.now());
+  const job = newJob('toUsdc', route, 12, clock.now());
   edit?.(job);
   jobs.write(job);
   const cache = new TtlCache();
@@ -718,10 +718,10 @@ describe('JobFile', () => {
 
   it('writes an owner-only file that a new JobFile reads back', () => {
     const d = dir();
-    const job = newJob('payDown', 'loop', 12, 1_000_000);
+    const job = newJob('toUsdc', 'loop', 12, 1_000_000);
     expect(job.id).toBe((1_000_000).toString(36));
     expect(job.steps.map((s) => s.name)).toEqual(['Buy USDC', 'To spot', 'To Hyperliquid']);
-    expect(newJob('payDown', 'convert', 5, 7).steps.map((s) => s.name)).toEqual(['Convert']);
+    expect(newJob('toUsdc', 'convert', 5, 7).steps.map((s) => s.name)).toEqual(['Convert']);
 
     new JobFile(d).write(job);
 
@@ -737,7 +737,7 @@ describe('JobFile', () => {
     const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     try {
       const d = dir();
-      const { steps: _steps, ...noSteps } = newJob('payDown', 'loop', 12, 1_000_000);
+      const { steps: _steps, ...noSteps } = newJob('toUsdc', 'loop', 12, 1_000_000);
       fs.writeFileSync(path.join(d, 'rebalance.json'), JSON.stringify(noSteps));
       const jobs = new JobFile(d);
       expect(jobs.read()).toBeNull();
@@ -748,12 +748,12 @@ describe('JobFile', () => {
       fs.writeFileSync(path.join(d, 'rebalance.json'), '{not json');
       expect(new JobFile(d).read()).toBeNull();
 
-      const bogus = newJob('payDown', 'loop', 12, 1_000_000);
+      const bogus = newJob('toUsdc', 'loop', 12, 1_000_000);
       bogus.steps[1].name = 'Bogus';
       fs.writeFileSync(path.join(d, 'rebalance.json'), JSON.stringify(bogus));
       expect(new JobFile(d).read()).toBeNull();
 
-      const wrongIndex = { ...newJob('payDown', 'loop', 12, 1_000_000), stepIndex: 3 };
+      const wrongIndex = { ...newJob('toUsdc', 'loop', 12, 1_000_000), stepIndex: 3 };
       fs.writeFileSync(path.join(d, 'rebalance.json'), JSON.stringify(wrongIndex));
       expect(new JobFile(d).read()).toBeNull();
       expect(error).toHaveBeenCalledTimes(4);
@@ -764,7 +764,7 @@ describe('JobFile', () => {
 
   it('stamps updatedAt from the clock it was given', () => {
     const jobs = new JobFile(dir(), () => 42);
-    const job = newJob('payDown', 'loop', 12, 1_000_000);
+    const job = newJob('toUsdc', 'loop', 12, 1_000_000);
     jobs.write(job);
     expect(job.updatedAt).toBe(42);
   });
@@ -772,7 +772,7 @@ describe('JobFile', () => {
   it('haltIfRunning halts a running job with the reason and leaves other statuses alone', () => {
     const d = dir();
     const jobs = new JobFile(d);
-    jobs.write(newJob('payDown', 'loop', 12, 1_000_000));
+    jobs.write(newJob('toUsdc', 'loop', 12, 1_000_000));
 
     expect(jobs.haltIfRunning('server restarted')).toBe(true);
 
@@ -780,7 +780,7 @@ describe('JobFile', () => {
     expect(new JobFile(d).read()).toMatchObject({ status: 'halted', haltReason: 'server restarted' });
     expect(jobs.haltIfRunning('server restarted')).toBe(false);
 
-    const done = { ...newJob('payDown', 'loop', 12, 2_000_000), status: 'done' as const };
+    const done = { ...newJob('toUsdc', 'loop', 12, 2_000_000), status: 'done' as const };
     jobs.write(done);
     expect(jobs.haltIfRunning('server restarted')).toBe(false);
     expect(jobs.read()).toMatchObject({ status: 'done', haltReason: null });
@@ -788,3 +788,28 @@ describe('JobFile', () => {
     expect(new JobFile(dir()).haltIfRunning('server restarted')).toBe(false);
   });
 });
+
+describe('JobFile legacy names', () => {
+  it('reads a job file from before 1.5.1: direction pull and step Pull from Hyperliquid become toUsdt and From Hyperliquid', () => {
+    const d = fs.mkdtempSync(path.join(tmpdir(), 'rebalance-'));
+    const legacy = JSON.parse(JSON.stringify(newJob('toUsdt', 'loop', 12, 1000))) as Record<string, unknown>;
+    legacy.direction = 'pull';
+    (legacy.steps as { name: string }[])[0].name = 'Pull from Hyperliquid';
+    fs.writeFileSync(path.join(d, 'rebalance.json'), JSON.stringify(legacy));
+
+    const back = new JobFile(d).read();
+
+    expect(back).toMatchObject({ direction: 'toUsdt', fundsAt: 'HYPERLIQUID' });
+    expect(back?.steps.map((s) => s.name)).toEqual(['From Hyperliquid', 'To Gate', 'Sell USDC']);
+  });
+
+  it('reads direction payDown from before 1.5.1 as toUsdc', () => {
+    const d = fs.mkdtempSync(path.join(tmpdir(), 'rebalance-'));
+    const legacy = JSON.parse(JSON.stringify(newJob('toUsdc', 'convert', 12, 1000))) as Record<string, unknown>;
+    legacy.direction = 'payDown';
+    fs.writeFileSync(path.join(d, 'rebalance.json'), JSON.stringify(legacy));
+
+    expect(new JobFile(d).read()).toMatchObject({ direction: 'toUsdc' });
+  });
+});
+

--- a/web/src/api/queries.ts
+++ b/web/src/api/queries.ts
@@ -395,7 +395,7 @@ export function useAlerts() {
 
 export function useRebalance({ direction, amount }: { direction: RebalanceDirection; amount: number | null }) {
   const params = new URLSearchParams();
-  if (direction !== 'payDown') params.set('direction', direction);
+  if (direction !== 'toUsdc') params.set('direction', direction);
   if (amount !== null) params.set('amount', String(amount));
   const query = params.toString();
   return useQuery({

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -137,7 +137,7 @@ export interface CrossexAccount {
 // GET /api/rebalance · POST /api/rebalance · POST /api/rebalance/:id/{resume,abandon}
 // ---------------------------------------------------------------------------
 
-export type RebalanceDirection = 'payDown' | 'pull';
+export type RebalanceDirection = 'toUsdc' | 'toUsdt';
 
 export interface RebalanceBucket {
   coin: string;

--- a/web/src/components/BorrowChip.tsx
+++ b/web/src/components/BorrowChip.tsx
@@ -8,7 +8,7 @@ import { floorCents } from '../lib/ticks';
  * trader who never opens Balances still learns about the borrow. Click
  * opens Balances, where the Rebalance section pays it back. */
 export function BorrowChip({ onOpen }: { onOpen: () => void }) {
-  const { data } = useRebalance({ direction: 'payDown', amount: null });
+  const { data } = useRebalance({ direction: 'toUsdc', amount: null });
   const borrowed = borrowedBucket(data?.buckets);
   if (!borrowed) return null;
   const borrow = floorCents(borrowed.borrow);

--- a/web/src/panels/RebalanceSection.test.tsx
+++ b/web/src/panels/RebalanceSection.test.tsx
@@ -15,9 +15,9 @@ import { env, server } from '../test/server';
 import { renderWithClient } from '../test/utils';
 import { RebalanceSection } from './RebalanceSection';
 
-const PAY_DOWN_TEXT = 'Pays the USDC borrow back. Each USDC frees 0.20 initial and 0.10 maintenance margin.';
+const PAY_USDC_TEXT = 'Pays the USDC borrow back. Each USDC frees 0.20 initial and 0.10 maintenance margin.';
 const PAY_USDT_TEXT = 'Pays the USDT borrow back. Each USDT frees 0.20 initial and 0.10 maintenance margin.';
-const PULL_TEXT = 'Brings spare USDC home. Capped at what you own there, so it never borrows.';
+const HOME_TEXT = 'Brings spare USDC home. Capped at what you own there, so it never borrows.';
 /** A labelled fact's value, or null when the label is not on screen. */
 const fact = (label: string) => screen.queryByText(label, { selector: 'dt' })?.nextElementSibling?.textContent ?? null;
 const expectFacts = (facts: Record<string, string>) => {
@@ -31,10 +31,10 @@ const LOOP_FACTS = {
   Frees: '$450.00 margin',
   Saves: '$0.29 / day',
 };
-const PULL_FACTS = { Route: 'Spot loop · about 6.7 min', Sends: '400.00 USDC → 399.52 USDT @ 0.9988', Cost: '$0.60' };
+const TO_USDT_FACTS = { Route: 'Spot loop · about 6.7 min', Sends: '400.00 USDC → 399.52 USDT @ 0.9988', Cost: '$0.60' };
 const CONVERT_NOTE = 'Sends on a fresh quote within 30 bps of this one.';
 const HOLD = 'Hold to move 900.00 USDT → USDC';
-const PULL_HOLD = 'Hold to pull 400.00 USDC → USDT';
+const TO_USDT_HOLD = 'Hold to move 400.00 USDC → USDT';
 
 const usdc = (over: Partial<RebalanceBucket> = {}): RebalanceBucket => ({
   coin: 'USDC',
@@ -63,7 +63,7 @@ const usdt: RebalanceBucket = {
   interestPerDayUsd: 0,
 };
 
-const pullBuckets = [
+const toUsdtBuckets = [
   usdc({ cash: 400, upnl: 100, equity: 500, borrow: 0, imHeldUsd: 0, mmHeldUsd: 0, interestPaidUsd: 0, interestPerDayUsd: 0 }),
   usdt,
 ];
@@ -77,7 +77,7 @@ const route = (over: Partial<RebalanceRoute> = {}): RebalanceRoute => ({
 });
 
 const plan = (over: Partial<RebalancePlan> = {}): RebalancePlan => ({
-  direction: 'payDown',
+  direction: 'toUsdc',
   amount: 900,
   receives: 899.55,
   price: 1.0005,
@@ -90,9 +90,9 @@ const plan = (over: Partial<RebalancePlan> = {}): RebalancePlan => ({
   ...over,
 });
 
-const pullPlan = (over: Partial<RebalancePlan> = {}): RebalancePlan =>
+const toUsdtPlan = (over: Partial<RebalancePlan> = {}): RebalancePlan =>
   plan({
-    direction: 'pull',
+    direction: 'toUsdt',
     amount: 400,
     receives: 399.52,
     price: 0.9988,
@@ -137,7 +137,7 @@ const step = (name: string, over: Partial<RebalanceStep> = {}): RebalanceStep =>
 
 const job = (over: Partial<RebalanceJob> = {}): RebalanceJob => ({
   id: 'rb-1',
-  direction: 'payDown',
+  direction: 'toUsdc',
   route: 'loop',
   amount: 900,
   status: 'running',
@@ -188,13 +188,13 @@ function serve(answer: Answer) {
   return urls;
 }
 
-const byDirection = (payDown: RebalanceView, pull: RebalanceView) => (url: URL) =>
-  url.searchParams.get('direction') === 'pull' ? pull : payDown;
+const byDirection = (toUsdc: RebalanceView, toUsdt: RebalanceView) => (url: URL) =>
+  url.searchParams.get('direction') === 'toUsdt' ? toUsdt : toUsdc;
 
-const borrowAccount = () => byDirection(view(), view({ plan: noRoutePlan({ direction: 'pull' }) }));
+const borrowAccount = () => byDirection(view(), view({ plan: noRoutePlan({ direction: 'toUsdt' }) }));
 
-const pullAccount = () =>
-  byDirection(view({ buckets: pullBuckets, plan: noRoutePlan() }), view({ buckets: pullBuckets, plan: pullPlan() }));
+const toUsdtAccount = () =>
+  byDirection(view({ buckets: toUsdtBuckets, plan: noRoutePlan() }), view({ buckets: toUsdtBuckets, plan: toUsdtPlan() }));
 
 function refuseStart() {
   server.use(
@@ -223,10 +223,10 @@ function recordStarts() {
 
 const section = () => screen.findByRole('region', { name: 'Rebalance' });
 const amountInput = (label: string) => screen.getByRole('textbox', { name: label });
-const toPull = () => userEvent.click(screen.getByRole('radio', { name: 'Hyperliquid USDC → USDT' }));
+const pickToUsdt = () => userEvent.click(screen.getByRole('radio', { name: 'Hyperliquid USDC → USDT' }));
 
 /** The report's box, scaled to this account: $20k margin, $250k a leg, short
- * on Hyperliquid, 0.5% maintenance a leg. Liquidates at +64%; a $900 pay-down
+ * on Hyperliquid, 0.5% maintenance a leg. Liquidates at +64%; a $900 move to USDC
  * moves that to +64% still (900 of cover on a $250k leg is 0.4%). */
 const liquidationAccount = () => ({
   ...account,
@@ -380,12 +380,12 @@ describe('RebalanceSection', () => {
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    expect(screen.getByText(PAY_DOWN_TEXT)).toBeInTheDocument();
+    expect(screen.getByText(PAY_USDC_TEXT)).toBeInTheDocument();
 
-    await toPull();
+    await pickToUsdt();
 
-    expect(await screen.findByText(PULL_TEXT)).toBeInTheDocument();
-    expect(screen.queryByText(PAY_DOWN_TEXT)).toBeNull();
+    expect(await screen.findByText(HOME_TEXT)).toBeInTheDocument();
+    expect(screen.queryByText(PAY_USDC_TEXT)).toBeNull();
   });
 
   it('opens the what-and-why card from the info mark next to the title', async () => {
@@ -408,31 +408,31 @@ describe('RebalanceSection', () => {
     await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull());
   });
 
-  it('defaults the direction to pull when there is no borrow and USDC can be pulled', async () => {
-    const urls = serve(pullAccount());
+  it('defaults the direction to USDT when there is no borrow and there is spare USDC', async () => {
+    const urls = serve(toUsdtAccount());
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
     expect(urls[0].searchParams.has('direction')).toBe(false);
     expect(await screen.findByRole('radio', { name: 'Hyperliquid USDC → USDT', checked: true })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'USDT → Hyperliquid USDC' })).not.toBeChecked();
-    await waitFor(() => expect(urls.at(-1)?.searchParams.get('direction')).toBe('pull'));
-    expect(await screen.findByRole('button', { name: PULL_HOLD })).toBeInTheDocument();
+    await waitFor(() => expect(urls.at(-1)?.searchParams.get('direction')).toBe('toUsdt'));
+    expect(await screen.findByRole('button', { name: TO_USDT_HOLD })).toBeInTheDocument();
   });
 
   it('re-reads the plan and resets the input when the direction toggles', async () => {
-    const urls = serve(pullAccount());
+    const urls = serve(toUsdtAccount());
     renderWithClient(<RebalanceSection holdMs={50} />);
 
-    await screen.findByRole('button', { name: PULL_HOLD });
+    await screen.findByRole('button', { name: TO_USDT_HOLD });
     expect(screen.getByRole('radiogroup', { name: 'Direction' })).toBeInTheDocument();
-    const pullInput = amountInput('Amount (USDC) · free 400.00');
-    expect(pullInput).toHaveValue('400.00');
-    expect(screen.getByText(PULL_TEXT)).toBeInTheDocument();
-    expectFacts(PULL_FACTS);
-    await userEvent.clear(pullInput);
-    await userEvent.type(pullInput, '77');
-    expect(pullInput).toHaveValue('77');
+    const usdcInput = amountInput('Amount (USDC) · free 400.00');
+    expect(usdcInput).toHaveValue('400.00');
+    expect(screen.getByText(HOME_TEXT)).toBeInTheDocument();
+    expectFacts(TO_USDT_FACTS);
+    await userEvent.clear(usdcInput);
+    await userEvent.type(usdcInput, '77');
+    expect(usdcInput).toHaveValue('77');
 
     await userEvent.click(screen.getByRole('radio', { name: 'USDT → Hyperliquid USDC' }));
 
@@ -440,18 +440,18 @@ describe('RebalanceSection', () => {
     expect(screen.getByRole('radio', { name: 'USDT → Hyperliquid USDC' })).toBeChecked();
     const input = await screen.findByRole('textbox', { name: 'Amount (USDT) · free 5,000.00' });
     await waitFor(() => expect(input).toHaveValue('0.00'));
-    expect(screen.getByText(PAY_DOWN_TEXT)).toBeInTheDocument();
+    expect(screen.getByText(PAY_USDC_TEXT)).toBeInTheDocument();
     expect(fact('Sends')).toBeNull();
     expect(screen.getByText('Nothing to pay back. There is no USDC borrow on Hyperliquid.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
 
-    await toPull();
+    await pickToUsdt();
 
-    await waitFor(() => expect(urls.at(-1)?.searchParams.get('direction')).toBe('pull'));
+    await waitFor(() => expect(urls.at(-1)?.searchParams.get('direction')).toBe('toUsdt'));
     expect(await screen.findByRole('textbox', { name: 'Amount (USDC) · free 400.00' })).toHaveValue('400.00');
-    expect(screen.getByText(PULL_TEXT)).toBeInTheDocument();
-    await waitFor(() => expectFacts(PULL_FACTS));
-    expect(screen.getByRole('button', { name: PULL_HOLD })).toBeInTheDocument();
+    expect(screen.getByText(HOME_TEXT)).toBeInTheDocument();
+    await waitFor(() => expectFacts(TO_USDT_FACTS));
+    expect(screen.getByRole('button', { name: TO_USDT_HOLD })).toBeInTheDocument();
   });
 
   it('prefills the amount and re-reads the plan with the typed amount after 300 ms', async () => {
@@ -521,7 +521,7 @@ describe('RebalanceSection', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: HOLD })).toBeEnabled());
   });
 
-  it('shows the pull amount label with the smaller of cash and equity', async () => {
+  it('shows the USDC amount label with the smaller of cash and equity', async () => {
     serve(view({ buckets: [usdc({ cash: 600, upnl: -150, equity: 450, borrow: 0 }), usdt], plan: noRoutePlan() }));
     renderWithClient(<RebalanceSection holdMs={50} />);
 
@@ -555,23 +555,23 @@ describe('RebalanceSection', () => {
     expect(screen.getByText(CONVERT_NOTE)).toBeInTheDocument();
   });
 
-  it('shows the quote line for a pull', async () => {
-    serve(pullAccount());
+  it('shows the quote line for a move to USDT', async () => {
+    serve(toUsdtAccount());
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    await waitFor(() => expectFacts(PULL_FACTS));
+    await waitFor(() => expectFacts(TO_USDT_FACTS));
     expect(fact('Borrow after')).toBeNull();
   });
 
-  it('shows the quote line for a pull by convert and posts route convert', async () => {
-    const convertPull = pullPlan({
+  it('shows the quote line for a move to USDT by convert and posts route convert', async () => {
+    const convertToUsdt = toUsdtPlan({
       route: 'convert',
       price: 0.998,
       receives: 399.2,
       routes: { loop: route({ costUsd: 1.4, waitSeconds: 400 }), convert: route({ costUsd: 0.8, waitSeconds: 0 }) },
     });
-    serve(byDirection(view({ buckets: pullBuckets, plan: noRoutePlan() }), view({ buckets: pullBuckets, plan: convertPull })));
+    serve(byDirection(view({ buckets: toUsdtBuckets, plan: noRoutePlan() }), view({ buckets: toUsdtBuckets, plan: convertToUsdt })));
     const posts = recordStarts();
     renderWithClient(<RebalanceSection holdMs={50} />);
 
@@ -581,9 +581,9 @@ describe('RebalanceSection', () => {
     );
     expect(fact('Borrow after')).toBeNull();
     expect(screen.getByText(CONVERT_NOTE)).toBeInTheDocument();
-    fireEvent.pointerDown(screen.getByRole('button', { name: PULL_HOLD }));
+    fireEvent.pointerDown(screen.getByRole('button', { name: TO_USDT_HOLD }));
 
-    await waitFor(() => expect(posts).toEqual([{ direction: 'pull', amount: 400, route: 'convert' }]));
+    await waitFor(() => expect(posts).toEqual([{ direction: 'toUsdt', amount: 400, route: 'convert' }]));
   });
 
   it('hides the hold and the quote line under 1 USDC and says why, for either direction', async () => {
@@ -600,11 +600,11 @@ describe('RebalanceSection', () => {
     unmount();
 
     const spare = usdc({ cash: 0.5, upnl: 0, equity: 0.5, borrow: 0, imHeldUsd: 0, mmHeldUsd: 0 });
-    serve(view({ buckets: [spare, usdt], plan: pullPlan({ amount: 0.5, route: 'convert', receives: 0.49, price: 0.998 }) }));
+    serve(view({ buckets: [spare, usdt], plan: toUsdtPlan({ amount: 0.5, route: 'convert', receives: 0.49, price: 0.998 }) }));
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    expect(await screen.findByText('Nothing to pull. Spare USDC is under 1 USDC.')).toBeInTheDocument();
+    expect(await screen.findByText('Nothing to move. Spare USDC is under 1 USDC.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
     expect(screen.queryByText(/^via /)).toBeNull();
   });
@@ -662,17 +662,17 @@ describe('RebalanceSection', () => {
     expect(amountInput('Amount (USDT) · free 5,000.00')).toHaveValue('900.00');
   });
 
-  it('shows one plain line for a pull with no route and never the convert reason', async () => {
+  it('shows one plain line for a move to USDT with no route and never the convert reason', async () => {
     serve(
       view({
         buckets: [usdc({ cash: 1.29, upnl: 0, equity: 1.29, borrow: 0, imHeldUsd: 0, mmHeldUsd: 0 }), usdt],
-        plan: pullPlan({
+        plan: toUsdtPlan({
           amount: 1.29,
           receives: 0,
           price: null,
           route: null,
           routes: {
-            loop: route({ available: false, reason: 'Too small to pull. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Pull at least 12 USDC.' }),
+            loop: route({ available: false, reason: 'Too small to move. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Move at least 12 USDC.' }),
             convert: route({ costUsd: 0, waitSeconds: 0, available: false, reason: 'Convert runs only from USDT to USDC.' }),
           },
         }),
@@ -681,7 +681,7 @@ describe('RebalanceSection', () => {
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
-    expect(await screen.findByText('Too small to pull. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Pull at least 12 USDC.')).toBeInTheDocument();
+    expect(await screen.findByText('Too small to move. Gate takes a flat $1 fee on the way out and needs at least 11 USDC to arrive. Move at least 12 USDC.')).toBeInTheDocument();
     expect(screen.queryByText(/Convert runs only/)).toBeNull();
     expect(screen.queryByText(/^Loop:/)).toBeNull();
     expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
@@ -695,19 +695,19 @@ describe('RebalanceSection', () => {
     const btn = await screen.findByRole('button', { name: HOLD });
     fireEvent.pointerDown(btn);
 
-    await waitFor(() => expect(posts).toEqual([{ direction: 'payDown', amount: 900, route: 'loop' }]));
+    await waitFor(() => expect(posts).toEqual([{ direction: 'toUsdc', amount: 900, route: 'loop' }]));
     await new Promise((r) => setTimeout(r, 200));
     expect(posts).toHaveLength(1);
   });
 
-  it('posts direction pull after a full hold in the pull direction', async () => {
-    serve(pullAccount());
+  it('posts direction toUsdt after a full hold toward USDT', async () => {
+    serve(toUsdtAccount());
     const posts = recordStarts();
     renderWithClient(<RebalanceSection holdMs={50} />);
 
-    fireEvent.pointerDown(await screen.findByRole('button', { name: PULL_HOLD }));
+    fireEvent.pointerDown(await screen.findByRole('button', { name: TO_USDT_HOLD }));
 
-    await waitFor(() => expect(posts).toEqual([{ direction: 'pull', amount: 400, route: 'loop' }]));
+    await waitFor(() => expect(posts).toEqual([{ direction: 'toUsdt', amount: 400, route: 'loop' }]));
   });
 
   it('shows the 409 message when the start is refused', async () => {
@@ -735,7 +735,7 @@ describe('RebalanceSection', () => {
     expect(screen.queryByRole('alert')).toBeNull();
   }, 10_000);
 
-  it('renders nothing with borrow 0, nothing to pull, and no job', async () => {
+  it('renders nothing with borrow 0, nothing to move, and no job', async () => {
     const urls = serve(view({ buckets: [usdc({ cash: 0, upnl: 0, equity: 0, borrow: 0 }), usdt], plan: noRoutePlan() }));
     renderWithClient(<RebalanceSection holdMs={50} />);
 
@@ -743,7 +743,7 @@ describe('RebalanceSection', () => {
     expect(screen.queryByRole('region', { name: 'Rebalance' })).toBeNull();
   });
 
-  it('stays rendered when the borrow and the pullable amount both floor to 0 but the bucket is in use', async () => {
+  it('stays rendered when the borrow and the spareUsdc amount both floor to 0 but the bucket is in use', async () => {
     const onTheLine = usdc({ cash: 16.65, upnl: -16.646, equity: 0.004, borrow: 0, imHeldUsd: 0, mmHeldUsd: 0 });
     serve(view({ buckets: [onTheLine, usdt], plan: noRoutePlan() }));
     renderWithClient(<RebalanceSection holdMs={50} />);
@@ -754,8 +754,8 @@ describe('RebalanceSection', () => {
     expect(screen.getByText('Nothing to pay back. There is no USDC borrow on Hyperliquid.')).toBeInTheDocument();
   });
 
-  it('renders with borrow 0 when USDC can be pulled, without the pill', async () => {
-    serve(pullAccount());
+  it('renders with borrow 0 and spare USDC, without the pill', async () => {
+    serve(toUsdtAccount());
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
@@ -764,7 +764,7 @@ describe('RebalanceSection', () => {
     expectFacts({ 'Lent by Gate': '0.00', 'Spare USDC on Hyperliquid': '400.00 USDC' });
   });
 
-  it('renders with borrow 0 and nothing to pull while a job runs', async () => {
+  it('renders with borrow 0 and nothing to move while a job runs', async () => {
     serve(view({ buckets: [usdc({ cash: 0, upnl: 0, equity: 0, borrow: 0 }), usdt], plan: noRoutePlan(), job: job() }));
     renderWithClient(<RebalanceSection holdMs={50} />);
 
@@ -905,15 +905,15 @@ describe('RebalanceSection', () => {
     const done = job({ status: 'done' });
     serve(
       byDirection(
-        view({ buckets: pullBuckets, plan: noRoutePlan(), job: done }),
-        view({ buckets: pullBuckets, plan: pullPlan(), job: done }),
+        view({ buckets: toUsdtBuckets, plan: noRoutePlan(), job: done }),
+        view({ buckets: toUsdtBuckets, plan: toUsdtPlan(), job: done }),
       ),
     );
 
     expect(
       await screen.findByRole('radio', { name: 'Hyperliquid USDC → USDT', checked: true }, { timeout: 5_000 }),
     ).toBeInTheDocument();
-    expect(await screen.findByRole('button', { name: PULL_HOLD })).toBeEnabled();
+    expect(await screen.findByRole('button', { name: TO_USDT_HOLD })).toBeEnabled();
     expect(amountInput('Amount (USDC) · free 400.00')).toHaveValue('400.00');
     expect(screen.queryByText(/^Borrowing /)).toBeNull();
   }, 10_000);
@@ -935,11 +935,11 @@ describe('RebalanceSection — a USDT borrow', () => {
     interestPerDayUsd: 0,
   };
   const repayPlan = (over: Partial<RebalancePlan> = {}) =>
-    pullPlan({ amount: 300, receives: 298.7, borrowAfterUsd: 1.3, marginFreedUsd: 59.74, savesPerDayUsd: 0, ...over });
-  const usdtBorrowAccount = (pull: RebalancePlan = repayPlan()) =>
+    toUsdtPlan({ amount: 300, receives: 298.7, borrowAfterUsd: 1.3, marginFreedUsd: 59.74, savesPerDayUsd: 0, ...over });
+  const usdtBorrowAccount = (toUsdt: RebalancePlan = repayPlan()) =>
     byDirection(
       view({ buckets: [spareUsdc, usdtBorrowed], plan: noRoutePlan() }),
-      view({ buckets: [spareUsdc, usdtBorrowed], plan: pull }),
+      view({ buckets: [spareUsdc, usdtBorrowed], plan: toUsdt }),
     );
 
   beforeEach(() => {
@@ -949,11 +949,11 @@ describe('RebalanceSection — a USDT borrow', () => {
     );
   });
 
-  it('defaults to the pull, reads it as a repayment, and shows the USDT borrow in the pill and the facts', async () => {
+  it('defaults to the toUsdt, reads it as a repayment, and shows the USDT borrow in the pill and the facts', async () => {
     serve(usdtBorrowAccount());
     renderWithClient(<RebalanceSection holdMs={50} />);
 
-    expect(await screen.findByRole('button', { name: 'Hold to pull 300.00 USDC → USDT' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Hold to move 300.00 USDC → USDT' })).toBeInTheDocument();
     expect(screen.getByText('Borrowing 300.00 USDT')).toHaveClass('border-amber-500/30');
     expect(screen.getByText(PAY_USDT_TEXT)).toBeInTheDocument();
     expectFacts({
@@ -966,11 +966,11 @@ describe('RebalanceSection — a USDT borrow', () => {
     });
   });
 
-  it('quotes the pull with the borrow after, the margin it frees, and the interest it saves', async () => {
+  it('quotes the move to USDT with the borrow after, the margin it frees, and the interest it saves', async () => {
     serve(usdtBorrowAccount());
     renderWithClient(<RebalanceSection holdMs={50} />);
 
-    await screen.findByRole('button', { name: 'Hold to pull 300.00 USDC → USDT' });
+    await screen.findByRole('button', { name: 'Hold to move 300.00 USDC → USDT' });
     expectFacts({
       Route: 'Spot loop · about 6.7 min',
       Sends: '300.00 USDC → 298.70 USDT @ 0.9988',
@@ -984,7 +984,7 @@ describe('RebalanceSection — a USDT borrow', () => {
     serve(usdtBorrowAccount(repayPlan({ amount: 100, receives: 98.9, shortfall: { reason: 'spare', remaining: 200 } })));
     renderWithClient(<RebalanceSection holdMs={50} />);
 
-    await screen.findByRole('button', { name: 'Hold to pull 100.00 USDC → USDT' });
+    await screen.findByRole('button', { name: 'Hold to move 100.00 USDC → USDT' });
     expect(
       screen.getByText('Only 100.00 USDC can move. 200.00 USDT stays borrowed: there is no more spare USDC on Hyperliquid'),
     ).toHaveClass('text-amber-300');
@@ -992,21 +992,21 @@ describe('RebalanceSection — a USDT borrow', () => {
 
   it('shows the section for a USDT borrow even when the USDC wallet is empty', async () => {
     const empty = usdc({ cash: 0, upnl: 0, equity: 0, borrow: 0, imHeldUsd: 0, mmHeldUsd: 0, interestPaidUsd: 0, interestPerDayUsd: 0 });
-    serve(view({ buckets: [empty, usdtBorrowed], plan: noRoutePlan({ direction: 'pull' }) }));
+    serve(view({ buckets: [empty, usdtBorrowed], plan: noRoutePlan({ direction: 'toUsdt' }) }));
     renderWithClient(<RebalanceSection holdMs={50} />);
 
     await section();
     expect(screen.getByText('Borrowing 300.00 USDT')).toBeInTheDocument();
-    expect(screen.getByText('Nothing to pull. There is no spare USDC on Hyperliquid.')).toBeInTheDocument();
+    expect(screen.getByText('Nothing to move. There is no spare USDC on Hyperliquid.')).toBeInTheDocument();
   });
 
-  it('keeps the USDC direction a plain pay-down when the USDT borrow is the only one', async () => {
+  it('keeps the USDC direction a plain repayment when the USDT borrow is the only one', async () => {
     serve(usdtBorrowAccount());
     renderWithClient(<RebalanceSection holdMs={50} />);
 
-    await screen.findByRole('button', { name: 'Hold to pull 300.00 USDC → USDT' });
+    await screen.findByRole('button', { name: 'Hold to move 300.00 USDC → USDT' });
     fireEvent.click(screen.getByRole('radio', { name: 'USDT → Hyperliquid USDC' }));
     expect(await screen.findByText('Nothing to pay back. There is no USDC borrow on Hyperliquid.')).toBeInTheDocument();
-    expect(screen.getByText(PAY_DOWN_TEXT)).toBeInTheDocument();
+    expect(screen.getByText(PAY_USDC_TEXT)).toBeInTheDocument();
   });
 });

--- a/web/src/panels/RebalanceSection.tsx
+++ b/web/src/panels/RebalanceSection.tsx
@@ -12,8 +12,8 @@ import { fmtLinePrice, fmtMove, lineFor, liquidationLines, nearestLiquidation, t
 import { floorCents, roundToStep } from '../lib/ticks';
 import { useNow } from '../lib/useNow';
 
-const PULL_STEP_SECONDS = 390;
-/** Under this the hold is hidden: a few-cent convert or a pull that the $1 fee eats is never worth a hold. */
+const FROM_HYPERLIQUID_SECONDS = 390;
+/** Under this the hold is hidden: a few-cent convert or a move to USDT that the $1 fee eats is never worth a hold. */
 const MIN_AMOUNT = 1;
 /** Gate charges interest on the borrow only past this. Server: INTEREST_THRESHOLD in core/rebalance/plan.ts. */
 const INTEREST_FREE_UNTIL = 10_000;
@@ -23,15 +23,15 @@ const EXPECTED_SECONDS: Record<string, number> = {
   'To spot': 5,
   'To Hyperliquid': 127,
   Convert: 2,
-  'Pull from Hyperliquid': PULL_STEP_SECONDS,
+  'From Hyperliquid': FROM_HYPERLIQUID_SECONDS,
   'To Gate': 6,
   'Sell USDC': 2,
 };
 
 /** One line under the direction toggle. The long form is in the info card.
- * A pull reads as a repayment when the USDT wallet is the borrowed one. */
+ * The move to USDT reads as a repayment when the USDT wallet is the borrowed one. */
 function explanation(direction: RebalanceDirection, usdtBorrowed: boolean): string {
-  if (direction === 'payDown') return 'Pays the USDC borrow back. Each USDC frees 0.20 initial and 0.10 maintenance margin.';
+  if (direction === 'toUsdc') return 'Pays the USDC borrow back. Each USDC frees 0.20 initial and 0.10 maintenance margin.';
   if (usdtBorrowed) return 'Pays the USDT borrow back. Each USDT frees 0.20 initial and 0.10 maintenance margin.';
   return 'Brings spare USDC home. Capped at what you own there, so it never borrows.';
 }
@@ -79,8 +79,8 @@ const ABOUT = (
 );
 
 const DIRECTION_OPTIONS: { value: RebalanceDirection; label: string }[] = [
-  { value: 'payDown', label: 'USDT → Hyperliquid USDC' },
-  { value: 'pull', label: 'Hyperliquid USDC → USDT' },
+  { value: 'toUsdc', label: 'USDT → Hyperliquid USDC' },
+  { value: 'toUsdt', label: 'Hyperliquid USDC → USDT' },
 ];
 
 const SHORTFALL_TEXT = {
@@ -116,7 +116,7 @@ function parseAmount(text: string): number | null {
 function quoteFacts(
   plan: RebalancePlan,
   routeName: 'loop' | 'convert',
-  pull: boolean,
+  toUsdt: boolean,
   repays: boolean,
   liquidation: string | null,
 ): Fact[] {
@@ -127,7 +127,7 @@ function quoteFacts(
     { label: 'Route', value: convert ? 'Convert · instant' : `Spot loop · about ${num(route.waitSeconds / 60, 1)} min` },
     {
       label: 'Sends',
-      value: pull
+      value: toUsdt
         ? `${num(plan.amount, 2)} USDC → ${num(plan.receives, 2)} USDT @ ${price}`
         : `${num(plan.amount, 2)} USDT → ${num(plan.receives, 2)} USDC @ ${price}`,
     },
@@ -153,14 +153,14 @@ function liquidationShift(
   acc: ReturnType<typeof useAccount>['data'],
   positions: ReturnType<typeof usePositions>['data'],
   plan: RebalancePlan,
-  pull: boolean,
+  toUsdt: boolean,
 ): string | null {
   const before = nearestLiquidation(acc, positions);
   if (!before || !acc || !positions) return null;
   const view = liquidationLines(
     acc,
     positions,
-    pull
+    toUsdt
       ? { 'USDC/HYPERLIQUID': -plan.amount, 'USDT/CROSSEX': plan.receives }
       : { 'USDC/HYPERLIQUID': plan.receives, 'USDT/CROSSEX': -plan.amount },
   );
@@ -176,7 +176,7 @@ function situationFacts(
   usdc: RebalanceBucket | undefined,
   usdt: RebalanceBucket | undefined,
   borrowed: RebalanceBucket | null,
-  pullable: number,
+  spareUsdc: number,
 ): Fact[] {
   const borrow = borrowed ? floorCents(borrowed.borrow) : 0;
   const interest = !borrowed
@@ -189,24 +189,24 @@ function situationFacts(
     { label: 'Initial margin held', value: fmtUsd(borrowed?.imHeldUsd ?? 0) },
     { label: 'Maintenance margin held', value: fmtUsd(borrowed?.mmHeldUsd ?? 0) },
     { label: 'Interest', value: interest },
-    { label: 'Spare USDC on Hyperliquid', value: `${num(pullable, 2)} USDC` },
+    { label: 'Spare USDC on Hyperliquid', value: `${num(spareUsdc, 2)} USDC` },
     { label: 'Interest paid · all time', value: fmtUsd((usdc?.interestPaidUsd ?? 0) + (usdt?.interestPaidUsd ?? 0)) },
   ];
 }
 
-function noRouteLine(plan: RebalancePlan, pull: boolean, borrow: number, free: number): { text: string; warn: boolean } {
+function noRouteLine(plan: RebalancePlan, toUsdt: boolean, borrow: number, free: number): { text: string; warn: boolean } {
   const reason = plan.routes.loop.reason;
   if (reason && reason !== 'nothing to move') return { text: reason, warn: true };
-  if (pull) {
-    return { text: free > 0 ? 'Nothing to pull.' : 'Nothing to pull. There is no spare USDC on Hyperliquid.', warn: false };
+  if (toUsdt) {
+    return { text: free > 0 ? 'Nothing to move.' : 'Nothing to move. There is no spare USDC on Hyperliquid.', warn: false };
   }
   if (borrow === 0) return { text: 'Nothing to pay back. There is no USDC borrow on Hyperliquid.', warn: false };
   if (free === 0) return { text: 'Nothing to move. There is no free USDT.', warn: false };
   return { text: 'Nothing to move.', warn: false };
 }
 
-function tooSmallLine(pull: boolean, borrow: number): string {
-  if (pull) return `Nothing to pull. Spare USDC is under ${MIN_AMOUNT} USDC.`;
+function tooSmallLine(toUsdt: boolean, borrow: number): string {
+  if (toUsdt) return `Nothing to move. Spare USDC is under ${MIN_AMOUNT} USDC.`;
   if (borrow < MIN_AMOUNT) return `Nothing to pay back. The borrow is under ${MIN_AMOUNT} USDC.`;
   return `Under ${MIN_AMOUNT} USDT can move. Free USDT or margin is too low.`;
 }
@@ -268,7 +268,7 @@ function errorLine(error: Error | null) {
 
 export function RebalanceSection({ holdMs }: { holdMs?: number }) {
   const [chosen, setChosen] = useState<RebalanceDirection | null>(null);
-  const direction = chosen ?? 'payDown';
+  const direction = chosen ?? 'toUsdc';
   const [typed, setTyped] = useState<string | null>(null);
   const [blurred, setBlurred] = useState(false);
   const [amountParam, setAmountParam] = useState<number | null>(null);
@@ -293,18 +293,18 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
   const borrowed = borrowedBucket(data?.buckets);
   const borrow = floorCents(usdc?.borrow ?? 0);
   const usdtBorrowed = borrowed?.venue === 'CROSSEX';
-  const pullable = Math.max(0, floorCents(Math.min(usdc?.cash ?? 0, usdc?.equity ?? 0)));
+  const spareUsdc = Math.max(0, floorCents(Math.min(usdc?.cash ?? 0, usdc?.equity ?? 0)));
   const job = data?.job && (data.job.status === 'running' || data.job.status === 'halted') ? data.job : null;
 
   /* Default to the direction that repays the borrow; with none, to bringing
      spare USDC home when there is any. */
   useEffect(() => {
     if (chosen !== null || !data) return;
-    setChosen(borrow >= MIN_AMOUNT ? 'payDown' : usdtBorrowed || pullable > 0 ? 'pull' : 'payDown');
-  }, [chosen, data, borrow, usdtBorrowed, pullable]);
+    setChosen(borrow >= MIN_AMOUNT ? 'toUsdc' : usdtBorrowed || spareUsdc > 0 ? 'toUsdt' : 'toUsdc');
+  }, [chosen, data, borrow, usdtBorrowed, spareUsdc]);
 
-  /* A finished job leaves the bucket on the other side: a pay-down leaves
-     spare USDC, a pull leaves nothing. Go back to the default direction and
+  /* A finished job leaves the bucket on the other side: a move to USDC leaves
+     spare USDC, a move to USDT leaves nothing. Go back to the default direction and
      a fresh input, so the section reads for what is now possible. */
   const activeJobId = job?.id ?? null;
   const lastActive = useRef<string | null>(null);
@@ -336,7 +336,7 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
   }
 
   /* Presence must not depend on cents. Both directions end with the bucket's
-     equity near zero, where unrealised PnL flips the borrow and the pullable
+     equity near zero, where unrealised PnL flips the borrow and the spareUsdc
      amount between 0.00 and a few cents on every poll. Show the section for
      any Hyperliquid USDC activity at all; the floor lines say what is
      possible. */
@@ -345,9 +345,9 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
   if (!active) return null;
 
   const plan = data.plan;
-  const pull = direction === 'pull';
-  const repays = pull ? usdtBorrowed : borrow >= MIN_AMOUNT;
-  const situation = situationFacts(usdc, usdt, borrowed, pullable);
+  const toUsdt = direction === 'toUsdt';
+  const repays = toUsdt ? usdtBorrowed : borrow >= MIN_AMOUNT;
+  const situation = situationFacts(usdc, usdt, borrowed, spareUsdc);
 
   const pickDirection = (next: RebalanceDirection) => {
     setChosen(next);
@@ -385,7 +385,7 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
     const showEnter = blurred && invalid;
     const settled = !query.isPlaceholderData && amountParam === typedAmount;
     const capped = settled && typedAmount !== null && floorCents(typedAmount) > plan.amount;
-    const free = pull ? pullable : floorCents(usdt?.cash ?? 0);
+    const free = toUsdt ? spareUsdc : floorCents(usdt?.cash ?? 0);
     const routeName = plan.route;
     const floorHit = settled && routeName !== null && plan.amount < MIN_AMOUNT;
     const capTooSmall = floorHit && (typedAmount === null || floorCents(typedAmount) > plan.amount);
@@ -404,7 +404,7 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
           </div>
           <div className="flex min-w-[16rem] flex-1 flex-col gap-1">
             <label htmlFor="rebalance-amount" className="text-[11px] text-ink-400">
-              {`Amount (${pull ? 'USDC' : 'USDT'}) · free ${num(free, 2)}`}
+              {`Amount (${toUsdt ? 'USDC' : 'USDT'}) · free ${num(free, 2)}`}
             </label>
             <input
               id="rebalance-amount"
@@ -424,8 +424,8 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
               disabled={start.isPending || invalid || !settled}
               onConfirm={() => start.mutate({ direction, amount: plan.amount, route: routeName })}
             >
-              {pull
-                ? `Hold to pull ${num(plan.amount, 2)} USDC → USDT`
+              {toUsdt
+                ? `Hold to move ${num(plan.amount, 2)} USDC → USDT`
                 : `Hold to move ${num(plan.amount, 2)} USDT → USDC`}
             </HoldToConfirmButton>
           )}
@@ -437,27 +437,27 @@ export function RebalanceSection({ holdMs }: { holdMs?: number }) {
         )}
         {typedTooSmall && (
           <p role="alert" className="text-[11px] text-rose-300">
-            {`Enter at least ${MIN_AMOUNT} ${pull ? 'USDC' : 'USDT'}`}
+            {`Enter at least ${MIN_AMOUNT} ${toUsdt ? 'USDC' : 'USDT'}`}
           </p>
         )}
         {capped && !floorHit && <p className="text-[11px] text-amber-300">Capped at {num(plan.amount, 2)}</p>}
-        {capTooSmall && <p className="text-[12px] text-ink-300">{tooSmallLine(pull, borrow)}</p>}
+        {capTooSmall && <p className="text-[12px] text-ink-300">{tooSmallLine(toUsdt, borrow)}</p>}
         {floorHit ? null : routeName ? (
           <>
-            <Facts items={quoteFacts(plan, routeName, pull, repays, liquidationShift(account, positions, plan, pull))} />
+            <Facts items={quoteFacts(plan, routeName, toUsdt, repays, liquidationShift(account, positions, plan, toUsdt))} />
             {routeName === 'convert' && (
               <p className="text-[11px] text-ink-500">Sends on a fresh quote within 30 bps of this one.</p>
             )}
             {plan.shortfall && (
               <p className="text-[12px] text-amber-300">
-                {`Only ${num(plan.amount, 2)} USDC can move. ${num(plan.shortfall.remaining, 2)} ${pull ? 'USDT' : 'USDC'} stays borrowed: ${SHORTFALL_TEXT[plan.shortfall.reason]}`}
+                {`Only ${num(plan.amount, 2)} USDC can move. ${num(plan.shortfall.remaining, 2)} ${toUsdt ? 'USDT' : 'USDC'} stays borrowed: ${SHORTFALL_TEXT[plan.shortfall.reason]}`}
               </p>
             )}
             {errorLine(start.error)}
           </>
         ) : (
           (() => {
-            const line = noRouteLine(plan, pull, borrow, free);
+            const line = noRouteLine(plan, toUsdt, borrow, free);
             return <p className={`text-[12px] ${line.warn ? 'text-amber-300' : 'text-ink-300'}`}>{line.text}</p>;
           })()
         )}

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -719,7 +719,7 @@ export function makeRebalanceView(over: Partial<RebalanceView> = {}): RebalanceV
   return {
     buckets: [],
     plan: {
-      direction: 'payDown',
+      direction: 'toUsdc',
       amount: 0,
       receives: 0,
       price: null,


### PR DESCRIPTION
## TLDR

The two directions of a rebalance were named for one situation each: `payDown` and `pull`. With either wallet able to be the borrowed one, those names are wrong half the time. Everything is now named for where the cash lands: `toUsdc` and `toUsdt`. On screen the last five strings that said "pull" now say "move", and the first step of the USDT route is `From Hyperliquid`. The line under the toggle already says what the move does in the current state, so nothing is lost.

Old names are still read: a job file written by the previous build resumes, and a tab still running the old bundle for a moment after an update is not flipped.

## What changed

- `Direction` is `'toUsdc' | 'toUsdt'` on the server, the API, the job file, and the web. The step lists, wait constants, and the $1 fee constant are named for the same thing: `TO_USDC_STEPS`, `TO_USDT_WAIT_SECONDS`, `HYPERLIQUID_WITHDRAW_FEE_USD`.
- On screen: `Hold to move 300.00 USDC → USDT`, `Nothing to move.`, `Nothing to move. Spare USDC is under 1 USDC.`, `Too small to move. … Move at least 12 USDC.`, and the step `From Hyperliquid` in the progress bar.
- `parseJob` maps `pull` and `payDown` to the new names and `Pull from Hyperliquid` to `From Hyperliquid` on read. The runner looks steps up by name, so without this a halted job from the previous build would halt again with `unknown step`.
- `directionOf` on the routes accepts `pull` as `toUsdt`. A POST with the old name must not start a move the other way.
- The user guide, the changelog, and the test brief say "toward USDC" and "toward USDT" where they said pay-down and pull.

## MUST DO BEFORE DEPLOY

Nothing. A `rebalance.json` from the previous build reads and resumes.

## Review focus

- `src/server/rebalanceJob.ts:48` — the two legacy maps and where `parseJob` applies them, before the validation that would reject the old names.
- `src/server/routes/rebalance.ts:21` — the API accepting the old value, and the comment that says why.
- `src/core/rebalance/plan.ts:247` — the reworded reason string.

## Test evidence

```
yarn verify
```

| Step | Result |
|---|---|
| `yarn typecheck` | pass |
| `yarn test` (unit + server) | 62 files, 1048 tests passed, exit 0 |
| `yarn --cwd web typecheck` | pass |
| `yarn --cwd web test` | 50 files, 749 tests passed, exit 0 |

New tests: a job file with `direction: pull` and a `Pull from Hyperliquid` step reads as `toUsdt` with `From Hyperliquid`; one with `payDown` reads as `toUsdc`; the API reads `?direction=pull` as `toUsdt` and `payDown` as `toUsdc`. Every other test was renamed with the code and passes unchanged in substance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkyjuJDutqYm5BdM9h9gEj
