### PR TITLE
Close form refuses multi-leg or mixed-collateral closes; wizard does not hedge exposure a fill only closed

### DIFF
--- a/web/src/trade/BorosPairTicket.tsx
+++ b/web/src/trade/BorosPairTicket.tsx
@@ -33,6 +33,7 @@ import {
   useTopUpGas,
 } from '../api/queries';
 import type {
+  BorosPairSimulation,
   BorosLegDirection,
   BorosPairIntent,
   BorosPairMarketRow,
@@ -129,7 +130,7 @@ export function BorosPairTicket({
    * denominated in, and the caller (the wizard) renders its own receipt from
    * these. Re-deriving it there could disagree with the ticket that traded.
    */
-  onExecuted?: (result: BorosPairResult, collateral: string) => void;
+  onExecuted?: (result: BorosPairResult, collateral: string, estimate?: BorosPairSimulation | null) => void;
   /**
    * True while an execution is in flight. The surface hosting this ticket
    * (wizard modal, order-ticket drawer) locks its close controls off it:
@@ -665,7 +666,10 @@ export function BorosPairTicket({
           setReport(res.result);
           setReportReplayed(Boolean(res.replayed));
           // A replay is the EARLIER submission's result — it already fired.
-          if (!res.replayed) onExecuted?.(res.result, simulation?.collateral ?? '');
+          // The server's own pre-trade estimate rides along: its per-leg
+          // `sizing.currentSize` is what the account held BEFORE this fill,
+          // which is what tells a hedge-sizer how much of the fill is new.
+          if (!res.replayed) onExecuted?.(res.result, simulation?.collateral ?? '', res.estimate ?? null);
           setAcknowledged(false);
           // This execution is DONE — the ids have served their replay-protection
           // purpose. Fresh ones now, so a later confirm of the same unchanged

--- a/web/src/trade/CloseBorosForm.test.tsx
+++ b/web/src/trade/CloseBorosForm.test.tsx
@@ -149,6 +149,41 @@ describe('CloseBorosForm — reporting what it closed', () => {
  * finish it" for a leg with nothing of the user's left in it. On a real-money
  * surface that is an invitation to send the order twice.
  */
+describe('CloseBorosForm — one size, two legs, one unit', () => {
+  it('refuses THREE legs: only two are quoted, and every leg would be sent the shared size', async () => {
+    const seen: unknown[] = [];
+    server.use(...ready(), closeReturns({ fill: fill(MINE) }, seen));
+    renderWithClient(
+      <CloseBorosForm
+        legs={[
+          makeStrategyLeg({ marketId: 155, notionalToken: MINE, collateral: 'ETH' }),
+          makeStrategyLeg({ marketId: 158, notionalToken: MINE, collateral: 'ETH' }),
+          makeStrategyLeg({ marketId: 161, notionalToken: MINE, collateral: 'ETH' }),
+        ]}
+      />,
+    );
+    expect(await screen.findByText(/spans 3 Boros legs/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Close 3 legs/ })).toBeDisabled();
+    expect(seen).toHaveLength(0);
+  });
+
+  it('refuses legs in DIFFERENT collateral: 0.01 ETH and 0.01 USDT are not one size', async () => {
+    const seen: unknown[] = [];
+    server.use(...ready(), closeReturns({ fill: fill(MINE) }, seen));
+    renderWithClient(
+      <CloseBorosForm
+        legs={[
+          makeStrategyLeg({ marketId: 155, notionalToken: MINE, collateral: 'ETH' }),
+          makeStrategyLeg({ marketId: 194, notionalToken: 8_000, collateral: 'USDT' }),
+        ]}
+      />,
+    );
+    expect(await screen.findByText(/different collateral \(ETH, USDT\)/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Close 2 legs/ })).toBeDisabled();
+    expect(seen).toHaveLength(0);
+  });
+});
+
 describe('CloseBorosForm — whose legs these are', () => {
   const ROOT = '0x1111111111111111111111111111111111111111';
   const OTHER = '0x2222222222222222222222222222222222222222';

--- a/web/src/trade/CloseBorosForm.tsx
+++ b/web/src/trade/CloseBorosForm.tsx
@@ -92,6 +92,22 @@ export function CloseBorosForm({
   const [partial, setPartial] = useState<{ marketId: number; filled: number; left: number }[]>([]);
 
   const closable = useMemo(() => legs.filter((l) => l.marketId !== undefined), [legs]);
+  /**
+   * ⚠ ONE size, TWO legs, ONE unit — or no close at all.
+   *
+   * The quote prices closable[0] and closable[1]; the run loop closes EVERY
+   * leg at the shared box number. A third leg would go out unquoted, and a
+   * USDT-margined leg beside an ETH-margined one would be sent the same raw
+   * number as two different quantities. Neither is a close the user was
+   * shown, so the form refuses and points at the legs table, where each leg
+   * closes on its own terms.
+   */
+  const collaterals = [...new Set(closable.map((l) => (l.collateral ?? '').toUpperCase()))];
+  const legsBlocked = closable.length > 2 || collaterals.length > 1;
+  const legsReason =
+    closable.length > 2
+      ? `This close spans ${closable.length} Boros legs, but one size can only be quoted and sent for two. Close them one at a time from the legs table.`
+      : `These legs are sized in different collateral (${collaterals.join(', ')}), so one size cannot apply to both. Close them one at a time from the legs table.`;
 
   const ctx = useBorosPairContext(address);
   /**
@@ -177,7 +193,7 @@ export function CloseBorosForm({
    */
   const closeDir = (l: StrategyLeg) => (l.side === 'LONG' ? ('short' as const) : ('long' as const));
   const simReq: BorosPairRequest | null = useMemo(() => {
-    if (!address || closable.length === 0 || slipInvalid || anySizeInvalid) return null;
+    if (!address || closable.length === 0 || legsBlocked || slipInvalid || anySizeInvalid) return null;
     const a = closable[0];
     const slippageApr = slipPct / 100;
 
@@ -291,6 +307,7 @@ export function CloseBorosForm({
   const run = async () => {
     setFailed([]);
     setPartial([]);
+    if (legsBlocked) return;
     for (const l of closable) {
       const id = l.marketId as number;
       if (done.some((d) => d.marketId === id)) continue;
@@ -422,6 +439,11 @@ export function CloseBorosForm({
       {agentBlocked && (
         <p className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] leading-relaxed text-amber-300/90">
           {agentReason}
+        </p>
+      )}
+      {legsBlocked && (
+        <p className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-[11px] leading-relaxed text-amber-300/90">
+          {legsReason}
         </p>
       )}
 
@@ -683,7 +705,7 @@ export function CloseBorosForm({
         tone="red"
         // No quote, no close: a hold with the numbers blank sends a bound
         // nothing on screen describes.
-        disabled={close.isPending || slipInvalid || anySizeInvalid || agentBlocked || sim.isError || (simReq !== null && !sim.data) || anyBelowMin}
+        disabled={close.isPending || slipInvalid || anySizeInvalid || agentBlocked || legsBlocked || sim.isError || (simReq !== null && !sim.data) || anyBelowMin}
         onConfirm={run}
         className="w-full"
       >

--- a/web/src/trade/StrategyWizard.test.tsx
+++ b/web/src/trade/StrategyWizard.test.tsx
@@ -205,9 +205,12 @@ const tradableHandlersSeq = (next: () => Record<string, unknown>, collateral: st
       }),
     ),
   ),
-  http.post('/api/boros/pair/execute', () =>
-    HttpResponse.json(env({ result: next(), estimate: null, warnings: [] })),
-  ),
+  http.post('/api/boros/pair/execute', () => {
+    // A scripted answer may carry its own pre-trade `estimate` (per-leg
+    // `sizing.currentSize`); the rest of the object is the result.
+    const { estimate = null, ...result } = next() as { estimate?: unknown } & Record<string, unknown>;
+    return HttpResponse.json(env({ result, estimate, warnings: [] }));
+  }),
 ];
 
 const CLEAN_FILL = {
@@ -220,6 +223,31 @@ const CLEAN_FILL = {
   partial: false,
   bothLegsSubmitted: true,
 };
+
+describe('StrategyWizard — a fill that closes an existing position is not new exposure', () => {
+  it('does not offer to hedge a leg whose fill only closed a position the account already held', async () => {
+    // The account holds +1000 on HL from before. Step 1 shorts 1000 HL and
+    // longs 1000 BN: the HL short CLOSES the old long (nothing new there),
+    // so only the BN long is new — a one-sided book, not a locked spread.
+    // Folding raw fills read it as ±1000 hedged and armed a perp hedge for
+    // exposure that does not exist.
+    const closingFill = {
+      ...CLEAN_FILL,
+      estimate: {
+        legA: { sizing: { currentSize: 1000, resultingSize: 0, deltaSize: -1000, opposing: true, flips: false, clampedToClose: false } },
+        legB: { sizing: { currentSize: 0, resultingSize: 1000, deltaSize: 1000, opposing: false, flips: false, clampedToClose: false } },
+      },
+    };
+    server.use(...tradableHandlers(closingFill), ...symbolHandlers([ETH_GATE]));
+    renderWizard({ ...INTENT, maturity: MAT, borosLongVenue: 'BINANCE', borosShortVenue: 'HYPERLIQUID' });
+    await waitFor(() => expect(screen.getByLabelText('Leg A')).toHaveValue(String(BN_M)));
+    const confirm = await screen.findByRole('button', { name: /Confirm — 2 Boros market orders/ });
+    await waitFor(() => expect(confirm).toBeEnabled(), { timeout: 4000 });
+    fireEvent.pointerDown(confirm);
+    expect(await screen.findByText(/no shared size to hedge/i, {}, { timeout: 4000 })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rate locked/ })).not.toBeInTheDocument();
+  });
+});
 
 describe('StrategyWizard — the hedge is sized off the EXECUTED collateral', () => {
   it('an ETH-collateral fill with no sizeBase arms the perps in DOLLARS, not the coin count', async () => {

--- a/web/src/trade/StrategyWizard.tsx
+++ b/web/src/trade/StrategyWizard.tsx
@@ -23,7 +23,7 @@
  * (the asset card's missing-perp cue) and re-enters here at step 2.
  */
 import { Fragment, useEffect, useState } from 'react';
-import type { BorosLegFill, BorosPairResult } from '../api/types';
+import type { BorosLegFill, BorosLegSizing, BorosPairResult, BorosPairSimulation } from '../api/types';
 import { Modal } from '../components/Modal';
 import { isUsdCollateral } from '../lib/boros';
 import { sig } from '../lib/fmt';
@@ -60,7 +60,16 @@ type Step = 1 | 2 | 'done';
  * in the executed market's collateral — so a close (which always carries the
  * direction opposing the position) subtracts on its own, with no intent flag.
  */
-type SlotFill = { size: number; marketId: number; execApr: number | null };
+type SlotFill = {
+  size: number;
+  marketId: number;
+  execApr: number | null;
+  /** The account's position in this market BEFORE the session's first fill
+   * (from the server's pre-trade estimate), or null when no estimate has
+   * named it. With it, `size` is the exposure this session is responsible
+   * for; without it, the signed sum of fills. */
+  baseline: number | null;
+};
 
 /**
  * What step 1 has actually put on, folded across EVERY accepted execution —
@@ -90,7 +99,7 @@ type StepOneBook = {
   soleClean: boolean;
 };
 
-const EMPTY_SLOT: SlotFill = { size: 0, marketId: 0, execApr: null };
+const EMPTY_SLOT: SlotFill = { size: 0, marketId: 0, execApr: null, baseline: null };
 const EMPTY_BOOK: StepOneBook = {
   a: EMPTY_SLOT,
   b: EMPTY_SLOT,
@@ -100,14 +109,26 @@ const EMPTY_BOOK: StepOneBook = {
 };
 
 
-const foldLeg = (slot: SlotFill, leg: BorosLegFill): SlotFill => {
+const foldLeg = (slot: SlotFill, leg: BorosLegFill, sizing: BorosLegSizing | null): SlotFill => {
   if (!legSubmitted(leg)) return slot;
-  return {
-    // The venue's own defence: never trust the raw sign of filledSize.
-    size: slot.size + (leg.direction === 'long' ? 1 : -1) * Math.abs(leg.filledSize),
-    marketId: leg.marketId,
-    execApr: leg.execApr ?? slot.execApr,
-  };
+  // The venue's own defence: never trust the raw sign of filledSize.
+  const signedFill = (leg.direction === 'long' ? 1 : -1) * Math.abs(leg.filledSize);
+  const execApr = leg.execApr ?? slot.execApr;
+  /**
+   * ⚠ A fill that REDUCES a position the account already held is not new
+   * exposure, and must not be hedged as if it were. The server's pre-trade
+   * estimate says what the account held; the exposure this session owns is
+   * the part of the position now beyond what was there when it started —
+   * all of it once the sign flipped, none while it only shrank.
+   */
+  if (sizing && Number.isFinite(sizing.currentSize)) {
+    const baseline = slot.baseline ?? sizing.currentSize;
+    const after = sizing.currentSize + signedFill;
+    const sameSide = baseline !== 0 && Math.sign(after) === Math.sign(baseline);
+    const owned = sameSide ? Math.sign(after) * Math.max(0, Math.abs(after) - Math.abs(baseline)) : after;
+    return { size: owned, marketId: leg.marketId, execApr, baseline };
+  }
+  return { size: slot.size + signedFill, marketId: leg.marketId, execApr, baseline: slot.baseline };
 };
 
 /** Fills round-trip 18-decimal venue values through float64, so exact-zero
@@ -172,7 +193,7 @@ function WizardBody({
 
   /** Fold one accepted execution into the book. Replays never reach this —
    * the ticket skips `onExecuted` for them. */
-  const recordExecution = (result: BorosPairResult, collateral: string) =>
+  const recordExecution = (result: BorosPairResult, collateral: string, estimate?: BorosPairSimulation | null) =>
     setBook((prev) => {
       /**
        * ⚠ Reset before folding when the legs stopped being the same book.
@@ -192,8 +213,8 @@ function WizardBody({
       const base = marketChanged || collateralChanged ? EMPTY_BOOK : prev;
       const wasEmpty = Math.abs(base.a.size) <= EPS && Math.abs(base.b.size) <= EPS;
       return {
-        a: foldLeg(base.a, result.legA),
-        b: foldLeg(base.b, result.legB),
+        a: foldLeg(base.a, result.legA, estimate?.legA?.sizing ?? null),
+        b: foldLeg(base.b, result.legB, estimate?.legB?.sizing ?? null),
         collateral: collateral || base.collateral,
         lastResult: result,
         soleClean: wasEmpty && result.bothLegsSubmitted && !result.partial,


### PR DESCRIPTION
Two fixes from the money-flow audit of 1.6.0 that were not yet on `dev` (the rest of that audit landed via the merge-gate pass). Base: `dev` at 91adb51. Verified: root `tsc`, web `tsc`, server + unit 878/878, web 583/583, `vite build`.

## Close Boros: refuse a close that spans more than two legs or mixed collateral

The close form quotes legs A and B, but the run loop sent EVERY leg the shared box number. A third leg went out unquoted, and an ETH-margined leg beside a USDT-margined one received the same raw number as two different quantities — either leaves the account unhedged. Reproduced by dac on the local stack.

The form now refuses both shapes (more than two closable legs, or legs whose collateral differs), skips the quote, and points at the legs table where each leg closes on its own terms. The run loop returns early as well, so a stale render cannot send. Two tests. A per-leg multi-close would be the full fix; that is a design change on the form and is left for the owner.

## Wizard: a fill that closes a position the account already held is not new exposure

Step 1 folded raw fills into the session book, so a short that merely closed a pre-existing long counted as fresh exposure and the perp ticket was armed to hedge it.

The Boros ticket now hands the wizard the server's own pre-trade estimate (already in the execute response). Each slot records the account's position from before the session and owns only what lies beyond it: all of it once the sign flips, none while the position only shrank. With no estimate the old signed sum applies. Test: an HL short that closes an old HL long against a fresh BN long reads as one-sided, not "rate locked", so no hedge is armed for exposure that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChDBH9oiPCm9RpXWWHHi44
