### PR TITLE
Say "Nothing to move" for the USDT → USDC empty states too

### DIFF
--- a/web/src/panels/RebalanceSection.test.tsx
+++ b/web/src/panels/RebalanceSection.test.tsx
@@ -442,7 +442,7 @@ describe('RebalanceSection', () => {
     await waitFor(() => expect(input).toHaveValue('0.00'));
     expect(screen.getByText(PAY_USDC_TEXT)).toBeInTheDocument();
     expect(fact('Sends')).toBeNull();
-    expect(screen.getByText('Nothing to pay back. There is no USDC borrow on Hyperliquid.')).toBeInTheDocument();
+    expect(screen.getByText('Nothing to move. There is no USDC borrow on Hyperliquid.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
 
     await pickToUsdt();
@@ -593,7 +593,7 @@ describe('RebalanceSection', () => {
 
     await section();
     expect(screen.queryByText(/^Borrowing /)).toBeNull();
-    expect(screen.getByText('Nothing to pay back. The borrow is under 1 USDC.')).toBeInTheDocument();
+    expect(screen.getByText('Nothing to move. The USDC borrow is under 1 USDC.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^Hold to/ })).toBeNull();
     expect(screen.queryByText(/^via /)).toBeNull();
     expect(screen.getByRole('radiogroup', { name: 'Direction' })).toBeInTheDocument();
@@ -751,7 +751,7 @@ describe('RebalanceSection', () => {
     await section();
     expect(screen.queryByText(/^Borrowing /)).toBeNull();
     expect(screen.getByRole('radiogroup', { name: 'Direction' })).toBeInTheDocument();
-    expect(screen.getByText('Nothing to pay back. There is no USDC borrow on Hyperliquid.')).toBeInTheDocument();
+    expect(screen.getByText('Nothing to move. There is no USDC borrow on Hyperliquid.')).toBeInTheDocument();
   });
 
   it('renders with borrow 0 and spare USDC, without the pill', async () => {
@@ -1006,7 +1006,7 @@ describe('RebalanceSection — a USDT borrow', () => {
 
     await screen.findByRole('button', { name: 'Hold to move 300.00 USDC → USDT' });
     fireEvent.click(screen.getByRole('radio', { name: 'USDT → Hyperliquid USDC' }));
-    expect(await screen.findByText('Nothing to pay back. There is no USDC borrow on Hyperliquid.')).toBeInTheDocument();
+    expect(await screen.findByText('Nothing to move. There is no USDC borrow on Hyperliquid.')).toBeInTheDocument();
     expect(screen.getByText(PAY_USDC_TEXT)).toBeInTheDocument();
   });
 });

--- a/web/src/panels/RebalanceSection.tsx
+++ b/web/src/panels/RebalanceSection.tsx
@@ -200,14 +200,14 @@ function noRouteLine(plan: RebalancePlan, toUsdt: boolean, borrow: number, free:
   if (toUsdt) {
     return { text: free > 0 ? 'Nothing to move.' : 'Nothing to move. There is no spare USDC on Hyperliquid.', warn: false };
   }
-  if (borrow === 0) return { text: 'Nothing to pay back. There is no USDC borrow on Hyperliquid.', warn: false };
+  if (borrow === 0) return { text: 'Nothing to move. There is no USDC borrow on Hyperliquid.', warn: false };
   if (free === 0) return { text: 'Nothing to move. There is no free USDT.', warn: false };
   return { text: 'Nothing to move.', warn: false };
 }
 
 function tooSmallLine(toUsdt: boolean, borrow: number): string {
   if (toUsdt) return `Nothing to move. Spare USDC is under ${MIN_AMOUNT} USDC.`;
-  if (borrow < MIN_AMOUNT) return `Nothing to pay back. The borrow is under ${MIN_AMOUNT} USDC.`;
+  if (borrow < MIN_AMOUNT) return `Nothing to move. The USDC borrow is under ${MIN_AMOUNT} USDC.`;
   return `Under ${MIN_AMOUNT} USDT can move. Free USDT or margin is too low.`;
 }
 


### PR DESCRIPTION
Two strings and their tests. No logic.

PR #45 made the holds and the empty states direction-neutral, but the two USDT → USDC empty states still read `Nothing to pay back`. A browser sweep of 1.5.1 on an account with no borrow showed it. They now read `Nothing to move. There is no USDC borrow on Hyperliquid.` and `Nothing to move. The USDC borrow is under 1 USDC.`, the same shape as the other direction.

Tests: `RebalanceSection.test.tsx`, 45 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkyjuJDutqYm5BdM9h9gEj
